### PR TITLE
chore: bump to v0.9.13

### DIFF
--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.9.13 - 2026-05-17
+
+### Fixed
+- **Action-verb gate**: Removed `confidence !== 'high'` from the gate condition. The confidence system cannot distinguish "this test covers the described feature" from "this test imports the same module coincidentally" — when `evidence.code=true` and `evidence.test=true` (from unrelated test imports), `confidence='high'` was bypassing the gate and marking action tasks complete without explicit evidence. Action tasks now require only explicit evidence: an `Evidence:` line, a canonical artifact, or a `grant-evidence` config rule.
+
 ## v0.9.12 - 2026-05-17
 
 ### Fixed

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version to `0.9.13`
- Add CHANGELOG entry for the action-gate confidence check removal (merged in #20)

## Changes

- `package.json`: `0.9.12` → `0.9.13`
- `CHANGELOG.md`: Added `v0.9.13` section documenting the removal of `confidence !== 'high'` from the action-verb gate