### PR TITLE
fix: defensive glob filtering for Node 20 CI compatibility

### DIFF
--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -178,6 +178,7 @@ function hasFileExtension(token) {
 }
 
 function isLikelyPath(token) {
+  if (token.includes('*') || token.includes('?')) return false; // glob/wildcard
   if (/^\.{1,2}\/|^\//.test(token)) return true;
   if (hasFileExtension(token)) return true;
   if (KNOWN_PATH_ROOTS.some((root) => token.startsWith(root))) return true;
@@ -288,7 +289,9 @@ function extractExplicitPaths(text) {
     }
   }
 
-  const paths = Array.from(results).sort((left, right) => left.localeCompare(right));
+  const paths = Array.from(results)
+    .filter((p) => !p.includes('*') && !p.includes('?'))
+    .sort((left, right) => left.localeCompare(right));
   return { paths, lineReferenceHints };
 }
 


### PR DESCRIPTION
## Summary

- Adds glob/wildcard check (`*`, `?`) as the first guard in `isLikelyPath` — tokens containing these characters are rejected before any path-pattern test runs
- Adds a final `.filter()` on the `paths` array in `extractExplicitPaths` as a belt-and-suspenders guard against any Node version edge case

## Root cause

Test #142 ("Task text with /api/* glob does not produce missing referenced file(s)") passes locally on Node 25 but fails on CI Node 20. The loop-level glob check (`if (token.includes('*')) continue`) should be sufficient, but some interaction between Node 20's runtime and the em dash (`—`) character in the task text appears to allow `/api/*` through to the `pathHints` array. The defensive layers added here make the filtering unconditional regardless of Node version.

## Test plan

- [ ] `npm test` passes on Node 20 (CI)
- [ ] All 147 tests pass (146 pass + 1 Windows case-insensitive skip)