### PR TITLE
chore: release roadmapsmith v0.9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,14 @@ jobs:
         id: changelog
         run: |
           VERSION=${{ steps.version_check.outputs.current }}
-          NOTES=$(awk "/^## v$VERSION/{found=1; next} /^## v/{if(found) exit} found{print}" CHANGELOG.md)
+          NOTES=$(awk -v version="$VERSION" '
+            $0 ~ "^##[[:space:]]+([[]?v?" version "[]]?)([[:space:]]|$)" { found=1; next }
+            found && $0 ~ "^##[[:space:]]+" { exit }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v$VERSION"
+          fi
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.9.6 - 2026-05-16
+
+### Fixed
+- `roadmapsmith sync` now scopes validation and updates to existing `rs:managed` blocks instead of allowing managed content to be structurally replaced.
+- Existing managed roadmap blocks preserve custom headings, business context, task order, and task presence; sync only updates checkbox state and validation warning lines.
+- Added regression coverage for weak path-only evidence so failed tasks receive a single warning without regenerating generic roadmap content.
+
+### CI / Release
+- Fixed GitHub Release note extraction to support `vX.Y.Z`, `[X.Y.Z]`, and `[vX.Y.Z]` changelog headings.
+- Bumped the npm package to `0.9.6` so the release workflow publishes a new package and GitHub Release.
+
 ## v0.9.4 - 2026-05-14
 
 ### Fixed

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump roadmapsmith npm package to 0.9.6
- Add v0.9.6 changelog notes for the managed-block sync fix
- Make release-note extraction support vX.Y.Z, [X.Y.Z], and [vX.Y.Z] headings

## Verification
- npm test
- npm pack --dry-run
- node bin/cli.js --version
- validated changelog extraction with awk