### PR TITLE
chore: release roadmapsmith v0.9.9

### DIFF
--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.9.9 - 2026-05-16
+
+### Fixed
+- `evidenceLineHasPassingSummary` now accepts `"N tests passing"` without requiring the `N/N` fraction format — fixes false negative when Evidence lines use bare count.
+- `extractExplicitPaths` filters glob tokens (`*`, `?`) so `/api/*` is never extracted as a path hint, allowing the preservation logic to keep checked tasks intact.
+- `requiresTest` is no longer enforced when the task text references a file that exists in the repo (`filesFromPurePathHints.length > 0`) — fixes false negative on tasks with direct file evidence.
+- Path hints with line-number suffixes (`file.ts:169`, `file.ts:13-15`) are tracked as `lineReferenceHints` and excluded from `hasDirectReferencePass` — a file existing at the referenced path no longer marks an unimplemented task as complete.
+- `shouldPreserveCheckedTask` now uses `purePathHints` (excluding line-reference hints) so checked tasks that only mention implementation locations are correctly preserved.
+- `validateTasks` post-pass blocks milestone tasks that declare `Blocked by: task-id` when any listed dependency has `passed: false`.
+- `applySync` preserves a more descriptive existing warning over a shorter generic `"validation failed"` message on re-sync.
+
 ## v0.9.8 - 2026-05-16
 
 ### Fixed

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Bumps version to `0.9.9` to distribute the validator fixes from #12.

## What ships in this release
- False negative: bare `"N tests passing"` now accepted in Evidence lines
- False negative: `/api/*` globs no longer extracted as path hints
- False negative: `requiresTest` skipped when a referenced file exists in the repo
- False positive: `file.ts:169` line-reference hints excluded from `hasDirectReferencePass`
- False positive: `shouldPreserveCheckedTask` uses pure path hints only
- False positive: milestone `Blocked by:` post-pass blocks incomplete milestones
- False positive: `applySync` preserves more descriptive existing warnings

## Test plan
- [x] `npm test` → 147 tests, 146 pass, 0 fail
- [ ] CI publishes `roadmapsmith@0.9.9` to npm after merge
- [ ] `npm install -g roadmapsmith@latest` installs `0.9.9`
