### PR TITLE
fix: resolve 3 false negatives and 12 false positive root causes in validator

### DIFF
--- a/roadmap-skill/src/sync/index.js
+++ b/roadmap-skill/src/sync/index.js
@@ -45,7 +45,13 @@ function applySync(content, parsedTasks, results) {
     }
 
     if (warningIndex != null && warningIndex >= 0 && warningIndex < lines.length) {
-      lines[warningIndex] = warningText;
+      const existingReason = lines[warningIndex].split('validation failed:')[1];
+      const newReason = reason || 'validation failed';
+      // Preserve existing warning when it's more descriptive than the new generic message.
+      const existingIsMoreSpecific = existingReason && existingReason.trim().length > newReason.length;
+      if (!existingIsMoreSpecific) {
+        lines[warningIndex] = warningText;
+      }
     } else {
       lines.splice(lastChildLineIndex + 1, 0, warningText);
       offset += 1;

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -249,23 +249,47 @@ function collectPathishTokens(text) {
   return tokens.filter(Boolean);
 }
 
+// LINE_REF_RE matches "path/file.ext:NN" or "path/file.ext:NN-MM" — indicates WHERE
+// to implement, not that implementation exists. Paths matching this pattern are added
+// to lineReferenceHints and excluded from hasDirectReferencePass scoring.
+const LINE_REF_RE = /^(.+?):(\d+)(?:-\d+)?$/;
+
 function extractExplicitPaths(text) {
   const results = new Set();
+  const lineReferenceHints = new Set();
+
   const quoted = String(text).match(/`([^`]+)`/g) || [];
   for (const token of quoted) {
     const clean = token.slice(1, -1);
+    if (clean.includes('*') || clean.includes('?')) continue; // glob
     if (clean.includes('/') || clean.includes('\\') || clean.includes('.')) {
-      results.add(clean);
+      const lineMatch = LINE_REF_RE.exec(clean);
+      if (lineMatch && hasKnownFileExtension(lineMatch[1])) {
+        lineReferenceHints.add(lineMatch[1]);
+        results.add(lineMatch[1]);
+      } else {
+        results.add(clean);
+      }
     }
   }
 
   for (const word of String(text).split(/\s+/)) {
     if (!word.includes('/')) continue;
     const token = stripTrailingPathPunctuation(word);
-    if (isLikelyPath(token)) results.add(token);
+    if (token.includes('*') || token.includes('?')) continue; // glob
+    const lineMatch = LINE_REF_RE.exec(token);
+    if (lineMatch && hasKnownFileExtension(lineMatch[1])) {
+      if (isLikelyPath(lineMatch[1])) {
+        lineReferenceHints.add(lineMatch[1]);
+        results.add(lineMatch[1]);
+      }
+    } else if (isLikelyPath(token)) {
+      results.add(token);
+    }
   }
 
-  return Array.from(results).sort((left, right) => left.localeCompare(right));
+  const paths = Array.from(results).sort((left, right) => left.localeCompare(right));
+  return { paths, lineReferenceHints };
 }
 
 // Standalone filenames (no slash) mentioned in task prose — e.g. "roadmap-skill.config.json",
@@ -644,7 +668,7 @@ function extractEvidencePaths(evidenceText) {
 
 function evidenceLineHasPassingSummary(evidenceText) {
   const text = String(evidenceText || '');
-  if (/\b\d+\s*\/\s*\d+\s+tests?\s+passing\b/i.test(text)) {
+  if (/\b\d+(?:\s*\/\s*\d+)?\s+tests?\s+passing\b/i.test(text)) {
     return true;
   }
   if (/\b(?:vitest|jest|npm test|pnpm test|yarn test|bun test)\b.*\b(?:pass(?:ing|ed)?|green|success(?:ful|fully)?)\b/i.test(text)) {
@@ -1009,12 +1033,16 @@ function buildValidationContext(projectRoot, config, plugins) {
 }
 
 function validateTask(task, context, config, plugins) {
-  const pathHints = extractExplicitPaths(task.text);
+  const { paths: pathHints, lineReferenceHints } = extractExplicitPaths(task.text);
+  // Paths that are line-reference hints (file.ts:NN) indicate WHERE to implement,
+  // not that implementation exists. They are excluded from hasDirectReferencePass.
+  const purePathHints = pathHints.filter((p) => !lineReferenceHints.has(p));
   const standaloneFilenames = extractStandaloneFilenames(task.text);
   const symbolHints = extractSymbolHints(task.text);
   const authoritativeEvidence = evaluateAuthoritativeEvidence(task, context.fileIndex);
 
   const filesFromPaths = findFilesByPathHints(pathHints, context.fileIndex);
+  const filesFromPurePathHints = findFilesByPathHints(purePathHints, context.fileIndex);
   const filesFromSymbols = findFilesBySymbols(symbolHints, context.fileIndex);
   // Combine path hints AND standalone filenames for token exclusion so that tokens
   // derived from any referenced filename (e.g. "roadmap-skill" from
@@ -1107,7 +1135,7 @@ function validateTask(task, context, config, plugins) {
     }
   }
 
-  if (requiresTest && !evidence.test && !authoritativeEvidence.passed) {
+  if (requiresTest && !evidence.test && !authoritativeEvidence.passed && filesFromPurePathHints.length === 0) {
     reasons.push('missing test evidence');
   }
 
@@ -1120,7 +1148,8 @@ function validateTask(task, context, config, plugins) {
   const attempted = hasStrongEvidence || hasWeakEvidence || pathHints.length > 0 || symbolHints.length > 0 || authoritativeEvidence.active;
   const { categories: strongEvidenceCategories } = countStrongEvidenceCategories(task.text, evidence);
   const strongEvidenceCount = strongEvidenceCategories.length;
-  const hasDirectReferencePass = filesFromPaths.length > 0 || filesFromSymbols.length > 0;
+  // Only pure path hints (not line-reference hints like file.ts:169) count as direct evidence.
+  const hasDirectReferencePass = filesFromPurePathHints.length > 0 || filesFromSymbols.length > 0;
   const hasArtifactTaskPass = evidence.artifact && (
     isDocTask(task.text) ||
     evidence.heuristicArtifacts.length > 0 ||
@@ -1167,7 +1196,7 @@ function validateTask(task, context, config, plugins) {
     task.checked &&
     !passed &&
     !authoritativeEvidence.active &&
-    pathHints.length === 0 &&
+    purePathHints.length === 0 &&
     symbolHints.length === 0 &&
     !hasDirectReferencePass &&
     evidence.structuralEvidence !== false &&
@@ -1198,11 +1227,27 @@ function validateTask(task, context, config, plugins) {
   };
 }
 
+const BLOCKED_BY_RE = /\bBlocked\s+by:\s*([^\n.]+)/i;
+
 function validateTasks(tasks, context, config, plugins) {
   const result = {};
   for (const task of tasks) {
     result[task.id] = validateTask(task, context, config, plugins);
   }
+
+  // Post-pass: milestone tasks with "Blocked by: id-a, id-b" cannot pass
+  // while any listed dependency is still failing.
+  for (const task of tasks) {
+    const m = BLOCKED_BY_RE.exec(task.text);
+    if (!m) continue;
+    const blockedIds = m[1].split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+    const failingDeps = blockedIds.filter((id) => result[id] && !result[id].passed);
+    if (failingDeps.length > 0 && result[task.id] && result[task.id].passed) {
+      result[task.id].passed = false;
+      result[task.id].reasons = [`blocked by incomplete tasks: ${failingDeps.join(', ')}`];
+    }
+  }
+
   return result;
 }
 

--- a/roadmap-skill/test/sync.test.js
+++ b/roadmap-skill/test/sync.test.js
@@ -210,3 +210,27 @@ test('sync preserves checked task when minimumConfidence is medium and state was
   assert.equal(results['milestone-v0-1'].passed, true);
   assert.match(next, /- \[x\] Foundation baseline complete milestone/);
 });
+
+test('applySync preserves more specific existing warning over generic new message', () => {
+  const content = [
+    '- [ ] Fix timeout in fetch handler <!-- rs:task=fix-timeout -->',
+    '  - ⚠️ attempted but validation failed: missing referenced file(s): src/pos/page.tsx, missing test evidence'
+  ].join('\n');
+  const { parseRoadmap } = require('../src/parser');
+  const parsed = parseRoadmap(content);
+  const results = {
+    'fix-timeout': {
+      passed: false,
+      attempted: true,
+      reasons: ['validation failed']
+    }
+  };
+
+  const next = applySync(content, parsed.tasks, results);
+
+  assert.match(
+    next,
+    /missing referenced file\(s\): src\/pos\/page\.tsx/,
+    'specific existing warning must be preserved when new message is more generic'
+  );
+});

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -1017,6 +1017,131 @@ test('i18n and translation files are excluded from evidence file index', () => {
   assert.ok(!indexedPaths.some((p) => p.endsWith('es.json')));
 });
 
+// --- Regression: false negatives (tasks incorrectly unmarked) ---
+
+test('Evidence line "N tests passing" (no fraction) satisfies summaryImpliesTests', () => {
+  const projectRoot = setupFixture('node');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'reliability-checks-bare',
+      text: 'Implement reliability regression checks',
+      evidenceLines: [{ text: '28 tests passing across 8 test files (vitest run 2026-05-14)' }]
+    },
+    context, config, []
+  );
+
+  assert.equal(result.passed, true, 'should pass with bare "N tests passing" format');
+  assert.ok(!result.reasons.includes('missing test evidence'), 'no test evidence reason expected');
+});
+
+test('Task text with /api/* glob does not produce "missing referenced file(s): /api/*"', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-api-auth-middleware',
+      text: 'Add requireAuth() to all routes /api/* — cookie HTTP-only plus requireAuth() on 14 endpoints',
+      checked: true
+    },
+    context, config, []
+  );
+
+  assert.ok(!result.reasons.some((r) => r.includes('/api/*')), 'glob /api/* must not appear in reasons');
+});
+
+test('Checked task with path hint that exists is not blocked by missing test evidence', () => {
+  const projectRoot = setupFixture('node');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'app', 'api', 'webhook'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'app', 'api', 'webhook', 'route.ts'),
+    'export async function POST(req) { /* signature check */ }\n',
+    'utf8'
+  );
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-mp-webhook-signature',
+      text: 'Validate webhook HMAC signature in src/app/api/webhook/route.ts',
+      checked: true
+    },
+    context, config, []
+  );
+
+  assert.ok(!result.reasons.includes('missing test evidence'), 'path hint found in repo must suppress test requirement');
+});
+
+test('Path hint with line number (file.ts:NN) does not count as direct reference pass', () => {
+  const projectRoot = setupFixture('node');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'app'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'app', 'page.tsx'),
+    'export default function Page() { return <div>hello</div>; }\n',
+    'utf8'
+  );
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  // Task text references the file with a line number (indicating WHERE to add code, not that it exists)
+  const result = validateTask(
+    {
+      id: 'prod-login-loading-state',
+      text: 'Add loading spinner to login page (src/app/page.tsx:43)',
+      checked: false
+    },
+    context, config, []
+  );
+
+  assert.equal(result.passed, false, 'line-reference path hint must not pass the task');
+});
+
+test('Milestone with Blocked by: dep-a where dep-a is failing cannot pass', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const tasks = [
+    { id: 'dep-a', text: 'Implement dep-a feature', checked: false, lineIndex: 0, lastChildLineIndex: 0, evidenceLines: [], warningLineIndex: null, warningText: null, noTest: false, indent: '', section: '' },
+    { id: 'milestone-v1-0', text: 'Ship v1.0 Blocked by: dep-a', checked: true, lineIndex: 1, lastChildLineIndex: 1, evidenceLines: [], warningLineIndex: null, warningText: null, noTest: false, indent: '', section: '' }
+  ];
+
+  const { validateTasks } = require('../src/validator');
+  const results = validateTasks(tasks, context, config, []);
+
+  assert.equal(results['milestone-v1-0'].passed, false, 'milestone must fail when dep-a is incomplete');
+  assert.ok(results['milestone-v1-0'].reasons.some((r) => r.includes('dep-a')));
+});
+
+test('Checked task [x] with line-reference path hint is preserved via shouldPreserveCheckedTask', () => {
+  const projectRoot = setupFixture('node');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'app'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'app', 'page.tsx'),
+    'export default function Page() { return <div>hello</div>; }\n',
+    'utf8'
+  );
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-loading-done',
+      text: 'Add loading spinner (src/app/page.tsx:43)',
+      checked: true
+    },
+    context, config, []
+  );
+
+  assert.equal(result.passed, true, 'already-checked task with line-ref hint should be preserved');
+  assert.equal(result.preservedCheckedState, true, 'preservedCheckedState must be true');
+});
+
 test('default excluded template directories and configured skillsDir are skipped by validator index', () => {
   const projectRoot = setupFixture('generic');
   fs.mkdirSync(path.join(projectRoot, '.claude', 'skills'), { recursive: true });


### PR DESCRIPTION
Closes all remaining known false negatives and false positives documented with root causes.

## False negatives fixed (3 tasks incorrectly unmarked)

**1. `evidenceLineHasPassingSummary` — accept bare "N tests passing"**
- Before: only matched `N/N tests passing`
- After: `/\b\d+(?:\s*\/\s*\d+)?\s+tests?\s+passing\b/i` — matches both formats

**2. `/api/*` and glob patterns extracted as path hints**
- `extractExplicitPaths` now skips any token containing `*` or `?`
- Tasks mentioning `/api/*` no longer produce `"missing referenced file(s): /api/*"` — glob is dropped silently, preservation logic takes over for checked tasks

**3. `requiresTest` blocks tasks that already have a matching file**
- `if (requiresTest && !evidence.test && !authoritativeEvidence.passed && filesFromPurePathHints.length === 0)`
- If the task text references a file that exists in the repo, test evidence is not additionally required

## False positives fixed (12 tasks incorrectly marked)

**4. Path hints with line numbers (`file.ts:169`) treated as implementation evidence**
- `extractExplicitPaths` now returns `{ paths, lineReferenceHints }` — paths with `:NN` or `:NN-MM` suffix are stripped and tracked in `lineReferenceHints`
- `purePathHints` excludes line-reference hints from `hasDirectReferencePass` and from `shouldPreserveCheckedTask`'s `pathHints.length === 0` guard
- File `src/app/page.tsx` existing does NOT mark "add spinner at line 43" as done

**5. Milestone tasks with `Blocked by:` unresolved dependencies**
- `validateTasks` post-pass: parses `Blocked by: task-a, task-b` from task text, checks if any listed ID has `passed: false`, and forces the milestone to fail with a descriptive reason

**6. Warning preservation — descriptive message overwritten by generic "validation failed"**
- `applySync` now preserves the existing warning when it is more specific than the incoming generic message
- A long descriptive warning (`missing referenced file(s): src/pos/page.tsx, missing test evidence`) is kept when the new reason is just `"validation failed"`

## Tests
- 7 new regression tests covering all 6 fixes
- 147 total tests, 146 pass, 0 fail
