### PR TITLE
fix: resolve v0.9.9 regression and 12 false positive root causes (v0.…

### DIFF
--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.9.10 - 2026-05-16
+
+### Fixed
+- `isLikelyPath` now rejects bare `/` and other empty-segment slash tokens (e.g. the separator in "Web Serial API / ESC-POS") — fixes regression where `p1-thermal-printer` was failing with `missing referenced file(s): /`.
+- Backtick-quoted property access like `` `err.message` `` or `` `error.stack` `` is no longer extracted as a path hint — requires a `/` or a known file extension; fixes `prod-sanitize-error-messages` false negative.
+- `evidence.files` now uses only pure path hints (excluding line-reference hints like `file.ts:169`) so line-reference hints no longer inflate `strongEvidenceCount` via the `feature-surface` category and no longer push tasks past `meetsStrongThreshold` with unrelated code evidence.
+- `hasDirectReferencePass` (file referenced in task text exists) is no longer sufficient alone to pass an unchecked task — it showed WHERE to implement, not that implementation is done. Unchecked tasks now require authoritative evidence, artifact evidence, or the strong code+test threshold. Unchecked tasks that fail only on this condition receive the reason `"file reference shows implementation location, not confirmed completion"`.
+- Already-checked `[x]` tasks with referenced files that exist are preserved via `shouldPreserveCheckedTask` (new case 2: `hasDirectReferencePass = true` + no strong evidence → preserve rather than uncheck).
+- `authoritativeEvidence.passed = true` suppresses `missing referenced file(s)` reasons — a confirmed Evidence line overrides a bad/moved path hint in the task text.
+
 ## v0.9.9 - 2026-05-16
 
 ### Fixed

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
   "main": "src/index.js",
   "bin": {

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -179,7 +179,10 @@ function hasFileExtension(token) {
 
 function isLikelyPath(token) {
   if (token.includes('*') || token.includes('?')) return false; // glob/wildcard
-  if (/^\.{1,2}\/|^\//.test(token)) return true;
+  if (/^\.{1,2}\/|^\//.test(token)) {
+    // Bare "/" or "./" with nothing after is not a real path (e.g. "API / ESC-POS" → "/")
+    return /[A-Za-z0-9_]/.test(token);
+  }
   if (hasFileExtension(token)) return true;
   if (KNOWN_PATH_ROOTS.some((root) => token.startsWith(root))) return true;
   // The ">= 2 slashes" rule was intentionally removed: it caused conceptual slash phrases
@@ -263,14 +266,16 @@ function extractExplicitPaths(text) {
   for (const token of quoted) {
     const clean = token.slice(1, -1);
     if (clean.includes('*') || clean.includes('?')) continue; // glob
-    if (clean.includes('/') || clean.includes('\\') || clean.includes('.')) {
-      const lineMatch = LINE_REF_RE.exec(clean);
-      if (lineMatch && hasKnownFileExtension(lineMatch[1])) {
-        lineReferenceHints.add(lineMatch[1]);
-        results.add(lineMatch[1]);
-      } else {
-        results.add(clean);
-      }
+    const hasSlash = clean.includes('/') || clean.includes('\\');
+    // Require a slash or a known file extension — rejects property access like err.message,
+    // fs.readFileSync, error.stack (whose extensions are not in KNOWN_FILE_EXTENSIONS).
+    if (!hasSlash && !hasKnownFileExtension(clean)) continue;
+    const lineMatch = LINE_REF_RE.exec(clean);
+    if (lineMatch && hasKnownFileExtension(lineMatch[1])) {
+      lineReferenceHints.add(lineMatch[1]);
+      results.add(lineMatch[1]);
+    } else {
+      results.add(clean);
     }
   }
 
@@ -1063,7 +1068,9 @@ function validateTask(task, context, config, plugins) {
     code: filesFromCode.length > 0 || filesFromSymbols.length > 0,
     test: filesFromTests.length > 0,
     artifact: filesFromArtifacts.length > 0,
-    files: filesFromPaths,
+    // Use only pure path hints (not line-reference hints) so that "file.ts:169" style hints
+    // — which indicate WHERE to implement — do not contribute to feature-surface scoring.
+    files: filesFromPurePathHints,
     symbols: filesFromSymbols,
     codeFiles: filesFromCode,
     weakPathFiles: filesFromWeakPathTokens,
@@ -1080,7 +1087,9 @@ function validateTask(task, context, config, plugins) {
   applyAuthoritativeEvidence(evidence, authoritativeEvidence, context.fileIndex);
 
   const reasons = [];
-  if (pathHints.length > 0 && filesFromPaths.length === 0) {
+  // Suppress path hint failures when authoritative evidence already confirms the task —
+  // a bad path hint (typo, moved file) should not override a passing Evidence line.
+  if (pathHints.length > 0 && filesFromPaths.length === 0 && !authoritativeEvidence.passed) {
     reasons.push(`missing referenced file(s): ${pathHints.join(', ')}`);
   }
   if (Array.isArray(authoritativeEvidence.reasons) && authoritativeEvidence.reasons.length > 0) {
@@ -1185,7 +1194,19 @@ function validateTask(task, context, config, plugins) {
     uniqueReasons = Array.from(new Set(uniqueReasons));
   }
 
-  let passed = authoritativeEvidence.passed || hasDirectReferencePass || hasArtifactTaskPass || hasTrustedRuleEvidencePass || meetsStrongThreshold;
+  // hasDirectReferencePass is intentionally excluded: a path hint in task text indicates
+  // WHERE to implement, not that implementation is done. Unchecked tasks need authoritative
+  // evidence, artifact evidence, or strong code+test threshold to pass.
+  // Already-checked tasks with found path hints are preserved via shouldPreserveCheckedTask.
+  let passed = authoritativeEvidence.passed || hasArtifactTaskPass || hasTrustedRuleEvidencePass || meetsStrongThreshold;
+
+  if (!passed && !task.checked && hasDirectReferencePass) {
+    const locationReason = 'file reference shows implementation location, not confirmed completion';
+    if (!uniqueReasons.includes(locationReason)) {
+      uniqueReasons.push(locationReason);
+    }
+  }
+
   if (task.warningText && passed && !authoritativeEvidence.passed && !meetsStrongThreshold) {
     passed = false;
     uniqueReasons.push(task.warningText);
@@ -1195,15 +1216,20 @@ function validateTask(task, context, config, plugins) {
     passed = false;
   }
 
+  // Preserve already-checked tasks when the validator can't confirm implementation but also
+  // can't find strong evidence against it. Two cases:
+  //   1. No path/symbol hints at all — no machine-readable claims to evaluate.
+  //   2. Path hints resolve to existing files but code/test evidence is absent —
+  //      file presence is not implementation; don't uncheck on that alone.
+  // Symbol hints are NOT preserved: a missing symbol is a concrete falsifiable claim.
   const shouldPreserveCheckedTask =
     task.checked &&
     !passed &&
     !authoritativeEvidence.active &&
-    purePathHints.length === 0 &&
     symbolHints.length === 0 &&
-    !hasDirectReferencePass &&
+    negativeSignalMatches.length === 0 &&
     evidence.structuralEvidence !== false &&
-    negativeSignalMatches.length === 0;
+    (hasDirectReferencePass || purePathHints.length === 0);
   let preservedCheckedState = false;
   if (shouldPreserveCheckedTask) {
     passed = true;

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -42,9 +42,18 @@ test('validator checks explicit file existence hints', () => {
   const config = loadConfig({ projectRoot });
   const context = buildValidationContext(projectRoot, config, []);
 
-  const pass = validateTask({ id: 'artifact-path', text: 'Document artifact in `docs/artifact.txt`' }, context, config, []);
-  assert.equal(pass.passed, true);
+  // Unchecked task: file exists but file-existence alone is not sufficient for unchecked tasks
+  // (path hint shows WHERE to implement, not that implementation is done).
+  const unchecked = validateTask({ id: 'artifact-path', text: 'Document artifact in `docs/artifact.txt`' }, context, config, []);
+  assert.equal(unchecked.passed, false);
+  assert.ok(unchecked.reasons.some((r) => r.includes('implementation location')), 'unchecked task must get location reason');
 
+  // Already-checked task: file exists → preserved via shouldPreserveCheckedTask.
+  const checked = validateTask({ id: 'artifact-path-done', text: 'Document artifact in `docs/artifact.txt`', checked: true }, context, config, []);
+  assert.equal(checked.passed, true, 'checked task with found file must be preserved');
+  assert.equal(checked.preservedCheckedState, true);
+
+  // File does not exist → missing reason regardless of checked state.
   const fail = validateTask({ id: 'missing-file', text: 'Create parser in `src/missing.js`' }, context, config, []);
   assert.equal(fail.passed, false);
   assert.match(fail.reasons.join('; '), /missing referenced file/);
@@ -1162,4 +1171,101 @@ test('default excluded template directories and configured skillsDir are skipped
   assert.ok(!indexedPaths.some((p) => p.startsWith('.agent/')));
   assert.ok(!indexedPaths.some((p) => p.startsWith('roadmap-skill/')));
   assert.ok(!indexedPaths.some((p) => p.startsWith('custom-skills/')));
+});
+
+// --- Regression: v0.9.10 false-positive and false-negative fixes ---
+
+test('Bare "/" from prose separator (e.g. "API / ESC-POS") is not extracted as path hint', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'p1-thermal-printer',
+      text: 'Impresión de tickets en impresora térmica 80mm (Web Serial API / ESC-POS)',
+      checked: false
+    },
+    context, config, []
+  );
+
+  assert.ok(!result.reasons.some((r) => r.includes('"/"') || r === 'missing referenced file(s): /'), 'bare "/" must not appear in reasons');
+});
+
+test('Backtick-quoted property access like err.message is not extracted as a path hint', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-sanitize-error-messages',
+      text: 'Sanitize error responses: never expose `err.message` or `error.stack` to the client',
+      checked: false
+    },
+    context, config, []
+  );
+
+  assert.ok(!result.reasons.some((r) => r.includes('err.message') || r.includes('error.stack')), 'property access must not appear in missing-file reasons');
+});
+
+test('authoritativeEvidence.passed=true overrides missing path-hint file reason', () => {
+  const projectRoot = setupFixture('node');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'lib', 'auth.ts'), 'export function requireAuth() {}\n', 'utf8');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-auth-guard',
+      text: 'Add requireAuth guard to all routes — see src/lib/nonexistent-moved.ts for pattern',
+      checked: false,
+      evidenceLines: [{ text: 'src/lib/auth.ts — requireAuth implemented and tested' }]
+    },
+    context, config, []
+  );
+
+  assert.equal(result.passed, true, 'authoritative evidence must override missing path hint');
+  assert.ok(!result.reasons.some((r) => r.includes('nonexistent-moved')), 'missing path hint reason must be suppressed by auth evidence');
+});
+
+test('Unchecked task with pure path hint (file exists, no impl evidence) does not auto-pass', () => {
+  const projectRoot = setupFixture('node');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'lib', 'db.ts'), 'export function query() {}\n', 'utf8');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-db-corruption-recovery',
+      text: 'Add fallback recovery in src/lib/db.ts when database corruption is detected',
+      checked: false
+    },
+    context, config, []
+  );
+
+  assert.equal(result.passed, false, 'unchecked task must not pass just because referenced file exists');
+  assert.ok(result.reasons.some((r) => r.includes('implementation location')), 'reason must clarify that path hint shows location not completion');
+});
+
+test('Checked [x] task with pure path hint (file exists, no impl evidence) is preserved', () => {
+  const projectRoot = setupFixture('node');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'lib', 'db.ts'), 'export function query() {}\n', 'utf8');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-db-corruption-recovery',
+      text: 'Add fallback recovery in src/lib/db.ts when database corruption is detected',
+      checked: true
+    },
+    context, config, []
+  );
+
+  assert.equal(result.passed, true, 'already-checked task with found path hint must be preserved');
+  assert.equal(result.preservedCheckedState, true, 'preservedCheckedState must be true');
 });


### PR DESCRIPTION
…9.10)

- isLikelyPath rejects bare '/' — fixes p1-thermal-printer regression from v0.9.9
- Backtick property access (err.message, error.stack) no longer extracted as path hints
- evidence.files uses only pure path hints; line-reference hints no longer inflate feature-surface
- hasDirectReferencePass removed from passed formula — unchecked tasks need real evidence, not just file existence
- shouldPreserveCheckedTask extended to preserve [x] tasks whose referenced files exist
- authoritativeEvidence.passed suppresses missing-path-hint reasons
- 5 new regression tests; 152 total, 0 fail