### PR TITLE
fix(validator): remove confidence check from action gate

### DIFF
--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -1252,8 +1252,7 @@ function validateTask(task, context, config, plugins) {
     taskDescribesChange(task.text) &&
     !authoritativeEvidence.passed &&
     !hasTrustedRuleEvidencePass &&
-    !hasArtifactTaskPass &&
-    confidence !== 'high'
+    !hasArtifactTaskPass
   ) {
     passed = false;
     const actionVerbReason = 'action task requires Evidence line or high-confidence evidence (code + test) to be marked complete';

--- a/roadmap-skill/test/sync.test.js
+++ b/roadmap-skill/test/sync.test.js
@@ -22,7 +22,7 @@ test('sync marks task complete when validation passes', () => {
   const config = loadConfig({ projectRoot });
   const content = [
     '## Phase P0',
-    '- [ ] Implement app module <!-- rs:task=implement-app-module -->',
+    '- [ ] App module <!-- rs:task=implement-app-module -->',
     ''
   ].join('\n');
 
@@ -31,7 +31,7 @@ test('sync marks task complete when validation passes', () => {
   const results = validateTasks(parsed.tasks, context, config, []);
   const next = applySync(content, parsed.tasks, results);
 
-  assert.match(next, /- \[x\] Implement app module/);
+  assert.match(next, /- \[x\] App module/);
   assert.doesNotMatch(next, /validation failed/);
 });
 

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -21,7 +21,7 @@ test('validator passes when code and tests exist for code task', () => {
   const config = loadConfig({ projectRoot });
   const context = buildValidationContext(projectRoot, config, []);
 
-  const result = validateTask({ id: 'implement-app-module', text: 'Implement app module' }, context, config, []);
+  const result = validateTask({ id: 'implement-app-module', text: 'App module' }, context, config, []);
   assert.equal(result.passed, true);
 });
 
@@ -1485,4 +1485,48 @@ test('/api/* HTTP route paths do not produce missing-file failures', () => {
       `"${task.text}" must not produce missing-file failure for HTTP route, got: ${reasons}`
     );
   }
+});
+
+test('action task stays unchecked even when BOTH code and test files match its tokens', () => {
+  const projectRoot = setupFixture('generic');
+
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  // File contains "cash", "sessions", "recovery" — 3 matches for 5 task tokens (threshold=3)
+  // so evidence.code=true and meetsStrongThreshold fires, letting the gate reach and override.
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'lib', 'cash.ts'),
+    'export function getCashSessions() { return []; }\n// recovery path handler\n',
+    'utf8'
+  );
+
+  // A test file that imports the same module — this causes confidence='high'
+  // (meetsStrongThreshold && evidence.test) and bypasses the gate in v0.9.12
+  fs.mkdirSync(path.join(projectRoot, 'src', '__tests__'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', '__tests__', 'cash.test.ts'),
+    "import { getCashSessions } from '../lib/cash';\n" +
+    "test('cash sessions list', () => { expect(getCashSessions()).toEqual([]); });\n",
+    'utf8'
+  );
+
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask(
+    {
+      id: 'recovery-cash',
+      text: 'Recovery path para cash sessions huérfanas',
+      checked: false
+    },
+    context, config, []
+  );
+
+  assert.equal(
+    result.passed, false,
+    'action task must stay unchecked even when code + test files both match tokens'
+  );
+  assert.ok(
+    result.reasons.some((r) => r.includes('action task requires')),
+    `expected "action task requires" in reasons, got: ${JSON.stringify(result.reasons)}`
+  );
 });


### PR DESCRIPTION
## Summary

- Removes `confidence !== 'high'` from the action-verb gate in `validateTask`.
- Root cause: when a codebase has test files that import modules sharing tokens with an action task, `evidence.test=true` + `evidence.code=true` → `meetsStrongThreshold && evidence.test` → `confidence='high'` → the guard was bypassed and the gate did not fire.
- Confidence cannot distinguish "this test covers the described feature" from "this test imports the same module coincidentally." The only reliable evidence for action tasks is explicit: an Evidence line, artifact evidence, or a config rule.
- Adjusts test 1 task text from `"Implement app module"` to `"App module"` since `"implement"` triggers `taskDescribesChange` and would now be caught by the gate without an Evidence line.
- 76 tests pass (previous 75 + 1 new).

## Test plan

- [ ] New test passes: `action task stays unchecked even when BOTH code and test files match its tokens`
- [ ] `Action task WITH Evidence line is marked complete` still passes
- [ ] `Action-verb task with path hint and code tokens stays unchecked without Evidence line` still passes
- [ ] `canonical artifact heuristic: "Add SECURITY.md"` still passes (hasArtifactTaskPass exempts it)
- [ ] Full suite: 76 tests, 0 failures