### PR TITLE
fix: resolve 7 false positives — action-verb gate, warning preservation, child-bullet Blocked-by (v0.9.11)

### DIFF
--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.9.11 - 2026-05-16
+
+### Fixed
+- **Causa 1 — Blocked-by in child bullets**: Parser now extracts `blockedByIds` from child-bullet `- Blocked by: task-id, ...` lines (previously only inline "Blocked by:" in task text was recognised). `validateTasks` post-pass checks both sources, so a milestone whose dependencies are listed as child bullets now correctly stays failed when any dependency is incomplete.
+- **Causa 2 — Existing ⚠️ warning bypassed by token match**: Unchecked tasks that already carry a `⚠️ attempted but validation failed:` warning are now kept failing even when `meetsStrongThreshold` is true (code + feature-surface ≥ 2 categories). The warning represents a prior human/agent judgment that code token overlap must not override. Only an explicit `Evidence:` line (`authoritativeEvidence.passed = true`) can clear it.
+- **Causa 3 — Action-verb tasks auto-pass on token match**: Unchecked tasks whose text starts with a pending-work verb (Agregar, Configurar, Add, Fix, Implement, …) now require either an `Evidence:` line, test evidence, grant-evidence from config, or canonical artifact evidence to pass. Code token overlap alone (path hint exists + tokens in file content = 2 categories) is no longer sufficient — the verb signals that work is still to be done.
+
 ## v0.9.10 - 2026-05-16
 
 ### Fixed

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
   "main": "src/index.js",
   "bin": {

--- a/roadmap-skill/src/parser/index.js
+++ b/roadmap-skill/src/parser/index.js
@@ -86,6 +86,11 @@ function parseWarningLine(content) {
   return content.slice(WARNING_PREFIX.length).trim();
 }
 
+function parseBlockedByLine(content) {
+  if (!/^blocked\s+by:/i.test(content)) return null;
+  return content.replace(/^blocked\s+by:\s*/i, '').trim();
+}
+
 function parseRoadmap(content) {
   const lines = String(content || '').split(/\r?\n/);
   const managedRange = findManagedRange(lines);
@@ -111,6 +116,7 @@ function parseRoadmap(content) {
     let warningLineIndex = null;
     let warningText = null;
     const evidenceLines = [];
+    const blockedByIds = [];
     let lastChildLineIndex = index;
     for (let childIndex = index + 1; childIndex < lines.length; childIndex += 1) {
       const childLine = lines[childIndex];
@@ -145,6 +151,12 @@ function parseRoadmap(content) {
         warningLineIndex = childIndex;
         warningText = warningTextValue;
       }
+
+      const blockedByText = parseBlockedByLine(childBullet.content);
+      if (blockedByText !== null) {
+        const ids = blockedByText.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+        blockedByIds.push(...ids);
+      }
     }
 
     const id = markerId || slugify(text);
@@ -157,6 +169,7 @@ function parseRoadmap(content) {
       warningLineIndex,
       warningText,
       evidenceLines,
+      blockedByIds,
       markerId,
       noTest,
       indent,

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -50,6 +50,28 @@ const GENERIC_TASK_TOKENS = new Set([
   'phrases', 'conceptual',
 ]);
 
+// Verbs that indicate the task describes work still to be done, not completed work.
+// When a task starts with one of these verbs, code token overlap alone cannot pass it —
+// either an Evidence line (authoritativeEvidence.passed) or test evidence is required.
+const ACTION_VERBS = new Set([
+  'agregar', 'mostrar', 'implementar', 'configurar', 'reemplazar', 'cambiar',
+  'corregir', 'manejar', 'proteger', 'sanitizar', 'validar', 'deshabilitar',
+  'generar', 'expandir', 'reducir', 'completar', 'crear', 'eliminar',
+  'add', 'show', 'implement', 'configure', 'replace', 'change', 'fix',
+  'handle', 'protect', 'sanitize', 'validate', 'disable', 'generate',
+  'expand', 'reduce', 'complete', 'create', 'remove'
+]);
+
+function taskStartsWithActionVerb(taskText) {
+  const normalized = String(taskText)
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\[([^\]]+)\]/g, '$1')
+    .trim()
+    .toLowerCase();
+  const firstWord = normalized.split(/[\s,;:()[\]]+/)[0] || '';
+  return ACTION_VERBS.has(firstWord);
+}
+
 const CANONICAL_FILES = {
   security: 'SECURITY.md',
   readme: 'README.md',
@@ -1207,13 +1229,39 @@ function validateTask(task, context, config, plugins) {
     }
   }
 
-  if (task.warningText && passed && !authoritativeEvidence.passed && !meetsStrongThreshold) {
+  // Unchecked tasks with an existing ⚠️ warning are preserved as failing unless an Evidence line
+  // explicitly confirms implementation. meetsStrongThreshold (token match) cannot override a
+  // human/agent judgment that the feature is incomplete.
+  if (task.warningText && !task.checked && passed && !authoritativeEvidence.passed) {
     passed = false;
     uniqueReasons.push(task.warningText);
     uniqueReasons = Array.from(new Set(uniqueReasons));
   }
   if (negativeSignalMatches.length > 0) {
     passed = false;
+  }
+
+  // Action-verb gate (Causa 3): unchecked tasks whose text starts with a pending-work verb
+  // (Agregar, Configurar, Add, Fix, …) cannot pass on code token overlap alone.
+  // The verb signals "this is work to do", so the validator requires either:
+  //   a) an Evidence line confirming the work is done (authoritativeEvidence.passed), or
+  //   b) test evidence proving the feature is exercised, or
+  //   c) grant-evidence from a config rule (hasTrustedRuleEvidencePass), or
+  //   d) canonical artifact evidence (hasArtifactTaskPass — e.g. "Add SECURITY.md").
+  if (
+    !task.checked &&
+    passed &&
+    taskStartsWithActionVerb(task.text) &&
+    !authoritativeEvidence.passed &&
+    !hasTrustedRuleEvidencePass &&
+    !hasArtifactTaskPass &&
+    !evidence.test
+  ) {
+    passed = false;
+    const actionVerbReason = 'action-verb task requires high-confidence evidence or Evidence line';
+    if (!uniqueReasons.includes(actionVerbReason)) {
+      uniqueReasons.push(actionVerbReason);
+    }
   }
 
   // Preserve already-checked tasks when the validator can't confirm implementation but also
@@ -1264,13 +1312,21 @@ function validateTasks(tasks, context, config, plugins) {
     result[task.id] = validateTask(task, context, config, plugins);
   }
 
-  // Post-pass: milestone tasks with "Blocked by: id-a, id-b" cannot pass
-  // while any listed dependency is still failing.
+  // Post-pass: tasks with "Blocked by: id-a, id-b" cannot pass while any listed dependency
+  // is still failing. The IDs may appear inline in task.text OR as child bullet lines
+  // (parsed by parser into task.blockedByIds).
   for (const task of tasks) {
+    const blockedIds = [];
     const m = BLOCKED_BY_RE.exec(task.text);
-    if (!m) continue;
-    const blockedIds = m[1].split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
-    const failingDeps = blockedIds.filter((id) => result[id] && !result[id].passed);
+    if (m) {
+      blockedIds.push(...m[1].split(/[\s,]+/).map((s) => s.trim()).filter(Boolean));
+    }
+    if (Array.isArray(task.blockedByIds) && task.blockedByIds.length > 0) {
+      blockedIds.push(...task.blockedByIds);
+    }
+    if (blockedIds.length === 0) continue;
+    const uniqueBlockedIds = Array.from(new Set(blockedIds));
+    const failingDeps = uniqueBlockedIds.filter((id) => result[id] && !result[id].passed);
     if (failingDeps.length > 0 && result[task.id] && result[task.id].passed) {
       result[task.id].passed = false;
       result[task.id].reasons = [`blocked by incomplete tasks: ${failingDeps.join(', ')}`];

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -1269,3 +1269,108 @@ test('Checked [x] task with pure path hint (file exists, no impl evidence) is pr
   assert.equal(result.passed, true, 'already-checked task with found path hint must be preserved');
   assert.equal(result.preservedCheckedState, true, 'preservedCheckedState must be true');
 });
+
+// --- Regression: v0.9.11 false-positive fixes ---
+
+// Causa 1: Blocked-by in child bullet (not inline in task text)
+// The milestone is [x] (would be preserved as passed), but its child-bullet declares
+// "Blocked by: child-dep-task" and child-dep-task is still [ ] → post-pass must fail it.
+test('Milestone with Blocked-by in child bullet stays failed when dep is incomplete', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const { parseRoadmap } = require('../src/parser');
+  const { validateTasks } = require('../src/validator');
+  const content = [
+    '## Milestones',
+    '- [ ] Dependency task <!-- rs:task=child-dep-task -->',
+    '- [x] v1.0 release <!-- rs:task=child-milestone-v1 -->',
+    '  - Blocked by: child-dep-task',
+    ''
+  ].join('\n');
+  const { tasks } = parseRoadmap(content);
+
+  const results = validateTasks(tasks, context, config, []);
+  assert.equal(results['child-milestone-v1'].passed, false, 'milestone must fail when child-bullet Blocked-by dep is incomplete');
+  assert.ok(results['child-milestone-v1'].reasons.some((r) => r.includes('child-dep-task')), 'reason must name the blocking dep');
+});
+
+// Causa 2: existing ⚠️ warning on unchecked task must survive even when meetsStrongThreshold
+test('Unchecked task with existing warning stays unchecked even when code+feature-surface evidence exists', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  // Code file with matching tokens so evidence.code = true
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'lib', 'notification.ts'),
+    'export function sendNotification() {} export function notifySystem() {}\n',
+    'utf8'
+  );
+
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const { parseRoadmap } = require('../src/parser');
+  const content = [
+    '## Phase P2',
+    '- [ ] Add notification system <!-- rs:task=add-notifications -->',
+    '  - ⚠️ attempted but validation failed: helper exists but no delivery mechanism',
+    ''
+  ].join('\n');
+  const { tasks } = parseRoadmap(content);
+  const task = tasks.find((t) => t.id === 'add-notifications');
+
+  const result = validateTask(task, context, config, []);
+  assert.equal(result.passed, false, 'existing warning must keep unchecked task failing regardless of token evidence');
+});
+
+// Causa 3a: action-verb task with path hint + code tokens — stays unchecked without Evidence line
+test('Action-verb task with path hint and code tokens stays unchecked without Evidence line', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'lib', 'db.ts'),
+    'export function query() { return prisma.findMany(); }\nfunction handleFallback() { /* recovery */ }\n',
+    'utf8'
+  );
+
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-db-recovery',
+      text: 'Agregar fallback recovery en src/lib/db.ts cuando falla Prisma',
+      checked: false
+    },
+    context, config, []
+  );
+  assert.equal(result.passed, false, 'action-verb task without Evidence line must stay unchecked');
+  assert.ok(result.reasons.some((r) => r.includes('action-verb')), 'reason must indicate action-verb requirement');
+});
+
+// Causa 3b: same action-verb task WITH Evidence line passes
+test('Action-verb task WITH Evidence line passes despite no test evidence', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'lib', 'db.ts'),
+    'export function query() { return prisma.findMany(); }\nfunction handleFallback() { /* recovery logic */ }\n',
+    'utf8'
+  );
+
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'prod-db-recovery',
+      text: 'Agregar fallback recovery en src/lib/db.ts cuando falla Prisma',
+      checked: false,
+      evidenceLines: [{ text: 'src/lib/db.ts' }]
+    },
+    context, config, []
+  );
+  assert.equal(result.passed, true, 'action-verb task WITH Evidence line must pass');
+  assert.ok(!result.reasons.some((r) => r.includes('action-verb')), 'action-verb reason must not appear when Evidence line is present');
+});


### PR DESCRIPTION
## Summary

- **Causa 1 — child-bullet `Blocked by:`**: Parser now extracts `blockedByIds` from `- Blocked by: id-a, id-b` child-bullet lines. `validateTasks` post-pass merges inline and child-bullet blocked IDs, so milestones like `milestone-v1-0` correctly stay failed when any dependency is `[ ]`.
- **Causa 2 — existing ⚠️ warning bypassed**: Removed `&& !meetsStrongThreshold` from the warning-preservation guard on unchecked tasks. Code token overlap (2 evidence categories) can no longer clear a warning that was written by a human/agent who inspected the repo and found the feature incomplete. Only an `Evidence:` line overrides it.
- **Causa 3 — action-verb tasks auto-pass on token match**: Added `ACTION_VERBS` set (18 Spanish + 18 English pending-work verbs) and a gate in `validateTask`. Unchecked tasks starting with verbs like `Agregar`, `Configurar`, `Add`, `Fix`, `Implement` now require `authoritativeEvidence.passed`, test evidence, grant-evidence from config, or canonical artifact evidence — path-hint existence + code tokens alone is no longer sufficient.
- 4 new regression tests (one per root cause + Evidence-line override for action-verb).

## Test plan

- [x] `npm test` — 70 validator tests + 10 sync tests, all pass (80/80)
- [x] 4 new regression tests added and green
- [x] All 14 items in the verification matrix preserved (false negatives = 0, 7 false positives corrected)