### PR TITLE
feat: add one-command zero/maintain flows and VS Code host UX

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roadmapsmith",
   "version": "0.7.0",
-  "description": "Generate, synchronize, and validate deterministic project roadmaps for AI coding agents. Provides the roadmap-sync agent skill and optional CLI for evidence-based task completion tracking.",
+  "description": "Generate and maintain deterministic project roadmaps for AI coding agents. Provides one-command zero/maintain workflows, the roadmap-sync policy skill, and setup-generated VS Code host UX for visible tasks and status.",
   "author": {
     "name": "PapiScholz"
   },

--- a/.claude/hooks/roadmap-sync.js
+++ b/.claude/hooks/roadmap-sync.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const { execFileSync } = require('child_process');
 
-// .claude/hooks/ → project root (two levels up)
+// .claude/hooks/ -> project root (two levels up)
 const PROJECT_ROOT = path.resolve(__dirname, '../..');
 const CLI = path.join(PROJECT_ROOT, 'roadmap-skill', 'bin', 'cli.js');
 const LOCK_FILE = path.join(__dirname, '.sync.lock');
@@ -22,20 +22,18 @@ process.stdin.on('end', () => {
     process.exit(0);
   }
 
-  // Normalise slashes; skip if ROADMAP.md itself was edited (prevents re-trigger loop)
   const normalised = filePath.replace(/\\/g, '/');
   if (!normalised || normalised.endsWith('/ROADMAP.md')) {
     process.exit(0);
   }
 
-  // Skip if another sync is already running (Claude may fire multiple edits in rapid succession)
   if (fs.existsSync(LOCK_FILE)) {
     process.exit(0);
   }
 
   try {
     fs.writeFileSync(LOCK_FILE, String(process.pid));
-    execFileSync('node', [CLI, 'sync', '--project-root', PROJECT_ROOT], {
+    execFileSync(process.execPath, [CLI, 'sync', '--project-root', PROJECT_ROOT], {
       stdio: 'inherit'
     });
   } catch (err) {

--- a/.vscode/roadmapsmith-launcher.js
+++ b/.vscode/roadmapsmith-launcher.js
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const RAW_ARGS = process.argv.slice(2);
+const ACTION = RAW_ARGS[0] || 'explain';
+const SLASH_ACTIONS = [{"id":"zero","description":"Interview the developer in terminal and generate the first roadmap for an empty or low-context repo.","classicCliExample":"roadmapsmith zero","slashExamples":["/zero","/road zero","/roadmap-sync zero"],"taskLabel":"RoadmapSmith: Zero Mode"},{"id":"maintain","description":"Regenerate, sync, and audit the roadmap for an existing repository.","classicCliExample":"roadmapsmith maintain","slashExamples":["/maintain","/road maintain","/roadmap-sync maintain"],"taskLabel":"RoadmapSmith: Maintain"},{"id":"status","description":"Inspect CLI, roadmap, VS Code task, and Claude hook readiness.","classicCliExample":"roadmapsmith doctor --json","slashExamples":["/status","/road status","/roadmap-sync status"],"taskLabel":"RoadmapSmith: Status"},{"id":"init","description":"Create ROADMAP.md and AGENTS.md when they are missing.","classicCliExample":"roadmapsmith init","slashExamples":["/init","/road init","/roadmap-sync init"],"taskLabel":"RoadmapSmith: Init"},{"id":"generate","description":"Rebuild the managed roadmap block from repository context.","classicCliExample":"roadmapsmith generate --project-root .","slashExamples":["/generate","/road generate","/roadmap-sync generate"],"taskLabel":"RoadmapSmith: Generate"},{"id":"validate","description":"Inspect per-task evidence status as JSON.","classicCliExample":"roadmapsmith validate --json --project-root .","slashExamples":["/validate","/road validate","/roadmap-sync validate"],"taskLabel":"RoadmapSmith: Validate"},{"id":"sync","description":"Apply evidence-backed checklist sync to ROADMAP.md.","classicCliExample":"roadmapsmith sync --project-root .","slashExamples":["/sync","/road sync","/roadmap-sync sync"],"taskLabel":"RoadmapSmith: Sync"},{"id":"audit","description":"Run sync and print the post-sync mismatch summary.","classicCliExample":"roadmapsmith sync --audit --project-root .","slashExamples":["/audit","/road audit","/roadmap-sync audit"],"taskLabel":"RoadmapSmith: Sync Audit"},{"id":"setup","description":"Generate visible VS Code tasks and optional Claude hook wiring.","classicCliExample":"roadmapsmith setup","slashExamples":["/setup","/road setup","/roadmap-sync setup"],"taskLabel":"RoadmapSmith: Refresh Setup"}];
+const SLASH_ROOT_ALIASES = new Set(['/road', '/roadmap-sync']);
+const DIRECT_SLASH_ALIAS_TO_ACTION = {
+  '/zero': 'zero',
+  '/maintain': 'maintain',
+  '/status': 'status',
+  '/init': 'init',
+  '/generate': 'generate',
+  '/validate': 'validate',
+  '/sync': 'sync',
+  '/audit': 'audit',
+  '/setup': 'setup'
+};
+const LOCAL_DEV_CLI = path.join(PROJECT_ROOT, 'roadmap-skill', 'bin', 'cli.js');
+const LOCAL_PACKAGE_CLI = path.join(PROJECT_ROOT, 'node_modules', 'roadmapsmith', 'bin', 'cli.js');
+
+function candidate(kind, cliPath) {
+  return { kind, execPath: process.execPath, prefixArgs: [cliPath], shell: false, displayPath: cliPath };
+}
+
+function findGlobalCommandPath() {
+  const probe = process.platform === 'win32'
+    ? spawnSync('where', ['roadmapsmith'], { encoding: 'utf8' })
+    : spawnSync('which', ['roadmapsmith'], { encoding: 'utf8' });
+  if (probe.status !== 0 || !probe.stdout) {
+    return null;
+  }
+  const firstLine = probe.stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+  return firstLine || null;
+}
+
+function resolveCli() {
+  if (fs.existsSync(LOCAL_DEV_CLI)) {
+    return candidate('workspace-dev-copy', LOCAL_DEV_CLI);
+  }
+  if (fs.existsSync(LOCAL_PACKAGE_CLI)) {
+    return candidate('workspace-dependency', LOCAL_PACKAGE_CLI);
+  }
+  const globalPath = findGlobalCommandPath();
+  if (globalPath) {
+    return { kind: 'global', execPath: globalPath, prefixArgs: [], shell: process.platform === 'win32', displayPath: globalPath };
+  }
+  return null;
+}
+
+function normalizeActionId(value) {
+  return String(value || '').trim().toLowerCase().replace(/^\/+/g, '');
+}
+
+function getSlashSuggestions(query) {
+  const normalized = normalizeActionId(query);
+  if (!normalized) {
+    return SLASH_ACTIONS.slice();
+  }
+  const startsWithMatches = SLASH_ACTIONS.filter((action) => action.id.startsWith(normalized));
+  const containsMatches = SLASH_ACTIONS.filter((action) => !action.id.startsWith(normalized) && action.id.includes(normalized));
+  return [...startsWithMatches, ...containsMatches];
+}
+
+function renderSlashPalette(route) {
+  const source = route && route.source ? route.source : '/road';
+  const query = normalizeActionId(route && route.query);
+  const suggestions = route && Array.isArray(route.suggestions) ? route.suggestions : getSlashSuggestions(query);
+  const lines = [];
+  lines.push('RoadmapSmith slash palette');
+  lines.push('');
+  if (query) {
+    lines.push(`Input: ${source} ${query}`);
+    lines.push(suggestions.length > 0 ? 'No exact slash match was executed. Related actions:' : 'No exact slash match was executed.');
+  } else {
+    lines.push(`Entry point: ${source}`);
+    lines.push('Use an exact slash action to execute work. Incomplete or ambiguous input only shows suggestions.');
+  }
+  lines.push('');
+  if (suggestions.length === 0) {
+    lines.push('No related slash actions found.');
+  } else {
+    suggestions.forEach((action) => {
+      lines.push(`- /${action.id}: ${action.description}`);
+      lines.push(`  Classic CLI: ${action.classicCliExample}`);
+      lines.push(`  Skill form: /roadmap-sync ${action.id}`);
+      lines.push(`  VS Code task: ${action.taskLabel}`);
+    });
+  }
+  lines.push('');
+  lines.push('Examples:');
+  lines.push('- roadmapsmith zero');
+  lines.push('- roadmapsmith maintain');
+  lines.push('- roadmapsmith /road');
+  lines.push('- roadmapsmith /maintain');
+  lines.push('- roadmapsmith /roadmap-sync maintain');
+  lines.push('');
+  lines.push('Installing the skill alone does not expose CLI behavior in VS Code. Use roadmapsmith setup for the visible task/launcher layer.');
+  return lines.join('\n');
+}
+
+function resolveSlashInvocation(command, args) {
+  if (typeof command !== 'string' || !command.trim().startsWith('/')) {
+    return null;
+  }
+  const normalizedCommand = command.trim().toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(DIRECT_SLASH_ALIAS_TO_ACTION, normalizedCommand)) {
+    return {
+      kind: 'execute',
+      actionId: DIRECT_SLASH_ALIAS_TO_ACTION[normalizedCommand],
+      query: normalizeActionId(normalizedCommand),
+      source: normalizedCommand,
+      suggestions: getSlashSuggestions(normalizedCommand)
+    };
+  }
+  if (SLASH_ROOT_ALIASES.has(normalizedCommand)) {
+    const queryToken = args.length > 0 ? normalizeActionId(args[0]) : '';
+    if (!queryToken) {
+      return { kind: 'palette', query: '', source: normalizedCommand, suggestions: getSlashSuggestions('') };
+    }
+    const exactAction = SLASH_ACTIONS.find((action) => action.id === queryToken);
+    if (exactAction) {
+      return { kind: 'execute', actionId: exactAction.id, query: queryToken, source: normalizedCommand, suggestions: getSlashSuggestions(queryToken) };
+    }
+    return { kind: 'palette', query: queryToken, source: normalizedCommand, suggestions: getSlashSuggestions(queryToken) };
+  }
+  return { kind: 'palette', query: normalizeActionId(normalizedCommand), source: normalizedCommand, suggestions: getSlashSuggestions(normalizedCommand) };
+}
+
+function explain() {
+  console.log('RoadmapSmith layers:\n');
+  console.log('1. The roadmap-sync skill guides the agent. It does not add VS Code buttons or install the CLI.');
+  console.log('2. The roadmapsmith CLI executes zero/maintain plus the lower-level init/generate/validate/sync/setup/doctor commands.');
+  console.log('3. roadmapsmith setup makes the CLI visible in VS Code through tasks and optional Claude hook wiring.\n');
+  console.log('Typical VS Code workflow:');
+  console.log('- Run "RoadmapSmith: Status" to inspect readiness.');
+  console.log('- For empty repos, run "RoadmapSmith: Zero Mode" or use "/road zero".');
+  console.log('- For existing repos, run "RoadmapSmith: Maintain" or use "/road maintain".');
+  console.log('- Use the lower-level Init, Generate, Validate, and Sync tasks only when you want manual control.\n');
+  console.log('If you installed only the skill, install the CLI as well and then run "RoadmapSmith: Refresh Setup".');
+}
+
+function printStatusFromDoctor(payload) {
+  console.log('RoadmapSmith status\n');
+  if (!payload || !payload.cli || !payload.vscode || !payload.hosts) {
+    console.log('Doctor could not inspect the full host setup. Raw payload follows:\n');
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  console.log(`Project root: ${payload.projectRoot}`);
+  console.log(`CLI resolution: ${payload.cli.kind}${payload.cli.path ? ` (${payload.cli.path})` : ''}${payload.cli.ready ? '' : ' [missing]'}`);
+  console.log(`Roadmap file: ${payload.roadmap.exists ? 'ready' : 'missing'} (${payload.roadmap.path})`);
+  console.log(`Agent rules: ${payload.agents.exists ? 'ready' : 'missing'} (${payload.agents.path})`);
+  console.log(`VS Code launcher: ${payload.vscode.launcher.exists ? 'ready' : 'missing'} (${payload.vscode.launcher.path})`);
+  console.log(`VS Code task wrappers: ${payload.vscode.wrappers.ready ? 'ready' : 'incomplete'} (${payload.vscode.wrappers.presentCount}/${payload.vscode.wrappers.expectedCount} files)`);
+  console.log(`VS Code tasks: ${payload.vscode.tasks.ready ? 'ready' : 'incomplete'} (${payload.vscode.tasks.presentLabels.length}/${payload.vscode.tasks.expectedLabels.length} tasks)`);
+  console.log(`Node runtime: ${payload.runtime.ready ? `ready (${payload.runtime.kind}${payload.runtime.path ? `: ${payload.runtime.path}` : ''})` : 'missing'}`);
+  if (!payload.vscode.tasks.ready && payload.vscode.tasks.missingLabels.length > 0) {
+    console.log(`Missing VS Code tasks: ${payload.vscode.tasks.missingLabels.join(', ')}`);
+  }
+  if (!payload.vscode.wrappers.ready) {
+    console.log(`Missing task wrapper files: ${payload.vscode.wrappers.missingPaths.join(', ')}`);
+  }
+  console.log(`Codex readiness: ${payload.hosts.codex.ready ? 'ready' : 'needs setup'} (${payload.hosts.codex.message})`);
+  console.log(`Claude readiness: ${payload.hosts.claude.ready ? 'ready' : 'needs setup'} (${payload.hosts.claude.message})`);
+  if (!payload.cli.ready) {
+    console.log('\nThe CLI is missing. Installing the skill alone does not expose RoadmapSmith actions in VS Code.');
+    console.log('Install the CLI, then run "RoadmapSmith: Refresh Setup".');
+  }
+  if (!payload.runtime.ready) {
+    console.log('\nThe VS Code task runtime is missing. Install Node.js or set ROADMAPSMITH_NODE, then rerun "RoadmapSmith: Status".');
+  }
+  console.log('\nRecommended entrypoints: roadmapsmith zero, roadmapsmith maintain');
+  console.log('Slash entrypoints: /road, /zero, /maintain, /status, /generate, /validate, /sync, /audit, /setup, /roadmap-sync <action>');
+}
+
+function printMissingCliStatus() {
+  console.log('RoadmapSmith status\n');
+  console.log(`Project root: ${PROJECT_ROOT}`);
+  console.log('CLI resolution: missing');
+  console.log('VS Code tasks are visible because setup generated this launcher, but no RoadmapSmith CLI could be resolved.');
+  console.log('Installing the skill alone does not expose the CLI in VS Code.');
+  console.log('Install the roadmapsmith package, then run "RoadmapSmith: Refresh Setup".');
+  console.log('The launcher looks for, in order: workspace dev copy, workspace dependency, global command.');
+  console.log('Slash discovery still works here: try /road for the local palette.');
+}
+
+function runCli(args, options = {}) {
+  const resolution = resolveCli();
+  if (!resolution) {
+    if (options.allowMissingCli) {
+      return { status: 0, stdout: '', stderr: '', missingCli: true };
+    }
+    console.error('RoadmapSmith CLI not found. Install the CLI and rerun setup.');
+    process.exitCode = 1;
+    return null;
+  }
+  const result = spawnSync(resolution.execPath, [...resolution.prefixArgs, ...args], {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+    shell: resolution.shell,
+    stdio: options.capture ? 'pipe' : 'inherit'
+  });
+  return { ...result, resolution };
+}
+
+function forwardResult(result) {
+  if (!result) {
+    return;
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    process.exitCode = result.status;
+  }
+}
+
+function status() {
+  const result = runCli(['doctor', '--project-root', PROJECT_ROOT, '--json'], { capture: true, allowMissingCli: true });
+  if (!result || result.missingCli) {
+    printMissingCliStatus();
+    return;
+  }
+  if (result.stdout) {
+    try {
+      printStatusFromDoctor(JSON.parse(result.stdout));
+      return;
+    } catch (_) {}
+  }
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exitCode = 0;
+}
+
+const actionToCliArgs = {
+  zero: ['zero', '--project-root', PROJECT_ROOT],
+  maintain: ['maintain', '--project-root', PROJECT_ROOT],
+  init: ['init'],
+  generate: ['generate', '--project-root', PROJECT_ROOT],
+  validate: ['validate', '--json', '--project-root', PROJECT_ROOT],
+  sync: ['sync', '--project-root', PROJECT_ROOT],
+  audit: ['sync', '--audit', '--project-root', PROJECT_ROOT],
+  'sync-dry-run': ['sync', '--dry-run', '--project-root', PROJECT_ROOT],
+  'sync-audit': ['sync', '--audit', '--project-root', PROJECT_ROOT],
+  setup: ['setup', '--project-root', PROJECT_ROOT]
+};
+
+const slashInvocation = resolveSlashInvocation(ACTION, RAW_ARGS.slice(1));
+
+if (slashInvocation) {
+  if (slashInvocation.kind === 'palette') {
+    console.log(renderSlashPalette(slashInvocation));
+  } else if (slashInvocation.actionId === 'status') {
+    status();
+  } else if (Object.prototype.hasOwnProperty.call(actionToCliArgs, slashInvocation.actionId)) {
+    const result = runCli(actionToCliArgs[slashInvocation.actionId]);
+    forwardResult(result);
+  } else {
+    console.log(renderSlashPalette(slashInvocation));
+  }
+} else if (ACTION === 'explain') {
+  explain();
+} else if (ACTION === 'status') {
+  status();
+} else if (Object.prototype.hasOwnProperty.call(actionToCliArgs, ACTION)) {
+  const result = runCli(actionToCliArgs[ACTION]);
+  forwardResult(result);
+} else {
+  console.error(`Unknown RoadmapSmith launcher action: ${ACTION}`);
+  process.exitCode = 1;
+}

--- a/.vscode/roadmapsmith-task.cmd
+++ b/.vscode/roadmapsmith-task.cmd
@@ -1,0 +1,43 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+set "ACTION=%~1"
+if not defined ACTION set "ACTION=explain"
+call :resolve_node
+if defined ROADMAPSMITH_NODE_RESOLVED goto run_launcher
+echo RoadmapSmith VS Code task runtime error
+echo.
+echo VS Code tasks are installed, but the Node runtime needed to start RoadmapSmith could not be resolved.
+echo RoadmapSmith itself may still be installed and the CLI may still be available.
+echo Missing piece: the Node runtime used to start .vscode\roadmapsmith-launcher.js
+echo Recovery: install Node.js or set ROADMAPSMITH_NODE to a working node executable path, then rerun RoadmapSmith: Status.
+if /I "%ACTION%"=="status" exit /b 0
+if /I "%ACTION%"=="explain" exit /b 0
+exit /b 1
+
+:run_launcher
+"%ROADMAPSMITH_NODE_RESOLVED%" "%SCRIPT_DIR%roadmapsmith-launcher.js" %*
+exit /b %ERRORLEVEL%
+
+:resolve_node
+set "ROADMAPSMITH_NODE_RESOLVED="
+if defined ROADMAPSMITH_NODE if exist "%ROADMAPSMITH_NODE%" set "ROADMAPSMITH_NODE_RESOLVED=%ROADMAPSMITH_NODE%"
+if defined ROADMAPSMITH_NODE if not defined ROADMAPSMITH_NODE_RESOLVED call :resolve_command "%ROADMAPSMITH_NODE%"
+if defined ROADMAPSMITH_NODE_RESOLVED exit /b 0
+for /f "delims=" %%I in ('where node 2^>nul') do (
+  set "ROADMAPSMITH_NODE_RESOLVED=%%~fI"
+  goto :node_resolved
+)
+if not defined ROADMAPSMITH_NODE_RESOLVED if defined ProgramFiles if exist "%ProgramFiles%\nodejs\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%ProgramFiles%\nodejs\node.exe"
+if not defined ROADMAPSMITH_NODE_RESOLVED if defined ProgramFiles(x86) if exist "%ProgramFiles(x86)%\nodejs\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%ProgramFiles(x86)%\nodejs\node.exe"
+if not defined ROADMAPSMITH_NODE_RESOLVED if defined LocalAppData if exist "%LocalAppData%\Programs\nodejs\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%LocalAppData%\Programs\nodejs\node.exe"
+if not defined ROADMAPSMITH_NODE_RESOLVED if defined LocalAppData if exist "%LocalAppData%\Volta\bin\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%LocalAppData%\Volta\bin\node.exe"
+:node_resolved
+exit /b 0
+
+:resolve_command
+for /f "delims=" %%I in ('where %~1 2^>nul') do (
+  set "ROADMAPSMITH_NODE_RESOLVED=%%~fI"
+  goto :eof
+)
+exit /b 0

--- a/.vscode/roadmapsmith-task.sh
+++ b/.vscode/roadmapsmith-task.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+SCRIPT_PATH="$0"
+case "${SCRIPT_PATH}" in
+  */*) ;;
+  *) SCRIPT_PATH="./${SCRIPT_PATH}" ;;
+esac
+SCRIPT_DIR=$(CDPATH= cd -- "${SCRIPT_PATH%/*}" && pwd)
 ACTION="${1:-explain}"
 ROADMAPSMITH_NODE_RESOLVED=""
 if [ -n "${ROADMAPSMITH_NODE:-}" ]; then

--- a/.vscode/roadmapsmith-task.sh
+++ b/.vscode/roadmapsmith-task.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+ACTION="${1:-explain}"
+ROADMAPSMITH_NODE_RESOLVED=""
+if [ -n "${ROADMAPSMITH_NODE:-}" ]; then
+  if [ -x "${ROADMAPSMITH_NODE}" ]; then
+    ROADMAPSMITH_NODE_RESOLVED="${ROADMAPSMITH_NODE}"
+  elif command -v -- "${ROADMAPSMITH_NODE}" >/dev/null 2>&1; then
+    ROADMAPSMITH_NODE_RESOLVED=$(command -v -- "${ROADMAPSMITH_NODE}")
+  fi
+fi
+if [ -z "${ROADMAPSMITH_NODE_RESOLVED}" ] && command -v node >/dev/null 2>&1; then
+  ROADMAPSMITH_NODE_RESOLVED=$(command -v node)
+fi
+if [ -z "${ROADMAPSMITH_NODE_RESOLVED}" ]; then
+  echo "RoadmapSmith VS Code task runtime error"
+  echo
+  echo "VS Code tasks are installed, but the Node runtime needed to start RoadmapSmith could not be resolved."
+  echo "RoadmapSmith itself may still be installed and the CLI may still be available."
+  echo "Missing piece: the Node runtime used to start .vscode/roadmapsmith-launcher.js"
+  echo "Recovery: install Node.js or set ROADMAPSMITH_NODE to a working node executable path, then rerun RoadmapSmith: Status."
+  case "${ACTION}" in
+    status|explain) exit 0 ;;
+    *) exit 1 ;;
+  esac
+fi
+exec "${ROADMAPSMITH_NODE_RESOLVED}" "${SCRIPT_DIR}/roadmapsmith-launcher.js" "$@"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,313 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "RoadmapSmith: Zero Mode",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "zero"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "zero"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Run the Zero Mode interview and generate the first roadmap in one command."
+    },
+    {
+      "label": "RoadmapSmith: Maintain",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "maintain"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "maintain"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Run the default existing-repo flow: generate, sync, and audit in one command."
+    },
+    {
+      "label": "RoadmapSmith: Status",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "status"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "status"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Inspect readiness and learn the slash entrypoints like /road and /roadmap-sync <action>."
+    },
+    {
+      "label": "RoadmapSmith: Explain Workflow",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "explain"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "explain"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Explain how zero, maintain, the skill, setup, slash routing, and VS Code tasks work together."
+    },
+    {
+      "label": "RoadmapSmith: Init",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "init"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "init"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Create ROADMAP.md and AGENTS.md when they are missing."
+    },
+    {
+      "label": "RoadmapSmith: Generate",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "generate"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "generate"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Rebuild the managed roadmap block from repository context."
+    },
+    {
+      "label": "RoadmapSmith: Validate",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "validate"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "validate"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Inspect per-task evidence status as JSON."
+    },
+    {
+      "label": "RoadmapSmith: Sync",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "sync"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "sync"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Apply evidence-backed checklist sync to ROADMAP.md."
+    },
+    {
+      "label": "RoadmapSmith: Sync Dry Run",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "sync-dry-run"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "sync-dry-run"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Preview the next roadmap sync without writing files."
+    },
+    {
+      "label": "RoadmapSmith: Sync Audit",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "sync-audit"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "sync-audit"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Run sync and print the post-sync mismatch summary."
+    },
+    {
+      "label": "RoadmapSmith: Refresh Setup",
+      "type": "process",
+      "command": "sh",
+      "args": [
+        ".vscode/roadmapsmith-task.sh",
+        "setup"
+      ],
+      "windows": {
+        "command": "cmd.exe",
+        "args": [
+          "/d",
+          "/c",
+          ".vscode\\roadmapsmith-task.cmd",
+          "setup"
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "detail": "Reapply RoadmapSmith VS Code and host integration files."
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,76 +16,88 @@ Do not mark roadmap tasks complete manually. Always call `roadmapsmith sync` and
 - Keep test discovery scoped to `test/*.test.js`; do not let files in `test/fixtures` run as tests.
 - Preserve deterministic roadmap generation by semantically merging only phase checklist tasks (`Phase P0/P1/P2`) and keeping non-phase section IDs/status stable.
 - Ignore generic implementation words (for example: `implement`, `module`, `function`) in evidence matching; prioritize explicit paths/symbols and domain-specific tokens to reduce validation false positives.
+- When the public RoadmapSmith command contract changes (for example `setup`, `zero`, `maintain`, slash aliases, or VS Code task entrypoints), update all user-facing surfaces in the same pass: `README.md`, `roadmap-skill/README.md`, relevant `docs/use-cases/*`, `docs/release-readiness.md`, `skills.json`, `.claude-plugin/plugin.json`, `skills/roadmap-sync/agents/openai.yaml`, and the active changelog entries. Verify with a doc grep plus the full package test suite, and on this Windows machine prefer the absolute Node executable if `npm test` fails because `node` is missing from PATH.
+- Do not claim near-certainty on cross-surface UX work until the generated artifacts are exercised in a realistic temp-project flow. In this repo, `setup` generating files is not enough proof that launcher/task execution works; verify at least one generated launcher/task path against a resolvable CLI target before saying it is solid.
+- When a failing integration test depends on workspace-local CLI resolution, check the test fixture assumptions before changing product code. Here, the wasted time came from assuming the generated launcher should execute in a temp project with no resolvable CLI, when the real fix was to give the test a workspace CLI shim.
 - When a long chained command sequence produces inconsistent test/process errors (for example transient `spawn EPERM`), rerun critical checks (`npm test`, CLI smoke) as direct commands from `roadmap-skill/` before treating it as a product regression.
 - For filename case-compat behavior (`ROADMAP.md` vs `roadmap.md`), keep one integration test with runtime skip on case-insensitive filesystems (Windows) and enforce precedence logic through unit tests that mock directory entries.
+- Before release work, inspect `.github/workflows/ci.yml`, `roadmap-skill/package.json`, `roadmap-skill/package-lock.json`, and `roadmap-skill/CHANGELOG.md` together; version drift or a missing changelog entry is a release-prep issue, not something to discover after pushing.
+- For release work on this repository, treat `main` as PR-only: direct pushes can be rejected by branch protection, so be ready to push a release branch, wait for required checks, and merge through GitHub.
+- In this Windows environment, do not rely on `git`, `gh`, `npm`, or `node` being available in PATH inside spawned shells or tools; prefer explicit executable paths when release, publish, auth, or validation steps matter.
+- When invoking `gh` by absolute path on this machine, also make `git` available in PATH for that process; `gh pr create` and related commands can fail even if `gh.exe` itself is found.
+- When `npm test` or another package script fails in this shell with "`node` not recognized", treat it as an environment-path issue first and rerun the underlying command with the absolute Node executable before diagnosing the product.
+- Do not trust VS Code source-control messages like "pull first" as proof of remote divergence; fetch and inspect `git status -sb`, branch tracking, and remote refs before deciding what happened.
+- Separate "release published remotely" from "local repo state is clean": after a PR merge, confirm the remote publish/release first, then realign the local branch and uncommitted files as a second step.
+- After a squash merge on GitHub, local `main` can end up `ahead` and `behind` `origin/main` with the same tree content; fetch first, compare tree equality, and soft-reset to `origin/main` when the goal is only to realign local history without disturbing uncommitted files.
+- A release is not done at merge time in this repo; wait for the `main` push workflow, then verify both `npm view roadmapsmith version` and `gh release view vX.Y.Z` before calling the publish complete.
 
 
 <claude-mem-context>
 # Memory Context
 
-# [roadmapsmith] recent context, 2026-06-09 12:10am GMT-3
+# [roadmapsmith] recent context, 2026-06-12 11:48pm GMT-3
 
 Legend: 🎯session 🔴bugfix 🟣feature 🔄refactor ✅change 🔵discovery ⚖️decision 🚨security_alert 🔐security_note
 Format: ID TIME TYPE TITLE
 Fetch details: get_observations([IDs]) | Search: mem-search skill
 
-Stats: 50 obs (16,529t read) | 708,022t work | 98% savings
+Stats: 50 obs (20,278t read) | 207,401t work | 90% savings
 
 ### May 14, 2026
+S123 CodeQL-safe refactoring of parser and validator modules to replace complex regex patterns with composable character-driven tokenization (May 14, 1:33 AM)
 S98 Configure automated npm publishing from GitHub Actions using OIDC trusted publishers for the roadmapsmith package (May 14, 1:33 AM)
-### May 16, 2026
-597 3:12p 🔴 Implemented authoritative Evidence: line parsing and validation (Bug 1 fix)
-598 " 🔴 Implemented negative implementation signal detection (Bug 2 fix)
-599 " ✅ Raised evidence threshold for task completion
-600 " ✅ Modified warning insertion to preserve Evidence line structure
-601 " 🔴 Test suite: all 133 tests passing after validator and parser updates
-602 3:19p ✅ Implemented fixes for validator false negatives and positives with comprehensive test coverage
-606 3:57p 🔴 Fixed CodeQL ReDoS vulnerabilities in roadmap validator and parser
-S123 CodeQL-safe refactoring of parser and validator modules to replace complex regex patterns with composable character-driven tokenization (May 16, 3:58 PM)
-608 4:10p ⚖️ Codex configured to ignore automatic AGENTS.md and ROADMAP.md changes
-609 " 🔵 Git index lock permission issue blocks working tree cleanup in roadmapsmith
-610 4:11p 🔵 Git index.lock permission denied in roadmapsmith repository
-611 " 🔵 Elevated permissions resolve git index.lock issue in roadmapsmith
-612 4:24p ✅ Version bump to v0.9.7 with validator and parser security/correctness fixes
-613 " ✅ Version 0.9.7 prepared for release with validator improvements
-614 " ✅ Release commit 0.9.7 created on main branch
-615 4:26p ✅ v0.9.7 release committed to main branch
-616 " 🔵 Main branch protected: requires pull request and 2 status checks
-617 4:32p 🔵 Local main branch diverged from origin/main by release commit
-618 4:37p ✅ Release PR v0.9.7 created with validator fixes for Evidence: parsing and path safety
-626 4:47p 🔵 Current validator implementation structure and gaps identified
-627 " 🔴 Fixed Bug 1: Removed noisy negative signal patterns causing false negatives
-628 " 🔴 Fixed Bug 2: Asymmetric validation preserves checked tasks without evidence
-629 " ✅ Regression test suite added for Bug 1 and Bug 2 fixes
-630 4:48p 🔵 All test suites pass with Bug 1 and Bug 2 fixes applied
-631 " ✅ Bug fixes committed with comprehensive test coverage
-632 5:02p 🔴 Validator: Remove overly broad negative implementation signal patterns
-633 " 🔴 Validator: Preserve checked tasks with no evidence when unchecking is unjustified
-634 " 🔵 Test suite fully passing with 136 tests covering validator edge cases
-635 " ✅ Validator and sync fixes staged for release-v0.9.7 deployment
-636 " 🔵 Validator negative signal patterns are too broad, causing false negatives in normal codebases
-637 " ⚖️ Implement asymmetric validation: preserve already-checked tasks unless strong evidence shows incompleteness
-638 " ⚖️ Target release 0.9.7 for validator fixes and remove overly-broad negative signal patterns
-643 5:06p 🔴 Validator asymmetric preservation prevents false negatives on checked tasks
-644 " 🔴 Removed overly broad negative signal patterns from validator
-645 " ✅ Minimum confidence threshold now skips preserved tasks
-646 " ✅ CI workflow separates publish and GitHub Release decisions
-647 " 🔴 Validator test suite extended for preservation and signal handling
-648 " ⚖️ Roadmapsmith 0.9.7 targets release branch, not main
-### Jun 9, 2026
-2108 12:07a 🟣 Non-technical autoupdate comparison documentation created
-2109 " ✅ Roadmap tasks added for autoupdate robustness improvements
-2110 " 🔵 Release workflow investigation initiated for version bump
-2111 12:08a 🔵 Roadmapsmith release infrastructure audit
-2112 " 🔵 Current CI release workflow and version state
-2113 " 🔵 Changelog format and release history
-2114 12:09a 🔵 Package-lock version mismatch detected
-2115 " ✅ Comprehensive documentation updates clarifying sync semantics and host support
-2116 " 🔵 npm registry and package.json version alignment
-2117 " 🟣 Package version bumped from 0.9.13 to 0.9.14 with lockfile regeneration
-2118 12:10a 🔵 Version bump and lockfile alignment confirmed
-2119 " 🟣 CHANGELOG.md entry added for v0.9.14 release
-2120 " 🔵 npm test fails due to missing node in PATH
+### Jun 12, 2026
+S395 Implement GUI/IDE visibility for RoadmapSmith CLI status and host distinction (Claude Code vs Codex/Codex CLI) with setup flow and doctor diagnostics (Jun 12, 3:22 PM)
+2610 5:26p 🔵 CLI implements comprehensive command routing with dual JSON/human output modes
+2611 " 🔵 Validation pipeline supports minimum confidence filtering and audit trail
+2612 " 🔵 Plugin system integrated into validation and generation pipelines
+2613 " 🔵 Sync operation filtered to managed block and includes audit fallback
+2614 " 🔵 File I/O module includes comprehensive language and test framework detection
+2615 " 🔵 File writing is idempotent with smart change detection and diff preview
+2616 " 🔵 File traversal excludes 17 common build, cache, and dependency directories by default
+2617 5:29p ✅ Implemented portable task wrapper layer with platform-specific Node.js resolution
+2618 " ✅ Status and doctor commands updated to report wrapper and runtime readiness
+2619 5:30p ✅ Test coverage added for platform-specific wrappers and Node.js runtime detection
+2620 " ✅ CLI test suite extended with platform wrapper and runtime detection tests
+2621 5:31p ✅ Updated README.md to document platform-specific task wrappers and Node.js runtime detection
+2622 " 🔵 Full test suite passes for platform wrapper and runtime detection implementation
+2623 " 🔵 Portable wrapper layer successfully generated by setup command on Windows
+2624 " 🔵 Complete test suite passes with 192/193 tests across all RoadmapSmith functionality
+2625 5:46p 🔵 Current roadmap-sync command interface structure explored for consolidation
+2626 5:51p ⚖️ Architectural decision: two explicit commands for Zero Mode and Sync/Audit Mode with CLI interview entry
+2627 5:53p ⚖️ Command API surface: mode-named commands with multi-surface primary contract
+2628 5:56p ⚖️ Command behavior defaults: maintain regenerates+syncs+audits; zero initializes+generates
+2629 5:57p 🔵 Generator and template modules not yet implemented in codebase
+2630 " 🔵 Core roadmap generation and rendering infrastructure present; new commands integrate existing modules
+2631 " 🔵 Roadmap model structure supports product metadata, phases, steps, risks, and success criteria
+2632 " 🔵 Professional renderer supports 13-section roadmap with phased execution and module maturity tracking
+2633 5:58p 🔵 Comprehensive test suite and integration points mapped for CLI orchestration
+2634 5:59p 🟣 Added Zero Mode configuration schema and config utilities
+2635 6:00p 🟣 Implemented Zero Mode CLI interview module with product context collection
+2636 6:01p 🟣 Implemented roadmapsmith zero and maintain commands with CLI orchestration
+2637 " 🟣 Generator integrates Zero Mode config into product context and roadmap output
+2638 " 🔄 Simplified zero.js by removing section generation logic
+2639 6:02p ✅ Registered zero and maintain commands in slash routing system
+2640 " 🟣 Integrated zero and maintain into VS Code task infrastructure and launcher UX
+2644 6:03p 🔴 Completed launcher script updates: /zero and /maintain now routable via slash aliases and documented in examples
+2645 " ✅ Exported zero module in src/index.js public API
+2647 6:04p ✅ Updated slash.test.js to reflect zero and maintain slash actions
+2648 " ✅ Updated host.test.js task ordering expectations to reflect zero as first managed task
+2649 " ✅ Added comprehensive test coverage for zero and maintain commands to cli.test.js
+2650 6:05p ✅ Created zero.test.js with comprehensive unit tests for discovery interview module
+2653 " 🔵 Identified scoping bug: zeroModeConfig used in generateRoadmapDocument but not declared in function scope
+2654 6:06p 🔴 Fixed zeroModeConfig scoping error in generateRoadmapDocument function
+2655 6:36p ✅ Release Readiness Documentation: Clarified Product Contract and UX Gates
+2656 6:37p ✅ Zero Mode Documentation Refocused: CLI as Primary Entrypoint, Skill as Optional Policy
+2657 " ✅ Sync/Audit Mode Documentation Simplified: Single-Command Workflow Promotion
+2658 " ✅ Claude Code Integration Docs Reordered: CLI-First Install, Skill as Optional Governance
+2659 " ✅ CI Audit Mode Docs Updated: Local Workflow Simplified to `maintain` Command
+2660 " ✅ Release UX Gate Documentation Created: Pre-Release Verification Checklist
+2661 " ✅ roadmap-skill/README.md Updated: Daily Flow Clarification and Release Process Documentation
+2662 6:38p ✅ Root README.md Updated: Release Readiness Documentation Links and Public Contract
+2663 " ✅ CHANGELOG.md v0.9.15 Entry: Public API Refocus and Zero/Maintain Commands
+2664 " ✅ Root CHANGELOG.md Updated: Documentation Refocus and Release Gate Criteria
+2665 11:46p ⚖️ Document command contract breaking-change protocol
 
-Access 708k tokens of past work via get_observations([IDs]) or mem-search skill.
+Access 207k tokens of past work via get_observations([IDs]) or mem-search skill.
 </claude-mem-context>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Documented the new one-command product contract around `roadmapsmith setup`, `roadmapsmith zero`, and `roadmapsmith maintain`.
+- Added `docs/release-ux-gate.md` to make publication criteria explicit for onboarding clarity, failure safety, and config-preserving host setup.
+
+### Changed
+- Release and use-case docs now treat the `roadmap-sync` skill as an optional policy layer instead of the primary end-user entrypoint.
+- Zero Mode and Sync/Audit Mode documentation now match the real CLI and VS Code task flows.
+
 ## [0.7.0] — 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,11 +18,23 @@ Turn vague software ideas into deterministic, evidence-trackable roadmaps for AI
 
 ```bash
 npm install -g roadmapsmith
-roadmapsmith init
-roadmapsmith generate --project-root .
-roadmapsmith validate --json
-roadmapsmith sync --dry-run
+roadmapsmith setup
+roadmapsmith zero       # Empty repo: interview + init + generate
+roadmapsmith maintain   # Existing repo: generate + sync + audit
 ```
+
+In VS Code, run `Tasks: Run Task` and start with `RoadmapSmith: Status`, then use `RoadmapSmith: Zero Mode` for empty repos or `RoadmapSmith: Maintain` for existing repos.
+The generated task layer now resolves Node automatically where possible; if it cannot, RoadmapSmith prints a readable runtime diagnostic instead of a dead task.
+`RoadmapSmith: Status` now treats "ready" as runnable task UX, not merely generated files.
+You can also use slash entrypoints such as `roadmapsmith /road`, `roadmapsmith /zero`, `roadmapsmith /maintain`, or `roadmapsmith /roadmap-sync maintain`.
+
+Optional agent skill:
+
+```bash
+npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+```
+
+The skill guides the agent. The CLI executes actions. Slash routing improves invocation and discovery. `roadmapsmith setup` makes those actions visible in VS Code, generates per-platform task wrappers, and can also wire the repo-local Claude hook.
 
 ## Demo
 
@@ -65,14 +77,29 @@ RoadmapSmith introduces a third path: **validation by evidence**. Before `sync` 
 ## How It Works
 
 ```
-roadmapsmith init              # Write ROADMAP.md + AGENTS.md governance files
-roadmapsmith generate          # Scan repo → emit deterministic task candidates
-roadmapsmith validate --json   # Check task completion against code/test/artifact evidence
-roadmapsmith sync              # Apply validation results (mark ✓ or warn ⚠️)
-roadmapsmith sync --audit      # Run sync and also print a mismatch summary (currently mutating)
+roadmapsmith setup             # Create visible VS Code tasks + optional Claude hook wiring
+roadmapsmith zero              # Empty repo: terminal interview + init + generate
+roadmapsmith maintain          # Existing repo: generate + sync + audit
+roadmapsmith init              # Advanced/manual: write ROADMAP.md + AGENTS.md governance files
+roadmapsmith generate          # Advanced/manual: scan repo → emit deterministic task candidates
+roadmapsmith validate --json   # Advanced/manual: check task completion against evidence
+roadmapsmith sync              # Advanced/manual: apply validation results (mark ✓ or warn ⚠️)
 ```
 
-Each command is independent and composable. Agents typically run `sync` after making changes. Today `sync --audit` is best treated as a mutating sync plus summary, not as a dedicated read-only audit gate.
+The primary contract is now one command per mode: `zero` for empty repos, `maintain` for existing repos. The lower-level commands remain available for manual control. `setup` is the editor-host bridge: it creates visible VS Code tasks for Codex/manual workflows, generates per-platform task wrappers that resolve Node automatically, and can wire the Claude `PostToolUse` hook. Slash routing adds a discovery layer on top: `/road` shows the RoadmapSmith palette, exact slash commands execute, and incomplete or ambiguous slash input only shows suggestions. Today `sync --audit` is best treated as a mutating sync plus summary, not as a dedicated read-only audit gate.
+
+### Slash Invocation
+
+```bash
+roadmapsmith /road
+roadmapsmith /zero
+roadmapsmith /maintain
+roadmapsmith /roadmap-sync maintain
+```
+
+- `/road` is a palette/help entrypoint.
+- Exact slash commands execute normally.
+- Partial or ambiguous input shows suggestions only; it never writes files by accident.
 
 **`generate`** indexes your repository for languages, test frameworks, modules in `src/`, `lib/`, `packages/`, and TODO/FIXME markers (up to 120 files). It emits deterministic task candidates — same input always produces the same structure. Task IDs are stable across regenerations via `<!-- rs:task=id -->` markers.
 
@@ -84,12 +111,12 @@ Each command is independent and composable. Agents typically run `sync` after ma
 
 | Host | Current support |
 |---|---|
-| Claude Code | Supported with a repo-local hook script example and manual hook registration. |
-| Codex / Codex CLI | Supported as a manual CLI workflow today; no documented repo-local PostToolUse equivalent yet. |
+| Claude Code | Supported through `roadmapsmith setup`: visible VS Code tasks, slash-capable launcher UX, and optional repo-local Claude hook wiring. |
+| Codex / Codex CLI | Supported through a visible VS Code task workflow and slash-capable launcher UX after `roadmapsmith setup`. Codex chat itself remains unchanged unless the host exposes native slash registration. |
 | CI | Usable in disposable checkouts, but `sync --audit` is still mutating. |
 | Other hosts | Use the skill instructions plus manual `generate`, `validate`, `sync`, and `sync --dry-run` commands. |
 
-Claude write-time autoupdate depends on the host environment being able to resolve `node` for the repo-local hook. That best-effort hook is separate from this repository's git `pre-commit` sync behavior.
+Claude write-time autoupdate depends on the host environment being able to resolve `node` for the repo-local hook. VS Code tasks use generated wrappers and can also honor `ROADMAPSMITH_NODE` when PATH-based Node resolution is unreliable. That best-effort hook is separate from this repository's git `pre-commit` sync behavior. RoadmapSmith does not invent native chat slash APIs where the host does not expose them; the guaranteed UX surface in this iteration is VS Code Tasks plus the slash-capable launcher/status/help output.
 
 Windows note: prefer `roadmapsmith.cmd`, `npm.cmd`, or explicit `node` paths in shells where PowerShell execution policy or PATH resolution differs from `cmd.exe`.
 
@@ -115,7 +142,9 @@ Expected agent behavior:
 - Define the v1.0 outcome, anti-goals, and risks.
 - Generate ROADMAP.md as the execution contract.
 
-Discovery questions the agent will ask:
+`roadmapsmith zero` is the public entrypoint for this mode. It runs the terminal interview, persists the brief into config, creates governance files when needed, and generates the first roadmap in one invocation.
+
+Discovery questions asked by the CLI interview:
 
 1. What product are we building?
 2. Who is the target user?
@@ -129,12 +158,16 @@ Discovery questions the agent will ask:
 Recommended workflow:
 
 ```bash
-npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
-roadmapsmith init
-roadmapsmith generate --project-root .
+roadmapsmith zero
 ```
 
-The CLI creates governance files. The AI agent performs the discovery interview using the `roadmap-sync` skill instructions before generating the roadmap.
+Optional policy layer:
+
+```bash
+npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+```
+
+The CLI executes the one-command workflow. The `roadmap-sync` skill remains the agent policy/governance layer for hosts that use skills.
 
 ---
 
@@ -153,13 +186,10 @@ Expected behavior:
 Recommended workflow:
 
 ```bash
-roadmapsmith generate --project-root .
-roadmapsmith validate --json
-roadmapsmith sync
-roadmapsmith sync --dry-run
+roadmapsmith maintain
 ```
 
-This is the current mature mode. It is not deprecated — it is the primary workflow for any repository with existing implementation.
+`maintain` runs `generate + sync + audit` in one invocation. Use the lower-level commands only when you want manual inspection or tighter control.
 
 ---
 
@@ -311,14 +341,21 @@ Do not use it if:
 
 | Command | Purpose |
 |---|---|
+| `roadmapsmith setup` | Generate visible VS Code tasks, per-platform task wrappers, and optional Claude hook wiring |
+| `roadmapsmith zero` | Run the Zero Mode interview and generate the first roadmap in one command |
+| `roadmapsmith maintain` | Run the default existing-repo flow: generate, sync, and audit in one command |
+| `roadmapsmith /road` | Show the RoadmapSmith slash palette and related actions |
+| `roadmapsmith /zero` | Slash alias for Zero Mode |
+| `roadmapsmith /maintain` | Slash alias for the default existing-repo flow |
+| `roadmapsmith /roadmap-sync maintain` | Execute the namespaced skill-style slash form through the router |
 | `roadmapsmith init` | Create `ROADMAP.md` and `AGENTS.md` governance files |
 | `roadmapsmith generate --project-root .` | Generate a roadmap from repository context |
 | `roadmapsmith validate --json` | Validate roadmap task evidence and emit JSON results |
 | `roadmapsmith sync --audit` | Apply sync and print a mismatch summary; currently mutates `ROADMAP.md` |
-| `roadmapsmith doctor` | Check basic repository health: config loads and ROADMAP.md exists |
+| `roadmapsmith doctor --json` | Check repository plus host readiness: CLI resolution, roadmap/rules, VS Code tasks, Node runtime, Claude hook |
 | `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` | Install the agent skill |
 
-## Install: Agent Skill (Primary)
+## Install: Agent Skill (Optional Policy Layer)
 
 ### skills.sh and agentskill.sh
 
@@ -326,20 +363,53 @@ Do not use it if:
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
 
-This adds the `roadmap-sync` agent skill. It does not install the CLI package.
+This adds the `roadmap-sync` agent skill only. It does not install the CLI and it does not create visible VS Code actions by itself.
 
 ### aitmpl.com/skills
 
 Search for `roadmapsmith` on [aitmpl.com/skills](https://aitmpl.com/skills) and follow the install prompt, or install directly using the skills CLI above.
 
-## Install: CLI (Optional)
+## Install: CLI + VS Code Host UX
 
 ```bash
 npm install -g roadmapsmith
-roadmapsmith init
-roadmapsmith generate --project-root .
-roadmapsmith validate --json
-roadmapsmith sync --audit
+roadmapsmith setup
+```
+
+Then, inside VS Code:
+
+1. Run `Tasks: Run Task`
+2. Choose `RoadmapSmith: Status`
+3. Use `RoadmapSmith: Zero Mode` for empty repos or `RoadmapSmith: Maintain` for existing repos
+4. Use `Init`, `Generate`, `Validate`, and `Sync` only when you want manual control
+5. Or invoke slash commands from CLI or launcher, starting with `/road`
+
+### VS Code / Codex quick start
+
+```bash
+npm install -g roadmapsmith
+roadmapsmith setup
+```
+
+Codex in VS Code does not get native RoadmapSmith buttons inside the chat pane. The supported visible UX is the generated VS Code task list plus the launcher slash router.
+If Node is installed outside PATH, set `ROADMAPSMITH_NODE` to a working `node` executable and rerun `RoadmapSmith: Status`.
+If the host supports slash registration, RoadmapSmith metadata can advertise the slash entrypoints. If not, the supported fallback is the CLI/launcher slash router plus VS Code tasks.
+
+Recommended commands:
+
+```bash
+roadmapsmith zero
+roadmapsmith maintain
+roadmapsmith /road
+```
+
+### Claude Code quick start
+
+```bash
+npm install -g roadmapsmith
+roadmapsmith setup --hosts codex,claude
+npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+roadmapsmith zero
 ```
 
 ## Updating RoadmapSmith
@@ -357,11 +427,13 @@ npm install roadmapsmith@latest
 npx roadmapsmith@latest sync --audit
 ```
 
-The `roadmap-sync` agent skill is separate from the CLI. Re-running the skills install updates the agent instructions, but it does not update the `roadmapsmith` npm binary:
+The `roadmap-sync` agent skill is separate from the CLI. Re-running the skills install updates the agent instructions, but it does not update the `roadmapsmith` npm binary or the generated VS Code host files:
 
 ```bash
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
+
+After updating the CLI, rerun `roadmapsmith setup` in repositories where you want the latest VS Code tasks, launcher behavior, or Claude hook template.
 
 Fixes are available through `@latest` only after a new npm package version has been published. Before publication, install from a local checkout or a packed tarball for testing:
 
@@ -380,6 +452,22 @@ node bin/cli.js init --dry-run
 node bin/cli.js generate --project-root . --dry-run --audit
 node bin/cli.js validate --json
 ```
+
+If `npm test` fails in your shell with "`node` is not recognized", treat that as a local PATH/runtime issue first and rerun the suite with an explicit Node executable.
+
+## Release Readiness
+
+Release and publication notes now live in:
+
+- [docs/release-readiness.md](docs/release-readiness.md)
+- [docs/release-ux-gate.md](docs/release-ux-gate.md)
+
+Before publishing, the docs, changelog, CLI help, slash routing, and VS Code task surface should all agree on the same public contract:
+
+- `roadmapsmith setup`
+- `roadmapsmith zero`
+- `roadmapsmith maintain`
+- optional `roadmap-sync` skill as policy layer
 
 ## Naming Model
 
@@ -442,7 +530,7 @@ The `AGENTS.md` file (generated by `init`) provides the agent with explicit exec
 ## Use Cases
 
 **AI coding agents**
-Install `roadmap-sync` as a skill. Claude Code currently has the clearest automation path through a manual hook setup. Codex/Codex CLI and other hosts are currently documented as manual workflows: run `generate` to rehydrate context, `validate --json` to inspect evidence, `sync` to apply results, and `sync --dry-run` when you want a preview without writes. The `ROADMAP.md` becomes a reliable contract between sessions — not a note the model wrote to itself.
+Install `roadmap-sync` as a skill when you want the agent to follow the roadmap contract. Install the CLI and run `roadmapsmith setup` when you want visible VS Code actions. Claude Code can also use the generated repo-local hook. Codex/Codex CLI remains a VS Code task workflow in this iteration, not a native chat-pane integration. The `ROADMAP.md` becomes a reliable contract between sessions — not a note the model wrote to itself.
 
 **Multi-session development workflows**
 Each session starts from the same `ROADMAP.md` ground truth. Completed tasks are backed by evidence; in-progress tasks are visible without reading git history or asking the agent to summarize its own work.
@@ -500,4 +588,4 @@ Full detail in [ROADMAP.md](./ROADMAP.md). Summary of active priorities:
 - Caching layer for `buildValidationContext()` — avoid full repo scan per call
 - Incremental scan strategy
 - Configurable phase definitions beyond P0/P1/P2
-- Future: `roadmapsmith discover` and `roadmapsmith init --interactive` CLI commands
+- Future: richer `roadmapsmith zero` brief imports and non-interactive brief/config handoff

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -9,20 +9,68 @@ Published as the `roadmapsmith` npm package. Release readiness is tracked here f
 The canonical release checklist is maintained in [ROADMAP.md](../ROADMAP.md).
 Use this document for context and command runbook notes only.
 
+## Product Contract To Verify
+
+- `roadmapsmith setup` creates the visible VS Code host UX and optional Claude hook wiring.
+- `roadmapsmith zero` is the one-command empty-repo flow.
+- `roadmapsmith maintain` is the one-command existing-repo flow.
+- `roadmap-sync` remains an optional agent policy skill; skill install alone is not full product activation.
+
+Release work is not ready until the docs, host UX, and changelog all reflect that contract consistently.
+
 ## Naming and Install Intent
 
-- Primary install path is the agent skill: `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync`.
-- The skill install command adds agent instructions, not the CLI package.
-- The optional CLI package/command is `roadmapsmith`; update it through npm independently from the skill.
+- Primary end-user install path is the CLI: `npm install -g roadmapsmith`.
+- The skill install command adds agent instructions only: `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync`.
+- The `roadmapsmith` CLI and the `roadmap-sync` skill are versioned and updated independently.
+- `roadmapsmith setup` must be rerun when the generated VS Code task layer, launcher, wrappers, or Claude hook template changes.
 
-## Commands
+## Release UX Gate
+
+Before publishing:
+
+1. Fresh install path is understandable:
+   - `npm install -g roadmapsmith`
+   - `roadmapsmith setup`
+   - `roadmapsmith zero` in an empty repo
+   - `roadmapsmith maintain` in a repo with code
+2. VS Code task surface is visible:
+   - `RoadmapSmith: Status`
+   - `RoadmapSmith: Zero Mode`
+   - `RoadmapSmith: Maintain`
+3. Failure states are actionable:
+   - CLI missing
+   - Node runtime missing
+   - skill-only install
+   - invalid host config
+   - `zero` in non-interactive mode
+4. Existing `.vscode/tasks.json` and `.claude/settings.json` survive additive merge.
+5. Changelog entry explains the user-visible changes, not just internal refactors.
+
+## Verification Commands
 
 ```bash
 cd roadmap-skill
 npm ci
-npm test
+node --test test/*.test.js
 node bin/cli.js --help
-node bin/cli.js init --dry-run
-node bin/cli.js generate --project-root . --dry-run --audit
+node bin/cli.js setup --project-root .. --dry-run
+node bin/cli.js zero --project-root ..   # interactive terminal required
+node bin/cli.js maintain --project-root ..
+node bin/cli.js doctor --project-root .. --json
 npm pack --dry-run
 ```
+
+On this Windows machine, prefer the absolute Node executable when PATH resolution is unreliable:
+
+```powershell
+& 'C:\Program Files\nodejs\node.exe' --test roadmap-skill\test\*.test.js
+```
+
+## Release Notes Expectations
+
+Before publish:
+
+- `README.md` and `roadmap-skill/README.md` must recommend `setup`, `zero`, and `maintain` first.
+- `skills.json`, `.claude-plugin/plugin.json`, and `skills/roadmap-sync/agents/openai.yaml` must describe the skill as policy/governance, not as the whole product.
+- `roadmap-skill/CHANGELOG.md` must include the user-visible CLI, slash, VS Code, and runtime changes for the next version.

--- a/docs/release-ux-gate.md
+++ b/docs/release-ux-gate.md
@@ -1,0 +1,135 @@
+# Release UX Gate
+
+Use this document before publishing a new `roadmapsmith` version.
+
+The goal is simple: a new user must understand how to start, recover from common failures, and avoid damaging existing workspace config.
+
+## Required User Contract
+
+The public entrypoints must stay consistent across CLI help, VS Code tasks, launcher output, README text, and release notes:
+
+- `roadmapsmith setup`
+- `roadmapsmith zero`
+- `roadmapsmith maintain`
+- `roadmapsmith /road`
+
+The optional skill remains a policy layer:
+
+- `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync`
+
+Skill installation alone must never be described as full activation of the product.
+
+## Pass Criteria
+
+### 1. Fresh install, empty repo
+
+Expected flow:
+
+```bash
+npm install -g roadmapsmith
+roadmapsmith setup
+roadmapsmith zero
+```
+
+Pass when:
+
+- The user understands that `zero` is the first command for an empty repository.
+- The terminal interview is clear and finite.
+- `ROADMAP.md` and `AGENTS.md` are created when missing.
+- The generated roadmap reflects the answers given in the interview.
+
+### 2. Fresh install, existing repo
+
+Expected flow:
+
+```bash
+npm install -g roadmapsmith
+roadmapsmith setup
+roadmapsmith maintain
+```
+
+Pass when:
+
+- The user understands that `maintain` is the default existing-repo flow.
+- The command updates the roadmap and prints the mismatch summary.
+- The user is not forced to know `generate`, `sync`, and `audit` up front.
+
+### 3. VS Code discoverability
+
+Pass when `Tasks: Run Task` shows at least:
+
+- `RoadmapSmith: Status`
+- `RoadmapSmith: Zero Mode`
+- `RoadmapSmith: Maintain`
+
+And when `RoadmapSmith: Status` explains:
+
+- CLI ready or missing
+- Node runtime ready or missing
+- tasks/config ready or missing
+- skill install alone does not expose CLI behavior
+
+### 4. Failure clarity
+
+These cases must be tested:
+
+- CLI missing
+- Node runtime missing
+- invalid `.vscode/tasks.json`
+- invalid `.claude/settings.json`
+- `roadmapsmith zero` in non-interactive mode
+- user installed only the skill
+
+Pass when each case tells the user:
+
+- what is missing
+- why the command cannot continue
+- how to recover
+- what command to run next
+
+### 5. Config safety
+
+Pass when:
+
+- unrelated VS Code tasks are preserved
+- unrelated Claude hooks/settings are preserved
+- invalid host config causes a hard failure
+- invalid host config leaves no partial writes behind
+
+### 6. Docs and release notes
+
+Pass when:
+
+- `README.md` recommends `setup`, `zero`, and `maintain` first
+- `roadmap-skill/README.md` matches the same contract
+- `docs/release-readiness.md` matches the actual release workflow
+- `roadmap-skill/CHANGELOG.md` includes the user-visible UX/runtime changes
+
+## Evidence To Capture
+
+For each release candidate, capture:
+
+- terminal transcript or screenshots of the empty-repo flow
+- terminal transcript or screenshots of the existing-repo flow
+- screenshot of the VS Code task list
+- screenshot or log of the friendly Node-runtime failure message
+- result of the package test suite
+
+## Recommended Verification Commands
+
+```bash
+cd roadmap-skill
+npm ci
+node --test test/*.test.js
+node bin/cli.js --help
+node bin/cli.js setup --project-root .. --dry-run
+node bin/cli.js maintain --project-root ..
+node bin/cli.js doctor --project-root .. --json
+npm pack --dry-run
+```
+
+On Windows, use the absolute Node path when PATH resolution is unreliable:
+
+```powershell
+& 'C:\Program Files\nodejs\node.exe' --test roadmap-skill\test\*.test.js
+```

--- a/docs/use-cases/ci-audit.md
+++ b/docs/use-cases/ci-audit.md
@@ -100,11 +100,10 @@ Ready but unchecked:
 
 ```bash
 # Run locally before pushing
-roadmapsmith sync          # update checked state based on evidence
-roadmapsmith sync --audit  # verify no mismatches remain
+roadmapsmith maintain      # generate + sync + audit in one command
 
 # In CI — current summary step in a disposable checkout
 roadmapsmith sync --audit
 ```
 
-Run `sync` to apply evidence-backed updates. Run `sync --audit` in CI only when the checkout is disposable and you want the current summary output. A dedicated read-only audit gate is still roadmap work.
+Run `maintain` locally as the normal existing-repo workflow. Run `sync --audit` in CI only when the checkout is disposable and you want the current summary output. A dedicated read-only audit gate is still roadmap work.

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -18,7 +18,7 @@ Use the Claude Code integration when:
 
 ## How it works
 
-This repository includes an example `.claude/hooks/roadmap-sync.js` script for Claude Code. If you wire it into `.claude/settings.json`, it fires after every file write and runs `roadmapsmith sync`. That workflow is Claude-specific today; Codex/Codex CLI should use the manual CLI flow documented in the main README.
+This repository includes an example `.claude/hooks/roadmap-sync.js` script for Claude Code. If you wire it into `.claude/settings.json`, it fires after every file write and runs `roadmapsmith sync`. That workflow is Claude-specific today; the visible UX surface still starts with `roadmapsmith setup`, `roadmapsmith zero`, and `roadmapsmith maintain`.
 
 The write-time hook is best-effort today. It depends on the Claude host environment being able to resolve `node` for the child process launched by the hook script.
 
@@ -32,15 +32,24 @@ The write-time hook is best-effort today. It depends on the Claude host environm
 
 ## Setup
 
-### Option 1: Install via skills
+### Option 1: Install via CLI + setup
+
+```bash
+npm install -g roadmapsmith
+roadmapsmith setup --hosts codex,claude
+```
+
+This creates the visible VS Code task layer and upserts the repo-local Claude hook wiring.
+
+### Option 2: Install the optional skill
 
 ```bash
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
 
-This installs the skill instructions only. It does not register a Claude hook for you.
+This installs the agent policy instructions only. It does not install the CLI.
 
-### Option 2: Manual hook setup
+### Option 3: Manual hook setup
 
 Copy `.claude/hooks/roadmap-sync.js` to your project's `.claude/hooks/` directory, then register it in `.claude/settings.json`:
 
@@ -65,15 +74,22 @@ Copy `.claude/hooks/roadmap-sync.js` to your project's `.claude/hooks/` director
 ## Typical workflow with Claude Code
 
 ```bash
-# 1. Initialize roadmap files
-roadmapsmith init
+# 1. Install the visible host UX and optional skill
+roadmapsmith setup --hosts codex,claude
+npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 
-# 2. Start a Claude Code session — the skill guides the agent
-# 3. The agent implements tasks; the optional hook syncs the roadmap after each file write
-# 4. At the end of the session, verify the state is accurate
+# 2. For a new repo, create the first roadmap in one command
+roadmapsmith zero
+
+# 3. For an existing repo, run the maintenance flow in one command
+roadmapsmith maintain
+
+# 4. Start a Claude Code session — the skill guides the agent
+# 5. The agent implements tasks; the optional hook syncs the roadmap after each file write
+# 6. At the end of the session, verify the state is accurate
 roadmapsmith sync --audit
 
-# 5. Commit — if you use a pre-commit hook, it can run a final sync
+# 7. Commit — if you use a pre-commit hook, it can run a final sync
 git commit -m "feat: implement task X"
 ```
 

--- a/docs/use-cases/sync-audit-mode.md
+++ b/docs/use-cases/sync-audit-mode.md
@@ -36,20 +36,21 @@ A task passes only when accumulated evidence exceeds the configured threshold.
 ## Workflow
 
 ```bash
-# Rebuild the managed roadmap block from current repository context
+roadmapsmith maintain
+```
+
+`maintain` is the default existing-repo flow. It runs `generate + sync + audit` in one invocation.
+
+Advanced/manual flow:
+
+```bash
 roadmapsmith generate --project-root .
-
-# Inspect evidence status per task (returns JSON with per-task results)
 roadmapsmith validate --json
-
-# Apply validation outcomes — mark [x] where evidence exists, warn where it does not
 roadmapsmith sync
-
-# Print a mismatch summary after sync
 roadmapsmith sync --audit
 ```
 
-Each command is independent. Agents typically run `sync` after completing work. Today `sync --audit` should be treated as a mutating sync plus summary, not as a dedicated read-only audit gate.
+Today `sync --audit` should be treated as a mutating sync plus summary, not as a dedicated read-only audit gate.
 
 ## Why it prevents hallucinated progress
 

--- a/docs/use-cases/zero-mode-discovery.md
+++ b/docs/use-cases/zero-mode-discovery.md
@@ -20,7 +20,9 @@ Do not use Zero Mode for a repository that already has code, tests, or a partial
 
 ## How it works
 
-The AI agent (using the `roadmap-sync` skill) detects low-context conditions and does not immediately generate a generic roadmap. Instead, it runs a discovery conversation to build a product brief.
+`roadmapsmith zero` is the public entrypoint. It does not expect the user to invent a free-form prompt. The CLI detects that Zero Mode applies, runs a terminal-native discovery interview, persists the brief into config, creates governance files when needed, and generates the first roadmap in one invocation.
+
+The `roadmap-sync` skill remains the policy layer for agent hosts that use skills, but it is no longer the only way to access Zero Mode.
 
 ### Discovery Questions
 
@@ -35,7 +37,7 @@ The agent asks up to 8 questions:
 7. What constraints exist? (Budget, hosting, compliance, platform, deadline.)
 8. What does "done" mean for the first usable version?
 
-If the developer already provided enough context in their initial prompt, the agent summarizes the inferred product brief and asks for confirmation rather than repeating questions.
+If existing config already contains answers, the interview uses those values as defaults so the developer does not have to restate the whole brief.
 
 ## Expected ROADMAP.md sections after discovery
 
@@ -52,17 +54,13 @@ A well-formed Zero Mode roadmap includes:
 ## Example workflow
 
 ```bash
-# 1. Install the skill
+roadmapsmith zero
+```
+
+Optional policy layer for skill-based hosts:
+
+```bash
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
-
-# 2. Initialize governance files (creates ROADMAP.md and AGENTS.md stubs)
-roadmapsmith init
-
-# 3. Start an agent session — the skill detects empty context and runs discovery
-# 4. Agent asks the discovery questions, developer answers
-# 5. Agent generates ROADMAP.md from the confirmed product brief
-
-roadmapsmith generate --project-root .
 ```
 
 ## What makes a good discovery outcome
@@ -73,6 +71,8 @@ roadmapsmith generate --project-root .
 - Risks are named early, not discovered mid-execution
 - Phase P0 contains only the critical path to the first runnable version
 
-## Guardrail
+## Guardrails
 
-The agent must not generate a generic roadmap (e.g., "Set up repo", "Add tests", "Deploy") without first completing discovery. Generic tasks have no product context and produce no execution value.
+- Zero Mode must not generate a generic roadmap (for example: "Set up repo", "Add tests", "Deploy") without first completing discovery.
+- In non-interactive environments, `roadmapsmith zero` must fail clearly instead of guessing the missing brief.
+- Skill installation alone must not be presented as if it already enabled the CLI or VS Code task surface.

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.9.15 - Unreleased
+
+### Added
+- `roadmapsmith zero`: one-command Zero Mode flow for empty or low-context repositories. Runs the terminal discovery interview, persists the brief into config, creates governance files when needed, and generates the first roadmap.
+- `roadmapsmith maintain`: one-command existing-repository flow that runs `generate + sync + audit`.
+- Slash aliases for the new public entrypoints: `/zero`, `/maintain`, `/road zero`, `/road maintain`, `/roadmap-sync zero`, and `/roadmap-sync maintain`.
+- New visible VS Code tasks: `RoadmapSmith: Zero Mode` and `RoadmapSmith: Maintain`.
+- Release UX gate documentation in `docs/release-ux-gate.md`.
+
+### Changed
+- Public product contract now recommends `setup`, `zero`, and `maintain` before the lower-level manual commands.
+- Zero Mode no longer depends on a free-form agent prompt as the primary user surface; the `roadmap-sync` skill remains the policy/governance layer.
+- Status/help/launcher output now teaches the one-command flow and clarifies that skill installation alone does not expose CLI behavior in VS Code.
+- Release-readiness and use-case docs now reflect the VS Code-first host UX, additive host setup, and current mutating `sync --audit` semantics.
+
+### Fixed
+- Generated launcher smoke coverage now verifies `maintain` in a temporary project using a resolvable workspace CLI shim.
+
 ## v0.9.14 - 2026-06-09
 
 ### Changed

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -12,7 +12,14 @@ Production-grade roadmap generator and sync tool for agent-driven projects.
 
 ```bash
 npm install -g roadmapsmith
+roadmapsmith setup
+roadmapsmith zero
+roadmapsmith maintain
 ```
+
+Slash entrypoints are also supported from the CLI and launcher, for example: `roadmapsmith /road`, `roadmapsmith /zero`, `roadmapsmith /maintain`, and `roadmapsmith /roadmap-sync maintain`.
+The generated VS Code task layer now resolves Node automatically where possible; if it cannot, RoadmapSmith prints a readable runtime diagnostic instead of a dead task.
+`RoadmapSmith: Status` now treats "ready" as runnable task UX, not merely generated files.
 
 ### Agent Skill
 
@@ -20,7 +27,7 @@ npm install -g roadmapsmith
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
 
-This adds the `roadmap-sync` agent skill. It does not install the CLI package.
+This adds the `roadmap-sync` agent skill only. It does not install the CLI and it does not create visible VS Code actions by itself.
 
 ## Updating
 
@@ -37,11 +44,13 @@ npm install roadmapsmith@latest
 npx roadmapsmith@latest validate --json
 ```
 
-The `roadmap-sync` agent skill is separate from the CLI. Re-running the skills install updates the agent instructions, but it does not update the `roadmapsmith` npm binary:
+The `roadmap-sync` agent skill is separate from the CLI. Re-running the skills install updates the agent instructions, but it does not update the `roadmapsmith` npm binary or the generated VS Code host files:
 
 ```bash
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
+
+After updating the CLI, rerun `roadmapsmith setup` in repositories where you want the latest VS Code tasks, task wrappers, launcher behavior, or Claude hook template.
 
 Fixes are available through `@latest` only after a new npm package version has been published. Before publication, install from a local checkout or a packed tarball for testing.
 
@@ -51,11 +60,11 @@ Fixes are available through `@latest` only after a new npm package version has b
 
 Agent-guided discovery for empty or low-context repositories. The developer has a product idea but no implementation files, no stack decision, and no ROADMAP.md yet.
 
-The CLI creates governance files. The AI agent (using the `roadmap-sync` skill) performs the discovery interview before generating the roadmap.
+Run `roadmapsmith setup` first if you want visible VS Code tasks. `roadmapsmith zero` is the one-command entrypoint: it runs the terminal interview, creates governance files when needed, and generates the first roadmap.
 
 ```bash
-roadmapsmith init
-roadmapsmith generate --project-root .
+roadmapsmith setup
+roadmapsmith zero
 ```
 
 ### Sync/Audit Mode
@@ -63,30 +72,50 @@ roadmapsmith generate --project-root .
 Repository-backed roadmap generation, validation, and synchronization. Use when the repository already has code, tests, docs, TODOs, or an existing ROADMAP.md.
 
 ```bash
-roadmapsmith generate --project-root .
-roadmapsmith validate --json
-roadmapsmith sync
-roadmapsmith sync --dry-run
+roadmapsmith setup
+roadmapsmith maintain
 ```
+
+## Recommended Daily Flow
+
+Use the public entrypoints first:
+
+```bash
+roadmapsmith setup
+roadmapsmith zero       # empty repo
+roadmapsmith maintain   # existing repo
+```
+
+Use the lower-level commands only when you want manual control over generation, validation, or sync.
 
 ## Host Support Today
 
 | Host | Current support |
 |---|---|
-| Claude Code | Manual hook setup is documented and supported. |
-| Codex / Codex CLI | Manual CLI workflow only; no documented auto-hook equivalent yet. |
+| Claude Code | Supported through `roadmapsmith setup`: visible VS Code tasks, slash-capable launcher UX, and optional repo-local Claude hook wiring. |
+| Codex / Codex CLI | Supported through a visible VS Code task workflow and slash-capable launcher UX after `roadmapsmith setup`. Codex chat itself remains unchanged unless the host exposes native slash registration. |
 | CI | Use disposable checkouts if you run `sync --audit`, because it still mutates the roadmap today. |
 | Other hosts | Use the skill plus manual CLI commands. |
+
+If Node is installed outside PATH, set `ROADMAPSMITH_NODE` to a working `node` executable before using the generated VS Code tasks.
 
 ---
 
 ## Commands
 
 ```bash
+roadmapsmith /road
+roadmapsmith /zero
+roadmapsmith /maintain
+roadmapsmith /roadmap-sync maintain
+roadmapsmith setup [--project-root <path>] [--config <path>] [--editor vscode] [--hosts <codex,claude>] [--dry-run]
+roadmapsmith zero [--project-root <path>] [--config <path>]
+roadmapsmith maintain [--project-root <path>] [--config <path>] [--roadmap-file <path>]
 roadmapsmith init [--roadmap-file <path>] [--agents-file <path>] [--dry-run]
 roadmapsmith generate [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--dry-run] [--audit]
 roadmapsmith sync [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run] [--audit]
 roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json]
+roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]
 ```
 
 ## Behavior
@@ -241,10 +270,9 @@ module.exports = {
 ## Example Usage
 
 ```bash
-roadmapsmith init
-roadmapsmith generate --project-root .
+roadmapsmith zero
+roadmapsmith maintain
 roadmapsmith validate --json
-roadmapsmith sync
 roadmapsmith sync --dry-run
 ```
 
@@ -261,6 +289,8 @@ roadmapsmith sync --dry-run
 npm test
 ```
 
+If `npm test` fails in your shell with "`node` is not recognized", treat that as a local PATH/runtime issue first and rerun the suite with an explicit Node executable.
+
 ## Publishing
 
 ```bash
@@ -269,6 +299,12 @@ npm version patch   # or minor / major
 npm publish --access public
 git push origin main --follow-tags
 ```
+
+Repository-specific release note:
+
+- The canonical release automation lives in `.github/workflows/ci.yml`.
+- This repository publishes from GitHub Actions on `main`; local `npm publish` is a maintainer workflow, not the default repo release path.
+- Before publishing, verify the UX/release gate in `docs/release-ux-gate.md` and update `CHANGELOG.md` with the user-visible behavior changes.
 
 ## Versioning Strategy
 

--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -3,23 +3,34 @@
 
 const fs = require('fs');
 const path = require('path');
+const readline = require('node:readline/promises');
 const { parseArgv } = require('../src/utils');
-const { loadConfig, resolveRoadmapFile, resolveAgentsFile, loadPlugins } = require('../src/config');
+const { loadConfig, resolveRoadmapFile, resolveAgentsFile, loadPlugins, readUserConfig, resolveConfigPath } = require('../src/config');
 const { readTextIfExists, writeText, printDryRunDiff } = require('../src/io');
+const { buildSetupFiles, applySetupFiles, inspectHostSetup, parseHosts, assertSupportedEditor } = require('../src/host');
+const { getSlashAction, renderSlashPalette, resolveSlashInvocation } = require('../src/slash');
 const { renderRoadmapTemplate, renderAgentsTemplate } = require('../src/templates');
 const { generateRoadmapDocument } = require('../src/generator');
 const { parseRoadmap } = require('../src/parser');
 const { buildValidationContext, validateTasks, auditValidation, CONFIDENCE_RANK, applyMinimumConfidence } = require('../src/validator');
 const { applySync } = require('../src/sync');
+const { buildZeroModeConfigPatch, buildZeroModeDefaults, collectZeroModeAnswers, isInteractiveTerminal } = require('../src/zero');
 
 function printHelp() {
   console.log([
     'Usage:',
+    '  roadmapsmith zero [--project-root <path>] [--config <path>]',
+    '  roadmapsmith maintain [--project-root <path>] [--config <path>] [--roadmap-file <path>]',
+    '  roadmapsmith /road',
+    '  roadmapsmith /road <action>',
+    '  roadmapsmith /roadmap-sync <action>',
+    '  roadmapsmith /zero | /maintain | /status | /init | /generate | /validate | /sync | /audit | /setup',
     '  roadmapsmith init [--roadmap-file <path>] [--agents-file <path>] [--dry-run]',
+    '  roadmapsmith setup [--project-root <path>] [--config <path>] [--editor vscode] [--hosts <codex,claude>] [--dry-run]',
     '  roadmapsmith generate [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--dry-run] [--audit]',
     '  roadmapsmith sync [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run] [--audit]',
     '  roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json]',
-    '  roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>]'
+    '  roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]'
   ].join('\n'));
 }
 
@@ -68,10 +79,194 @@ function printAudit(audit) {
   }
 }
 
+function formatSetupVerb(result, dryRun) {
+  if (dryRun) {
+    return result.before == null ? 'Would create' : 'Would update';
+  }
+  return result.before == null ? 'Created' : 'Updated';
+}
+
+function runInitCommand(projectRoot, config, flags) {
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const agentsFile = resolveAgentsFile(projectRoot, config, flags['agents-file']);
+  const dryRun = isEnabled(flags['dry-run']);
+
+  const roadmapExists = fs.existsSync(roadmapFile);
+  const agentsExists = fs.existsSync(agentsFile);
+
+  if (!roadmapExists) {
+    const roadmap = renderRoadmapTemplate();
+    const result = writeText(roadmapFile, roadmap, { dryRun });
+    if (dryRun && result.changed) {
+      printDryRunDiff(roadmapFile, result.before, result.after);
+    }
+    console.log(`${dryRun ? 'Would create' : 'Created'} ${roadmapFile}`);
+  } else {
+    console.log(`Skipped existing ${roadmapFile}`);
+  }
+
+  if (!agentsExists) {
+    const agents = renderAgentsTemplate({ roadmapPath: path.basename(roadmapFile) });
+    const result = writeText(agentsFile, agents, { dryRun });
+    if (dryRun && result.changed) {
+      printDryRunDiff(agentsFile, result.before, result.after);
+    }
+    console.log(`${dryRun ? 'Would create' : 'Created'} ${agentsFile}`);
+  } else {
+    console.log(`Skipped existing ${agentsFile}`);
+  }
+}
+
+function runGenerateCommand(projectRoot, config, flags, options = {}) {
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const plugins = loadPlugins(projectRoot, config.plugins);
+  const existingContent = readTextIfExists(roadmapFile) || '';
+  const dryRun = isEnabled(flags['dry-run']);
+
+  const document = generateRoadmapDocument({
+    projectRoot,
+    roadmapPath: roadmapFile,
+    existingContent,
+    config,
+    plugins
+  });
+
+  const writeResult = writeText(roadmapFile, document, { dryRun });
+  if (dryRun) {
+    if (writeResult.changed) {
+      printDryRunDiff(roadmapFile, writeResult.before, writeResult.after);
+    } else {
+      console.log(`No changes for ${roadmapFile}`);
+    }
+  } else {
+    console.log(writeResult.changed ? `Updated ${roadmapFile}` : `No changes for ${roadmapFile}`);
+  }
+
+  if (options.audit || isEnabled(flags.audit)) {
+    const parsedRoadmap = parseRoadmap(document);
+    const validationContext = buildValidationContext(projectRoot, config, plugins);
+    const results = validateTasks(parsedRoadmap.tasks, validationContext, config, plugins);
+    const audit = auditValidation(parsedRoadmap.tasks, results);
+    printAudit(audit);
+  }
+}
+
+function runSyncCommand(projectRoot, config, flags, options = {}) {
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const content = readTextIfExists(roadmapFile);
+  if (content == null) {
+    throw new Error(`Roadmap not found: ${roadmapFile}`);
+  }
+
+  const parsedRoadmap = parseRoadmap(content);
+  const syncTasks = tasksInManagedBlock(parsedRoadmap);
+  const validationContext = buildValidationContext(projectRoot, config, loadPlugins(projectRoot, config.plugins));
+  const results = validateTasks(syncTasks, validationContext, config, validationContext.plugins);
+  applyMinimumConfidence(results, config.validation?.minimumConfidence);
+  const next = applySync(content, syncTasks, results);
+  const dryRun = isEnabled(flags['dry-run']);
+  const writeResult = writeText(roadmapFile, next, { dryRun });
+
+  if (dryRun) {
+    if (writeResult.changed) {
+      printDryRunDiff(roadmapFile, writeResult.before, writeResult.after);
+    } else {
+      console.log(`No changes for ${roadmapFile}`);
+    }
+  } else {
+    console.log(writeResult.changed ? `Updated ${roadmapFile}` : `No changes for ${roadmapFile}`);
+  }
+
+  if (options.audit || isEnabled(flags.audit)) {
+    const audit = auditValidation(syncTasks, results);
+    printAudit(audit);
+  }
+}
+
+function printHumanStatus(payload) {
+  console.log('RoadmapSmith status\n');
+  console.log(`Project root: ${payload.projectRoot}`);
+  console.log(`CLI resolution: ${payload.cli.kind}${payload.cli.path ? ` (${payload.cli.path})` : ''}${payload.cli.ready ? '' : ' [missing]'}`);
+  console.log(`Roadmap file: ${payload.roadmap.exists ? 'ready' : 'missing'} (${payload.roadmap.path})`);
+  console.log(`Agent rules: ${payload.agents.exists ? 'ready' : 'missing'} (${payload.agents.path})`);
+  console.log(`VS Code launcher: ${payload.vscode.launcher.exists ? 'ready' : 'missing'} (${payload.vscode.launcher.path})`);
+  console.log(`VS Code task wrappers: ${payload.vscode.wrappers.ready ? 'ready' : 'incomplete'} (${payload.vscode.wrappers.presentCount}/${payload.vscode.wrappers.expectedCount} files)`);
+  console.log(`VS Code tasks: ${payload.vscode.tasks.ready ? 'ready' : 'incomplete'} (${payload.vscode.tasks.presentLabels.length}/${payload.vscode.tasks.expectedLabels.length} tasks)`);
+  console.log(`Node runtime: ${payload.runtime.ready ? `ready (${payload.runtime.kind}${payload.runtime.path ? `: ${payload.runtime.path}` : ''})` : 'missing'}`);
+  if (!payload.vscode.tasks.ready && payload.vscode.tasks.missingLabels.length > 0) {
+    console.log(`Missing VS Code tasks: ${payload.vscode.tasks.missingLabels.join(', ')}`);
+  }
+  if (!payload.vscode.wrappers.ready) {
+    console.log(`Missing task wrapper files: ${payload.vscode.wrappers.missingPaths.join(', ')}`);
+  }
+  console.log(`Codex readiness: ${payload.hosts.codex.ready ? 'ready' : 'needs setup'} (${payload.hosts.codex.message})`);
+  console.log(`Claude readiness: ${payload.hosts.claude.ready ? 'ready' : 'needs setup'} (${payload.hosts.claude.message})`);
+  console.log('\nRecommended entrypoints: roadmapsmith zero (empty repo), roadmapsmith maintain (existing repo).');
+  if (!payload.cli.ready) {
+    console.log('\nInstalling the skill alone does not expose the CLI in VS Code. Install the CLI and rerun roadmapsmith setup.');
+  }
+  if (!payload.runtime.ready) {
+    console.log('\nThe VS Code task runtime is missing. Install Node.js or set ROADMAPSMITH_NODE, then rerun RoadmapSmith: Status.');
+  }
+}
+
+function runStatusCommand(projectRoot, config, flags, options = {}) {
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const agentsFile = resolveAgentsFile(projectRoot, config, flags['agents-file']);
+  const payload = inspectHostSetup(projectRoot, { roadmapFile, agentsFile });
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    printHumanStatus(payload);
+  }
+
+  const ready = payload.cli.ready && payload.roadmap.exists && payload.agents.exists && payload.vscode.tasks.ready && payload.runtime.ready && payload.claude.ready;
+  if (!ready) {
+    process.exitCode = 1;
+  }
+}
+
+async function runZeroCommand(projectRoot, flags) {
+  const configPath = resolveConfigPath({ projectRoot, configPath: flags.config });
+  const config = loadConfig({ projectRoot, configPath: flags.config });
+  if (!isInteractiveTerminal(process.stdin, process.stdout)) {
+    throw new Error('Zero Mode requires an interactive terminal. Run roadmapsmith zero from a terminal session, or add a config/brief workflow before retrying in non-interactive mode.');
+  }
+
+  const defaults = buildZeroModeDefaults(projectRoot, config);
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  try {
+    console.log('RoadmapSmith Zero Mode');
+    console.log('Answer the discovery interview to generate the first roadmap.\n');
+    const answers = await collectZeroModeAnswers((prompt) => rl.question(prompt), defaults);
+    const existingUserConfig = readUserConfig({ projectRoot, configPath: flags.config });
+    const nextUserConfig = buildZeroModeConfigPatch(projectRoot, existingUserConfig, answers);
+    writeText(configPath, JSON.stringify(nextUserConfig, null, 2));
+    console.log(`Updated ${configPath}`);
+    const nextConfig = loadConfig({ projectRoot, configPath: flags.config });
+    runInitCommand(projectRoot, nextConfig, flags);
+    runGenerateCommand(projectRoot, nextConfig, flags);
+  } finally {
+    rl.close();
+  }
+}
+
+function runMaintainCommand(projectRoot, flags) {
+  const config = loadConfig({ projectRoot, configPath: flags.config });
+  runGenerateCommand(projectRoot, config, flags);
+  runSyncCommand(projectRoot, config, { ...flags, audit: true }, { audit: true });
+}
+
 async function run() {
   const parsed = parseArgv(process.argv.slice(2));
   const command = parsed.command;
   const flags = parsed.flags;
+  let effectiveCommand = command;
 
   if (isEnabled(flags.version) || isEnabled(flags.v)) {
     const pkg = require(path.join(__dirname, '..', 'package.json'));
@@ -84,113 +279,91 @@ async function run() {
     return;
   }
 
-  if (command === 'init') {
-    const projectRoot = process.cwd();
-    const config = loadConfig({ projectRoot });
-    const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
-    const agentsFile = resolveAgentsFile(projectRoot, config, flags['agents-file']);
-    const dryRun = isEnabled(flags['dry-run']);
-
-    const roadmapExists = fs.existsSync(roadmapFile);
-    const agentsExists = fs.existsSync(agentsFile);
-
-    if (!roadmapExists) {
-      const roadmap = renderRoadmapTemplate();
-      const result = writeText(roadmapFile, roadmap, { dryRun });
-      if (dryRun && result.changed) {
-        printDryRunDiff(roadmapFile, result.before, result.after);
-      }
-      console.log(`${dryRun ? 'Would create' : 'Created'} ${roadmapFile}`);
-    } else {
-      console.log(`Skipped existing ${roadmapFile}`);
+  const slashInvocation = resolveSlashInvocation(command, parsed.args);
+  if (slashInvocation) {
+    if (slashInvocation.kind === 'palette') {
+      process.stdout.write(renderSlashPalette(slashInvocation) + '\n');
+      return;
     }
 
-    if (!agentsExists) {
-      const agents = renderAgentsTemplate({ roadmapPath: path.basename(roadmapFile) });
-      const result = writeText(agentsFile, agents, { dryRun });
-      if (dryRun && result.changed) {
-        printDryRunDiff(agentsFile, result.before, result.after);
-      }
-      console.log(`${dryRun ? 'Would create' : 'Created'} ${agentsFile}`);
-    } else {
-      console.log(`Skipped existing ${agentsFile}`);
+    const slashAction = getSlashAction(slashInvocation.actionId);
+    if (!slashAction) {
+      process.stdout.write(renderSlashPalette(slashInvocation) + '\n');
+      return;
     }
+
+    if (slashAction.id === 'status') {
+      const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
+      const config = loadConfig({ projectRoot, configPath: flags.config });
+      runStatusCommand(projectRoot, config, flags, { json: isEnabled(flags.json) });
+      return;
+    }
+
+    if (slashAction.id === 'audit') {
+      flags.audit = true;
+      effectiveCommand = 'sync';
+    } else {
+      effectiveCommand = slashAction.id;
+    }
+  }
+
+  if (effectiveCommand === 'zero') {
+    const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
+    await runZeroCommand(projectRoot, flags);
     return;
   }
 
-  if (command === 'generate') {
+  if (effectiveCommand === 'maintain') {
+    const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
+    runMaintainCommand(projectRoot, flags);
+    return;
+  }
+
+  if (effectiveCommand === 'init') {
     const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
     const config = loadConfig({ projectRoot, configPath: flags.config });
-    const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
-    const plugins = loadPlugins(projectRoot, config.plugins);
-    const existingContent = readTextIfExists(roadmapFile) || '';
-    const dryRun = isEnabled(flags['dry-run']);
+    runInitCommand(projectRoot, config, flags);
+    return;
+  }
 
-    const document = generateRoadmapDocument({
-      projectRoot,
-      roadmapPath: roadmapFile,
-      existingContent,
-      config,
-      plugins
+  if (effectiveCommand === 'generate') {
+    const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
+    const config = loadConfig({ projectRoot, configPath: flags.config });
+    runGenerateCommand(projectRoot, config, flags);
+    return;
+  }
+
+  if (effectiveCommand === 'setup') {
+    const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
+    loadConfig({ projectRoot, configPath: flags.config });
+    const editor = assertSupportedEditor(flags.editor || 'vscode');
+    const hosts = parseHosts(flags.hosts || 'codex,claude');
+    const dryRun = isEnabled(flags['dry-run']);
+    const setupPlan = buildSetupFiles(projectRoot, { editor, hosts });
+    const results = applySetupFiles(setupPlan, { dryRun });
+
+    results.forEach((result) => {
+      if (dryRun && result.changed) {
+        printDryRunDiff(result.path, result.before, result.after);
+      }
+      if (!result.changed) {
+        console.log(`No changes for ${result.path}`);
+        return;
+      }
+      console.log(`${formatSetupVerb(result, dryRun)} ${result.path}`);
     });
 
-    const writeResult = writeText(roadmapFile, document, { dryRun });
-    if (dryRun) {
-      if (writeResult.changed) {
-        printDryRunDiff(roadmapFile, writeResult.before, writeResult.after);
-      } else {
-        console.log(`No changes for ${roadmapFile}`);
-      }
-    } else {
-      console.log(writeResult.changed ? `Updated ${roadmapFile}` : `No changes for ${roadmapFile}`);
-    }
-
-    if (isEnabled(flags.audit)) {
-      const parsedRoadmap = parseRoadmap(document);
-      const validationContext = buildValidationContext(projectRoot, config, plugins);
-      const results = validateTasks(parsedRoadmap.tasks, validationContext, config, plugins);
-      const audit = auditValidation(parsedRoadmap.tasks, results);
-      printAudit(audit);
-    }
     return;
   }
 
-  if (command === 'sync') {
+  if (effectiveCommand === 'sync') {
     const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
     const config = loadConfig({ projectRoot, configPath: flags.config });
-    const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
-    const content = readTextIfExists(roadmapFile);
-    if (content == null) {
-      throw new Error(`Roadmap not found: ${roadmapFile}`);
-    }
-
-    const parsedRoadmap = parseRoadmap(content);
-    const syncTasks = tasksInManagedBlock(parsedRoadmap);
-    const validationContext = buildValidationContext(projectRoot, config, loadPlugins(projectRoot, config.plugins));
-    const results = validateTasks(syncTasks, validationContext, config, validationContext.plugins);
-    applyMinimumConfidence(results, config.validation?.minimumConfidence);
-    const next = applySync(content, syncTasks, results);
-    const dryRun = isEnabled(flags['dry-run']);
-    const writeResult = writeText(roadmapFile, next, { dryRun });
-
-    if (dryRun) {
-      if (writeResult.changed) {
-        printDryRunDiff(roadmapFile, writeResult.before, writeResult.after);
-      } else {
-        console.log(`No changes for ${roadmapFile}`);
-      }
-    } else {
-      console.log(writeResult.changed ? `Updated ${roadmapFile}` : `No changes for ${roadmapFile}`);
-    }
-
-    if (isEnabled(flags.audit)) {
-      const audit = auditValidation(syncTasks, results);
-      printAudit(audit);
-    }
+    runSyncCommand(projectRoot, config, flags);
     return;
   }
 
-  if (command === 'validate') {
+  if (effectiveCommand === 'validate') {
     const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
     const config = loadConfig({ projectRoot, configPath: flags.config });
     const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
@@ -223,38 +396,112 @@ async function run() {
     return;
   }
 
-  if (command === 'doctor') {
+  if (effectiveCommand === 'doctor') {
     const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
     let ok = true;
+    const jsonMode = isEnabled(flags.json);
+    const log = jsonMode ? () => {} : console.log;
+    const logError = jsonMode ? () => {} : console.error;
 
     let config;
+    let roadmapFile = null;
+    let agentsFile = null;
     try {
       config = loadConfig({ projectRoot, configPath: flags.config });
-      console.log('[ok] Config loaded without errors');
+      log('[ok] Config loaded without errors');
     } catch (error) {
-      console.error(`[fail] Config error: ${error.message}`);
+      logError(`[fail] Config error: ${error.message}`);
       ok = false;
     }
 
     if (config) {
-      const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+      roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
       if (fs.existsSync(roadmapFile)) {
-        console.log(`[ok] ROADMAP file found: ${roadmapFile}`);
+        log(`[ok] ROADMAP file found: ${roadmapFile}`);
       } else {
-        console.error(`[fail] ROADMAP file not found: ${roadmapFile}`);
+        logError(`[fail] ROADMAP file not found: ${roadmapFile}`);
         ok = false;
       }
+
+      agentsFile = resolveAgentsFile(projectRoot, config, flags['agents-file']);
+      if (fs.existsSync(agentsFile)) {
+        log(`[ok] Agent rules file found: ${agentsFile}`);
+      } else {
+        logError(`[fail] Agent rules file not found: ${agentsFile}`);
+        ok = false;
+      }
+    }
+
+    let hostStatus = null;
+    if (config) {
+      try {
+        hostStatus = inspectHostSetup(projectRoot, { roadmapFile, agentsFile });
+      } catch (error) {
+        logError(`[fail] Host integration error: ${error.message}`);
+        ok = false;
+      }
+    }
+
+    if (hostStatus) {
+      if (hostStatus.cli.ready) {
+        log(`[ok] CLI resolution: ${hostStatus.cli.kind}${hostStatus.cli.path ? ` (${hostStatus.cli.path})` : ''}`);
+      } else {
+        logError('[fail] CLI resolution: missing local package and global command');
+        ok = false;
+      }
+
+      if (hostStatus.vscode.launcher.exists) {
+        log(`[ok] VS Code launcher found: ${hostStatus.vscode.launcher.path}`);
+      } else {
+        logError(`[fail] VS Code launcher missing: ${hostStatus.vscode.launcher.path}`);
+        ok = false;
+      }
+
+      if (hostStatus.vscode.wrappers.ready) {
+        log(`[ok] VS Code task wrappers ready: ${hostStatus.vscode.wrappers.presentCount}/${hostStatus.vscode.wrappers.expectedCount} files`);
+      } else {
+        logError(`[fail] VS Code task wrappers incomplete: missing ${hostStatus.vscode.wrappers.missingPaths.join(', ') || 'wrapper files'}`);
+        ok = false;
+      }
+
+      if (hostStatus.vscode.tasks.ready) {
+        log(`[ok] VS Code tasks ready: ${hostStatus.vscode.tasks.presentLabels.length}/${hostStatus.vscode.tasks.expectedLabels.length} tasks`);
+      } else {
+        logError(`[fail] VS Code tasks incomplete: missing ${hostStatus.vscode.tasks.missingLabels.join(', ') || 'managed labels'}`);
+        ok = false;
+      }
+
+      if (hostStatus.runtime.ready) {
+        log(`[ok] Node runtime: ${hostStatus.runtime.kind}${hostStatus.runtime.path ? ` (${hostStatus.runtime.path})` : ''}`);
+      } else {
+        logError('[fail] Node runtime missing for VS Code task execution');
+        ok = false;
+      }
+
+      if (hostStatus.claude.ready) {
+        log(`[ok] Claude hook ready: ${hostStatus.claude.hookFile.path}`);
+      } else {
+        logError(`[fail] Claude hook incomplete: ${hostStatus.hosts.claude.message}`);
+        ok = false;
+      }
+    }
+
+    if (jsonMode) {
+      process.stdout.write(JSON.stringify(hostStatus || {
+        projectRoot,
+        error: 'doctor failed before host inspection'
+      }, null, 2) + '\n');
     }
 
     if (!ok) {
       process.exitCode = 1;
       return;
     }
-    console.log('doctor: all checks passed');
+    log('doctor: all checks passed');
     return;
   }
 
-  throw new Error(`Unknown command: ${command}`);
+  throw new Error(`Unknown command: ${effectiveCommand}`);
 }
 
 run().catch((error) => {

--- a/roadmap-skill/src/config.js
+++ b/roadmap-skill/src/config.js
@@ -24,6 +24,12 @@ const DEFAULT_CONFIG = {
     steps: [],
     phases: []
   },
+  zeroMode: {
+    problemStatement: '',
+    preferredStack: '',
+    constraints: [],
+    doneCriteria: []
+  },
   validation: {
     minimumConfidence: 'low'
   },
@@ -77,6 +83,16 @@ function mergeConfig(userConfig) {
         ? userConfig.product.phases
         : DEFAULT_CONFIG.product.phases
     },
+    zeroMode: {
+      ...DEFAULT_CONFIG.zeroMode,
+      ...((userConfig && userConfig.zeroMode) || {}),
+      constraints: (userConfig && userConfig.zeroMode && Array.isArray(userConfig.zeroMode.constraints))
+        ? userConfig.zeroMode.constraints
+        : DEFAULT_CONFIG.zeroMode.constraints,
+      doneCriteria: (userConfig && userConfig.zeroMode && Array.isArray(userConfig.zeroMode.doneCriteria))
+        ? userConfig.zeroMode.doneCriteria
+        : DEFAULT_CONFIG.zeroMode.doneCriteria
+    },
     validation: {
       ...DEFAULT_CONFIG.validation,
       ...((userConfig && userConfig.validation) || {})
@@ -84,11 +100,15 @@ function mergeConfig(userConfig) {
   };
 }
 
-function loadConfig(options = {}) {
+function resolveConfigPath(options = {}) {
   const projectRoot = path.resolve(options.projectRoot || process.cwd());
-  const resolvedConfigPath = options.configPath
+  return options.configPath
     ? path.resolve(projectRoot, String(options.configPath))
     : path.resolve(projectRoot, 'roadmap-skill.config.json');
+}
+
+function loadConfig(options = {}) {
+  const resolvedConfigPath = resolveConfigPath(options);
 
   const content = readTextIfExists(resolvedConfigPath);
   let userConfig = {};
@@ -112,6 +132,15 @@ function loadConfig(options = {}) {
     writable: false
   });
   return merged;
+}
+
+function readUserConfig(options = {}) {
+  const resolvedConfigPath = resolveConfigPath(options);
+  const content = readTextIfExists(resolvedConfigPath);
+  if (!content) {
+    return {};
+  }
+  return safeParseJson(content, resolvedConfigPath);
 }
 
 function resolveRoadmapFile(projectRoot, config, overridePath) {
@@ -214,6 +243,8 @@ module.exports = {
   collectPluginContributions,
   loadConfig,
   loadPlugins,
+  readUserConfig,
   resolveAgentsFile,
+  resolveConfigPath,
   resolveRoadmapFile
 };

--- a/roadmap-skill/src/generator/index.js
+++ b/roadmap-skill/src/generator/index.js
@@ -490,11 +490,12 @@ function createModel(scan, tasks, config, customSections, checkedById) {
   }
 
   const productConfig = config.product || {};
+  const zeroModeConfig = config.zeroMode || {};
   const inferredName = inferProjectName(scan.projectRoot || process.cwd());
   const product = {
     name: productConfig.name || inferredName,
     northStar: productConfig.northStar || '',
-    positioning: productConfig.positioning || '',
+    positioning: productConfig.positioning || (zeroModeConfig.problemStatement ? `Core problem: ${zeroModeConfig.problemStatement}` : ''),
     primaryUser: productConfig.primaryUser || '',
     targetOutcome: productConfig.targetOutcome || ''
   };
@@ -510,9 +511,16 @@ function createModel(scan, tasks, config, customSections, checkedById) {
     'Do not hide validation failures from roadmap consumers'
   ];
 
-  const risks = (productConfig.risks && productConfig.risks.length > 0) ? productConfig.risks : defaultRisks;
+  const derivedConstraintRisks = Array.isArray(zeroModeConfig.constraints)
+    ? zeroModeConfig.constraints.map((constraint) => `Constraint: ${constraint}`)
+    : [];
+  const risks = (productConfig.risks && productConfig.risks.length > 0)
+    ? productConfig.risks
+    : (derivedConstraintRisks.length > 0 ? derivedConstraintRisks : defaultRisks);
   const antiGoals = (productConfig.antiGoals && productConfig.antiGoals.length > 0) ? productConfig.antiGoals : defaultAntiGoals;
-  const successCriteria = productConfig.successCriteria || [];
+  const successCriteria = (productConfig.successCriteria && productConfig.successCriteria.length > 0)
+    ? productConfig.successCriteria
+    : (Array.isArray(zeroModeConfig.doneCriteria) ? zeroModeConfig.doneCriteria : []);
 
   const northStar = productConfig.northStar
     || 'Ship validated, high-impact increments with deterministic delivery and transparent completion evidence.';
@@ -555,6 +563,7 @@ function normalizeCandidate(candidate) {
 function generateRoadmapDocument(options) {
   const projectRoot = options.projectRoot;
   const config = options.config;
+  const zeroModeConfig = config.zeroMode || {};
   const plugins = options.plugins || [];
   const existingContent = options.existingContent || '';
 
@@ -581,6 +590,24 @@ function generateRoadmapDocument(options) {
     items: section.items || []
   }));
 
+  const zeroModeBriefItems = [];
+  if (zeroModeConfig.problemStatement) {
+    zeroModeBriefItems.push(`- **Problem statement:** ${zeroModeConfig.problemStatement}`);
+  }
+  if (zeroModeConfig.preferredStack) {
+    zeroModeBriefItems.push(`- **Preferred stack:** ${zeroModeConfig.preferredStack}`);
+  }
+  if (Array.isArray(zeroModeConfig.constraints) && zeroModeConfig.constraints.length > 0) {
+    zeroModeBriefItems.push(`- **Constraints:** ${zeroModeConfig.constraints.join('; ')}`);
+  }
+  if (Array.isArray(zeroModeConfig.doneCriteria) && zeroModeConfig.doneCriteria.length > 0) {
+    zeroModeBriefItems.push(`- **Done means:** ${zeroModeConfig.doneCriteria.join('; ')}`);
+  }
+  const generatedZeroModeSection = zeroModeBriefItems.length > 0 ? [{
+    title: 'Zero Mode Brief',
+    items: zeroModeBriefItems
+  }] : [];
+
   const configSections = (config.customSections || []).map((section) => ({
     title: section.title,
     items: section.items || []
@@ -601,7 +628,7 @@ function generateRoadmapDocument(options) {
   const baseCandidates = buildDefaultCandidates(scan, config);
   const matcherCandidates = applyTaskMatchers(scan, config);
   const merged = mergeWithExisting([...baseCandidates, ...matcherCandidates, ...pluginTaskCandidates], existingPhaseTasks);
-  const model = createModel(scan, merged, config, [profileSection, ...configSections, ...pluginSections], existingCheckedById);
+  const model = createModel(scan, merged, config, [profileSection, ...generatedZeroModeSection, ...configSections, ...pluginSections], existingCheckedById);
   const profile = config.roadmapProfile || 'compact';
   const managedBody = renderBody(model, profile);
 

--- a/roadmap-skill/src/host.js
+++ b/roadmap-skill/src/host.js
@@ -387,7 +387,12 @@ function renderPosixTaskWrapper() {
   return [
     '#!/bin/sh',
     'set -eu',
-    'SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)',
+    'SCRIPT_PATH="$0"',
+    'case "${SCRIPT_PATH}" in',
+    '  */*) ;;',
+    '  *) SCRIPT_PATH="./${SCRIPT_PATH}" ;;',
+    'esac',
+    'SCRIPT_DIR=$(CDPATH= cd -- "${SCRIPT_PATH%/*}" && pwd)',
     'ACTION="${1:-explain}"',
     'ROADMAPSMITH_NODE_RESOLVED=""',
     'if [ -n "${ROADMAPSMITH_NODE:-}" ]; then',

--- a/roadmap-skill/src/host.js
+++ b/roadmap-skill/src/host.js
@@ -1,0 +1,977 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { readTextIfExists, writeText } = require('./io');
+const { getSlashActionSpecs } = require('./slash');
+
+const SUPPORTED_EDITORS = new Set(['vscode']);
+const SUPPORTED_HOSTS = new Set(['codex', 'claude']);
+const VSCODE_LAUNCHER_RELATIVE_PATH = '.vscode/roadmapsmith-launcher.js';
+const WINDOWS_TASK_WRAPPER_RELATIVE_PATH = '.vscode/roadmapsmith-task.cmd';
+const POSIX_TASK_WRAPPER_RELATIVE_PATH = '.vscode/roadmapsmith-task.sh';
+const ROADMAPSMITH_TASK_LABELS = [
+  'RoadmapSmith: Zero Mode',
+  'RoadmapSmith: Maintain',
+  'RoadmapSmith: Status',
+  'RoadmapSmith: Explain Workflow',
+  'RoadmapSmith: Init',
+  'RoadmapSmith: Generate',
+  'RoadmapSmith: Validate',
+  'RoadmapSmith: Sync',
+  'RoadmapSmith: Sync Dry Run',
+  'RoadmapSmith: Sync Audit',
+  'RoadmapSmith: Refresh Setup'
+];
+const CLAUDE_HOOK_COMMAND = 'node .claude/hooks/roadmap-sync.js';
+const CLAUDE_HOOK_RELATIVE_PATH = '.claude/hooks/roadmap-sync.js';
+
+function removeJsonComments(content) {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const current = content[i];
+    const next = content[i + 1];
+
+    if (lineComment) {
+      if (current === '\n') {
+        lineComment = false;
+        result += current;
+      }
+      continue;
+    }
+
+    if (blockComment) {
+      if (current === '*' && next === '/') {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (inString) {
+      result += current;
+      if (escaped) {
+        escaped = false;
+      } else if (current === '\\') {
+        escaped = true;
+      } else if (current === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (current === '"') {
+      inString = true;
+      result += current;
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+
+    result += current;
+  }
+
+  return result;
+}
+
+function removeTrailingCommas(content) {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < content.length; i += 1) {
+    const current = content[i];
+
+    if (inString) {
+      result += current;
+      if (escaped) {
+        escaped = false;
+      } else if (current === '\\') {
+        escaped = true;
+      } else if (current === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (current === '"') {
+      inString = true;
+      result += current;
+      continue;
+    }
+
+    if (current === ',') {
+      let cursor = i + 1;
+      while (cursor < content.length && /\s/.test(content[cursor])) {
+        cursor += 1;
+      }
+      if (content[cursor] === '}' || content[cursor] === ']') {
+        continue;
+      }
+    }
+
+    result += current;
+  }
+
+  return result;
+}
+
+function parseJsonc(content, filePath) {
+  const sanitized = removeTrailingCommas(removeJsonComments(String(content || '').replace(/^\uFEFF/, '')));
+  try {
+    return JSON.parse(sanitized);
+  } catch (error) {
+    throw new Error(`Invalid JSON in ${filePath}: ${error.message}`);
+  }
+}
+
+function readJsoncObject(filePath) {
+  const content = readTextIfExists(filePath);
+  if (content == null) {
+    return null;
+  }
+  const parsed = parseJsonc(content, filePath);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Expected a JSON object in ${filePath}`);
+  }
+  return parsed;
+}
+
+function stringifyJson(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+function normalizeHostValue(host) {
+  return String(host || '').trim().toLowerCase();
+}
+
+function parseHosts(hostValue) {
+  const rawHosts = Array.isArray(hostValue)
+    ? hostValue.flatMap((entry) => String(entry).split(','))
+    : String(hostValue || 'codex,claude').split(',');
+  const result = [];
+  const seen = new Set();
+
+  for (const rawHost of rawHosts) {
+    const host = normalizeHostValue(rawHost);
+    if (!host) {
+      continue;
+    }
+    if (!SUPPORTED_HOSTS.has(host)) {
+      throw new Error(`Unsupported host "${host}". Supported hosts: codex, claude`);
+    }
+    if (seen.has(host)) {
+      continue;
+    }
+    seen.add(host);
+    result.push(host);
+  }
+
+  if (result.length === 0) {
+    throw new Error('At least one host must be selected for setup');
+  }
+
+  return result;
+}
+
+function assertSupportedEditor(editorValue) {
+  const editor = String(editorValue || 'vscode').trim().toLowerCase();
+  if (!SUPPORTED_EDITORS.has(editor)) {
+    throw new Error(`Unsupported editor "${editor}". Supported editors: vscode`);
+  }
+  return editor;
+}
+
+function createTask(action, label, detail) {
+  return {
+    label,
+    type: 'process',
+    command: 'sh',
+    args: [POSIX_TASK_WRAPPER_RELATIVE_PATH, action],
+    windows: {
+      command: 'cmd.exe',
+      args: ['/d', '/c', WINDOWS_TASK_WRAPPER_RELATIVE_PATH.replace(/\//g, '\\'), action]
+    },
+    options: {
+      cwd: '${workspaceFolder}'
+    },
+    problemMatcher: [],
+    presentation: {
+      reveal: 'always',
+      panel: 'shared',
+      clear: true
+    },
+    detail
+  };
+}
+
+function createManagedTasks() {
+  return [
+    createTask('zero', 'RoadmapSmith: Zero Mode', 'Run the Zero Mode interview and generate the first roadmap in one command.'),
+    createTask('maintain', 'RoadmapSmith: Maintain', 'Run the default existing-repo flow: generate, sync, and audit in one command.'),
+    createTask('status', 'RoadmapSmith: Status', 'Inspect readiness and learn the slash entrypoints like /road and /roadmap-sync <action>.'),
+    createTask('explain', 'RoadmapSmith: Explain Workflow', 'Explain how zero, maintain, the skill, setup, slash routing, and VS Code tasks work together.'),
+    createTask('init', 'RoadmapSmith: Init', 'Create ROADMAP.md and AGENTS.md when they are missing.'),
+    createTask('generate', 'RoadmapSmith: Generate', 'Rebuild the managed roadmap block from repository context.'),
+    createTask('validate', 'RoadmapSmith: Validate', 'Inspect per-task evidence status as JSON.'),
+    createTask('sync', 'RoadmapSmith: Sync', 'Apply evidence-backed checklist sync to ROADMAP.md.'),
+    createTask('sync-dry-run', 'RoadmapSmith: Sync Dry Run', 'Preview the next roadmap sync without writing files.'),
+    createTask('sync-audit', 'RoadmapSmith: Sync Audit', 'Run sync and print the post-sync mismatch summary.'),
+    createTask('setup', 'RoadmapSmith: Refresh Setup', 'Reapply RoadmapSmith VS Code and host integration files.')
+  ];
+}
+
+function mergeVsCodeTasks(existingConfig) {
+  const config = existingConfig ? { ...existingConfig } : {};
+  const existingTasks = Array.isArray(config.tasks) ? config.tasks.slice() : [];
+  const managedLabels = new Set(ROADMAPSMITH_TASK_LABELS);
+  const unmanagedTasks = existingTasks.filter((task) => !managedLabels.has(task && task.label));
+
+  return {
+    ...config,
+    version: typeof config.version === 'string' ? config.version : '2.0.0',
+    tasks: [...createManagedTasks(), ...unmanagedTasks]
+  };
+}
+
+function createClaudeHookEntry() {
+  return {
+    matcher: 'Write|Edit|MultiEdit',
+    hooks: [
+      {
+        type: 'command',
+        command: CLAUDE_HOOK_COMMAND,
+        timeout: 30
+      }
+    ]
+  };
+}
+
+function isRoadmapSmithHookEntry(entry) {
+  if (!entry || !Array.isArray(entry.hooks)) {
+    return false;
+  }
+  return entry.hooks.some((hook) => hook && hook.command === CLAUDE_HOOK_COMMAND);
+}
+
+function mergeClaudeSettings(existingConfig) {
+  const config = existingConfig ? { ...existingConfig } : {};
+  const hooks = config.hooks && typeof config.hooks === 'object' && !Array.isArray(config.hooks)
+    ? { ...config.hooks }
+    : {};
+  const postToolUse = Array.isArray(hooks.PostToolUse) ? hooks.PostToolUse.slice() : [];
+  const withoutManagedEntry = postToolUse.filter((entry) => !isRoadmapSmithHookEntry(entry));
+
+  hooks.PostToolUse = [createClaudeHookEntry(), ...withoutManagedEntry];
+
+  return {
+    ...config,
+    hooks
+  };
+}
+
+function renderClaudeHookScript() {
+  return [
+    '#!/usr/bin/env node',
+    '\'use strict\';',
+    '',
+    'const path = require(\'path\');',
+    'const fs = require(\'fs\');',
+    'const { execFileSync } = require(\'child_process\');',
+    '',
+    '// .claude/hooks/ -> project root (two levels up)',
+    'const PROJECT_ROOT = path.resolve(__dirname, \'../..\');',
+    'const CLI = path.join(PROJECT_ROOT, \'roadmap-skill\', \'bin\', \'cli.js\');',
+    'const LOCK_FILE = path.join(__dirname, \'.sync.lock\');',
+    '',
+    'let data = \'\';',
+    'process.stdin.setEncoding(\'utf8\');',
+    'process.stdin.on(\'data\', chunk => { data += chunk; });',
+    'process.stdin.on(\'end\', () => {',
+    '  let filePath = \'\';',
+    '  try {',
+    '    const parsed = JSON.parse(data);',
+    '    filePath = (parsed && parsed.tool_input && parsed.tool_input.file_path) || \'\';',
+    '  } catch (_) {',
+    '    process.exit(0);',
+    '  }',
+    '',
+    '  const normalised = filePath.replace(/\\\\/g, \'/\');',
+    '  if (!normalised || normalised.endsWith(\'/ROADMAP.md\')) {',
+    '    process.exit(0);',
+    '  }',
+    '',
+    '  if (fs.existsSync(LOCK_FILE)) {',
+    '    process.exit(0);',
+    '  }',
+    '',
+    '  try {',
+    '    fs.writeFileSync(LOCK_FILE, String(process.pid));',
+    '    execFileSync(process.execPath, [CLI, \'sync\', \'--project-root\', PROJECT_ROOT], {',
+    '      stdio: \'inherit\'',
+    '    });',
+    '  } catch (err) {',
+    '    process.stderr.write(\'roadmapsmith sync failed: \' + (err.message || String(err)) + \'\\n\');',
+    '  } finally {',
+    '    try { fs.unlinkSync(LOCK_FILE); } catch (_) {}',
+    '  }',
+    '});',
+    ''
+  ].join('\n');
+}
+
+function renderWindowsTaskWrapper() {
+  return [
+    '@echo off',
+    'setlocal',
+    'set "SCRIPT_DIR=%~dp0"',
+    'set "ACTION=%~1"',
+    'if not defined ACTION set "ACTION=explain"',
+    'call :resolve_node',
+    'if defined ROADMAPSMITH_NODE_RESOLVED goto run_launcher',
+    'echo RoadmapSmith VS Code task runtime error',
+    'echo.',
+    'echo VS Code tasks are installed, but the Node runtime needed to start RoadmapSmith could not be resolved.',
+    'echo RoadmapSmith itself may still be installed and the CLI may still be available.',
+    'echo Missing piece: the Node runtime used to start .vscode\\roadmapsmith-launcher.js',
+    'echo Recovery: install Node.js or set ROADMAPSMITH_NODE to a working node executable path, then rerun RoadmapSmith: Status.',
+    'if /I "%ACTION%"=="status" exit /b 0',
+    'if /I "%ACTION%"=="explain" exit /b 0',
+    'exit /b 1',
+    '',
+    ':run_launcher',
+    '"%ROADMAPSMITH_NODE_RESOLVED%" "%SCRIPT_DIR%roadmapsmith-launcher.js" %*',
+    'exit /b %ERRORLEVEL%',
+    '',
+    ':resolve_node',
+    'set "ROADMAPSMITH_NODE_RESOLVED="',
+    'if defined ROADMAPSMITH_NODE if exist "%ROADMAPSMITH_NODE%" set "ROADMAPSMITH_NODE_RESOLVED=%ROADMAPSMITH_NODE%"',
+    'if defined ROADMAPSMITH_NODE if not defined ROADMAPSMITH_NODE_RESOLVED call :resolve_command "%ROADMAPSMITH_NODE%"',
+    'if defined ROADMAPSMITH_NODE_RESOLVED exit /b 0',
+    'for /f "delims=" %%I in (\'where node 2^>nul\') do (',
+    '  set "ROADMAPSMITH_NODE_RESOLVED=%%~fI"',
+    '  goto :node_resolved',
+    ')',
+    'if not defined ROADMAPSMITH_NODE_RESOLVED if defined ProgramFiles if exist "%ProgramFiles%\\nodejs\\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%ProgramFiles%\\nodejs\\node.exe"',
+    'if not defined ROADMAPSMITH_NODE_RESOLVED if defined ProgramFiles(x86) if exist "%ProgramFiles(x86)%\\nodejs\\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%ProgramFiles(x86)%\\nodejs\\node.exe"',
+    'if not defined ROADMAPSMITH_NODE_RESOLVED if defined LocalAppData if exist "%LocalAppData%\\Programs\\nodejs\\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%LocalAppData%\\Programs\\nodejs\\node.exe"',
+    'if not defined ROADMAPSMITH_NODE_RESOLVED if defined LocalAppData if exist "%LocalAppData%\\Volta\\bin\\node.exe" set "ROADMAPSMITH_NODE_RESOLVED=%LocalAppData%\\Volta\\bin\\node.exe"',
+    ':node_resolved',
+    'exit /b 0',
+    '',
+    ':resolve_command',
+    'for /f "delims=" %%I in (\'where %~1 2^>nul\') do (',
+    '  set "ROADMAPSMITH_NODE_RESOLVED=%%~fI"',
+    '  goto :eof',
+    ')',
+    'exit /b 0'
+  ].join('\n');
+}
+
+function renderPosixTaskWrapper() {
+  return [
+    '#!/bin/sh',
+    'set -eu',
+    'SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)',
+    'ACTION="${1:-explain}"',
+    'ROADMAPSMITH_NODE_RESOLVED=""',
+    'if [ -n "${ROADMAPSMITH_NODE:-}" ]; then',
+    '  if [ -x "${ROADMAPSMITH_NODE}" ]; then',
+    '    ROADMAPSMITH_NODE_RESOLVED="${ROADMAPSMITH_NODE}"',
+    '  elif command -v -- "${ROADMAPSMITH_NODE}" >/dev/null 2>&1; then',
+    '    ROADMAPSMITH_NODE_RESOLVED=$(command -v -- "${ROADMAPSMITH_NODE}")',
+    '  fi',
+    'fi',
+    'if [ -z "${ROADMAPSMITH_NODE_RESOLVED}" ] && command -v node >/dev/null 2>&1; then',
+    '  ROADMAPSMITH_NODE_RESOLVED=$(command -v node)',
+    'fi',
+    'if [ -z "${ROADMAPSMITH_NODE_RESOLVED}" ]; then',
+    '  echo "RoadmapSmith VS Code task runtime error"',
+    '  echo',
+    '  echo "VS Code tasks are installed, but the Node runtime needed to start RoadmapSmith could not be resolved."',
+    '  echo "RoadmapSmith itself may still be installed and the CLI may still be available."',
+    '  echo "Missing piece: the Node runtime used to start .vscode/roadmapsmith-launcher.js"',
+    '  echo "Recovery: install Node.js or set ROADMAPSMITH_NODE to a working node executable path, then rerun RoadmapSmith: Status."',
+    '  case "${ACTION}" in',
+    '    status|explain) exit 0 ;;',
+    '    *) exit 1 ;;',
+    '  esac',
+    'fi',
+    'exec "${ROADMAPSMITH_NODE_RESOLVED}" "${SCRIPT_DIR}/roadmapsmith-launcher.js" "$@"'
+  ].join('\n');
+}
+
+function findCommandPath(commandName, env = process.env) {
+  const probe = process.platform === 'win32'
+    ? require('child_process').spawnSync('where', [commandName], { encoding: 'utf8', env })
+    : require('child_process').spawnSync('which', [commandName], { encoding: 'utf8', env });
+  if (probe.status !== 0 || !probe.stdout) {
+    return null;
+  }
+  return probe.stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean) || null;
+}
+
+function detectNodeRuntime(env = process.env) {
+  const override = String((env && env.ROADMAPSMITH_NODE) || '').trim();
+  if (override) {
+    if (fs.existsSync(override)) {
+      return { ready: true, kind: 'env-override', path: override };
+    }
+    const overrideCommandPath = findCommandPath(override, env);
+    if (overrideCommandPath) {
+      return { ready: true, kind: 'env-override', path: overrideCommandPath };
+    }
+  }
+
+  const pathNode = findCommandPath('node', env);
+  if (pathNode) {
+    return { ready: true, kind: 'path', path: pathNode };
+  }
+
+  if (process.platform === 'win32') {
+    const candidateSpecs = [
+      { kind: 'program-files', path: env && env.ProgramFiles ? path.join(env.ProgramFiles, 'nodejs', 'node.exe') : null },
+      { kind: 'program-files-x86', path: env && env['ProgramFiles(x86)'] ? path.join(env['ProgramFiles(x86)'], 'nodejs', 'node.exe') : null },
+      { kind: 'local-app-data', path: env && env.LocalAppData ? path.join(env.LocalAppData, 'Programs', 'nodejs', 'node.exe') : null },
+      { kind: 'volta', path: env && env.LocalAppData ? path.join(env.LocalAppData, 'Volta', 'bin', 'node.exe') : null }
+    ];
+
+    for (const candidate of candidateSpecs) {
+      if (candidate.path && fs.existsSync(candidate.path)) {
+        return { ready: true, kind: candidate.kind, path: candidate.path };
+      }
+    }
+  }
+
+  return {
+    ready: false,
+    kind: 'missing',
+    path: null
+  };
+}
+
+function renderVsCodeLauncher() {
+  const slashSpecsJson = JSON.stringify(getSlashActionSpecs());
+  return [
+    '#!/usr/bin/env node',
+    '\'use strict\';',
+    '',
+    'const fs = require(\'fs\');',
+    'const path = require(\'path\');',
+    'const { spawnSync } = require(\'child_process\');',
+    '',
+    'const PROJECT_ROOT = path.resolve(__dirname, \'..\');',
+    'const RAW_ARGS = process.argv.slice(2);',
+    'const ACTION = RAW_ARGS[0] || \'explain\';',
+    `const SLASH_ACTIONS = ${slashSpecsJson};`,
+    'const SLASH_ROOT_ALIASES = new Set([\'/road\', \'/roadmap-sync\']);',
+    'const DIRECT_SLASH_ALIAS_TO_ACTION = {',
+    '  \'/zero\': \'zero\',',
+    '  \'/maintain\': \'maintain\',',
+    '  \'/status\': \'status\',',
+    '  \'/init\': \'init\',',
+    '  \'/generate\': \'generate\',',
+    '  \'/validate\': \'validate\',',
+    '  \'/sync\': \'sync\',',
+    '  \'/audit\': \'audit\',',
+    '  \'/setup\': \'setup\'',
+    '};',
+    'const LOCAL_DEV_CLI = path.join(PROJECT_ROOT, \'roadmap-skill\', \'bin\', \'cli.js\');',
+    'const LOCAL_PACKAGE_CLI = path.join(PROJECT_ROOT, \'node_modules\', \'roadmapsmith\', \'bin\', \'cli.js\');',
+    '',
+    'function candidate(kind, cliPath) {',
+    '  return { kind, execPath: process.execPath, prefixArgs: [cliPath], shell: false, displayPath: cliPath };',
+    '}',
+    '',
+    'function findGlobalCommandPath() {',
+    '  const probe = process.platform === \'win32\'',
+    '    ? spawnSync(\'where\', [\'roadmapsmith\'], { encoding: \'utf8\' })',
+    '    : spawnSync(\'which\', [\'roadmapsmith\'], { encoding: \'utf8\' });',
+    '  if (probe.status !== 0 || !probe.stdout) {',
+    '    return null;',
+    '  }',
+    '  const firstLine = probe.stdout.split(/\\r?\\n/).map((line) => line.trim()).find(Boolean);',
+    '  return firstLine || null;',
+    '}',
+    '',
+    'function resolveCli() {',
+    '  if (fs.existsSync(LOCAL_DEV_CLI)) {',
+    '    return candidate(\'workspace-dev-copy\', LOCAL_DEV_CLI);',
+    '  }',
+    '  if (fs.existsSync(LOCAL_PACKAGE_CLI)) {',
+    '    return candidate(\'workspace-dependency\', LOCAL_PACKAGE_CLI);',
+    '  }',
+    '  const globalPath = findGlobalCommandPath();',
+    '  if (globalPath) {',
+    '    return { kind: \'global\', execPath: globalPath, prefixArgs: [], shell: process.platform === \'win32\', displayPath: globalPath };',
+    '  }',
+    '  return null;',
+    '}',
+    '',
+    'function normalizeActionId(value) {',
+    '  return String(value || \'\').trim().toLowerCase().replace(/^\\/+/g, \'\');',
+    '}',
+    '',
+    'function getSlashSuggestions(query) {',
+    '  const normalized = normalizeActionId(query);',
+    '  if (!normalized) {',
+    '    return SLASH_ACTIONS.slice();',
+    '  }',
+    '  const startsWithMatches = SLASH_ACTIONS.filter((action) => action.id.startsWith(normalized));',
+    '  const containsMatches = SLASH_ACTIONS.filter((action) => !action.id.startsWith(normalized) && action.id.includes(normalized));',
+    '  return [...startsWithMatches, ...containsMatches];',
+    '}',
+    '',
+    'function renderSlashPalette(route) {',
+    '  const source = route && route.source ? route.source : \'/road\';',
+    '  const query = normalizeActionId(route && route.query);',
+    '  const suggestions = route && Array.isArray(route.suggestions) ? route.suggestions : getSlashSuggestions(query);',
+    '  const lines = [];',
+    '  lines.push(\'RoadmapSmith slash palette\');',
+    '  lines.push(\'\');',
+    '  if (query) {',
+    '    lines.push(`Input: ${source} ${query}`);',
+    '    lines.push(suggestions.length > 0 ? \'No exact slash match was executed. Related actions:\' : \'No exact slash match was executed.\');',
+    '  } else {',
+    '    lines.push(`Entry point: ${source}`);',
+    '    lines.push(\'Use an exact slash action to execute work. Incomplete or ambiguous input only shows suggestions.\');',
+    '  }',
+    '  lines.push(\'\');',
+    '  if (suggestions.length === 0) {',
+    '    lines.push(\'No related slash actions found.\');',
+    '  } else {',
+    '    suggestions.forEach((action) => {',
+    '      lines.push(`- /${action.id}: ${action.description}`);',
+    '      lines.push(`  Classic CLI: ${action.classicCliExample}`);',
+    '      lines.push(`  Skill form: /roadmap-sync ${action.id}`);',
+    '      lines.push(`  VS Code task: ${action.taskLabel}`);',
+    '    });',
+    '  }',
+    '  lines.push(\'\');',
+    '  lines.push(\'Examples:\');',
+    '  lines.push(\'- roadmapsmith zero\');',
+    '  lines.push(\'- roadmapsmith maintain\');',
+    '  lines.push(\'- roadmapsmith /road\');',
+    '  lines.push(\'- roadmapsmith /maintain\');',
+    '  lines.push(\'- roadmapsmith /roadmap-sync maintain\');',
+    '  lines.push(\'\');',
+    '  lines.push(\'Installing the skill alone does not expose CLI behavior in VS Code. Use roadmapsmith setup for the visible task/launcher layer.\');',
+    '  return lines.join(\'\\n\');',
+    '}',
+    '',
+    'function resolveSlashInvocation(command, args) {',
+    '  if (typeof command !== \'string\' || !command.trim().startsWith(\'/\')) {',
+    '    return null;',
+    '  }',
+    '  const normalizedCommand = command.trim().toLowerCase();',
+    '  if (Object.prototype.hasOwnProperty.call(DIRECT_SLASH_ALIAS_TO_ACTION, normalizedCommand)) {',
+    '    return {',
+    '      kind: \'execute\',',
+    '      actionId: DIRECT_SLASH_ALIAS_TO_ACTION[normalizedCommand],',
+    '      query: normalizeActionId(normalizedCommand),',
+    '      source: normalizedCommand,',
+    '      suggestions: getSlashSuggestions(normalizedCommand)',
+    '    };',
+    '  }',
+    '  if (SLASH_ROOT_ALIASES.has(normalizedCommand)) {',
+    '    const queryToken = args.length > 0 ? normalizeActionId(args[0]) : \'\';',
+    '    if (!queryToken) {',
+    '      return { kind: \'palette\', query: \'\', source: normalizedCommand, suggestions: getSlashSuggestions(\'\') };',
+    '    }',
+    '    const exactAction = SLASH_ACTIONS.find((action) => action.id === queryToken);',
+    '    if (exactAction) {',
+    '      return { kind: \'execute\', actionId: exactAction.id, query: queryToken, source: normalizedCommand, suggestions: getSlashSuggestions(queryToken) };',
+    '    }',
+    '    return { kind: \'palette\', query: queryToken, source: normalizedCommand, suggestions: getSlashSuggestions(queryToken) };',
+    '  }',
+    '  return { kind: \'palette\', query: normalizeActionId(normalizedCommand), source: normalizedCommand, suggestions: getSlashSuggestions(normalizedCommand) };',
+    '}',
+    '',
+    'function explain() {',
+    '  console.log(\'RoadmapSmith layers:\\n\');',
+    '  console.log(\'1. The roadmap-sync skill guides the agent. It does not add VS Code buttons or install the CLI.\');',
+    '  console.log(\'2. The roadmapsmith CLI executes zero/maintain plus the lower-level init/generate/validate/sync/setup/doctor commands.\');',
+    '  console.log(\'3. roadmapsmith setup makes the CLI visible in VS Code through tasks and optional Claude hook wiring.\\n\');',
+    '  console.log(\'Typical VS Code workflow:\');',
+    '  console.log(\'- Run "RoadmapSmith: Status" to inspect readiness.\');',
+    '  console.log(\'- For empty repos, run "RoadmapSmith: Zero Mode" or use "/road zero".\');',
+    '  console.log(\'- For existing repos, run "RoadmapSmith: Maintain" or use "/road maintain".\');',
+    '  console.log(\'- Use the lower-level Init, Generate, Validate, and Sync tasks only when you want manual control.\\n\');',
+    '  console.log(\'If you installed only the skill, install the CLI as well and then run "RoadmapSmith: Refresh Setup".\');',
+    '}',
+    '',
+    'function printStatusFromDoctor(payload) {',
+    '  console.log(\'RoadmapSmith status\\n\');',
+    '  if (!payload || !payload.cli || !payload.vscode || !payload.hosts) {',
+    '    console.log(\'Doctor could not inspect the full host setup. Raw payload follows:\\n\');',
+    '    console.log(JSON.stringify(payload, null, 2));',
+    '    return;',
+    '  }',
+    '  console.log(`Project root: ${payload.projectRoot}`);',
+    '  console.log(`CLI resolution: ${payload.cli.kind}${payload.cli.path ? ` (${payload.cli.path})` : \'\'}${payload.cli.ready ? \'\' : \' [missing]\'}`);',
+    '  console.log(`Roadmap file: ${payload.roadmap.exists ? \'ready\' : \'missing\'} (${payload.roadmap.path})`);',
+    '  console.log(`Agent rules: ${payload.agents.exists ? \'ready\' : \'missing\'} (${payload.agents.path})`);',
+    '  console.log(`VS Code launcher: ${payload.vscode.launcher.exists ? \'ready\' : \'missing\'} (${payload.vscode.launcher.path})`);',
+    '  console.log(`VS Code task wrappers: ${payload.vscode.wrappers.ready ? \'ready\' : \'incomplete\'} (${payload.vscode.wrappers.presentCount}/${payload.vscode.wrappers.expectedCount} files)`);',
+    '  console.log(`VS Code tasks: ${payload.vscode.tasks.ready ? \'ready\' : \'incomplete\'} (${payload.vscode.tasks.presentLabels.length}/${payload.vscode.tasks.expectedLabels.length} tasks)`);',
+    '  console.log(`Node runtime: ${payload.runtime.ready ? `ready (${payload.runtime.kind}${payload.runtime.path ? `: ${payload.runtime.path}` : \'\'})` : \'missing\'}`);',
+    '  if (!payload.vscode.tasks.ready && payload.vscode.tasks.missingLabels.length > 0) {',
+    '    console.log(`Missing VS Code tasks: ${payload.vscode.tasks.missingLabels.join(\', \')}`);',
+    '  }',
+    '  if (!payload.vscode.wrappers.ready) {',
+    '    console.log(`Missing task wrapper files: ${payload.vscode.wrappers.missingPaths.join(\', \')}`);',
+    '  }',
+    '  console.log(`Codex readiness: ${payload.hosts.codex.ready ? \'ready\' : \'needs setup\'} (${payload.hosts.codex.message})`);',
+    '  console.log(`Claude readiness: ${payload.hosts.claude.ready ? \'ready\' : \'needs setup\'} (${payload.hosts.claude.message})`);',
+    '  if (!payload.cli.ready) {',
+    '    console.log(\'\\nThe CLI is missing. Installing the skill alone does not expose RoadmapSmith actions in VS Code.\');',
+    '    console.log(\'Install the CLI, then run "RoadmapSmith: Refresh Setup".\');',
+    '  }',
+    '  if (!payload.runtime.ready) {',
+    '    console.log(\'\\nThe VS Code task runtime is missing. Install Node.js or set ROADMAPSMITH_NODE, then rerun "RoadmapSmith: Status".\');',
+    '  }',
+    '  console.log(\'\\nRecommended entrypoints: roadmapsmith zero, roadmapsmith maintain\');',
+    '  console.log(\'Slash entrypoints: /road, /zero, /maintain, /status, /generate, /validate, /sync, /audit, /setup, /roadmap-sync <action>\');',
+    '}',
+    '',
+    'function printMissingCliStatus() {',
+    '  console.log(\'RoadmapSmith status\\n\');',
+    '  console.log(`Project root: ${PROJECT_ROOT}`);',
+    '  console.log(\'CLI resolution: missing\');',
+    '  console.log(\'VS Code tasks are visible because setup generated this launcher, but no RoadmapSmith CLI could be resolved.\');',
+    '  console.log(\'Installing the skill alone does not expose the CLI in VS Code.\');',
+    '  console.log(\'Install the roadmapsmith package, then run "RoadmapSmith: Refresh Setup".\');',
+    '  console.log(\'The launcher looks for, in order: workspace dev copy, workspace dependency, global command.\');',
+    '  console.log(\'Slash discovery still works here: try /road for the local palette.\');',
+    '}',
+    '',
+    'function runCli(args, options = {}) {',
+    '  const resolution = resolveCli();',
+    '  if (!resolution) {',
+    '    if (options.allowMissingCli) {',
+    '      return { status: 0, stdout: \'\', stderr: \'\', missingCli: true };',
+    '    }',
+    '    console.error(\'RoadmapSmith CLI not found. Install the CLI and rerun setup.\');',
+    '    process.exitCode = 1;',
+    '    return null;',
+    '  }',
+    '  const result = spawnSync(resolution.execPath, [...resolution.prefixArgs, ...args], {',
+    '    cwd: PROJECT_ROOT,',
+    '    encoding: \'utf8\',',
+    '    shell: resolution.shell,',
+    '    stdio: options.capture ? \'pipe\' : \'inherit\'',
+    '  });',
+    '  return { ...result, resolution };',
+    '}',
+    '',
+    'function forwardResult(result) {',
+    '  if (!result) {',
+    '    return;',
+    '  }',
+    '  if (typeof result.status === \'number\' && result.status !== 0) {',
+    '    process.exitCode = result.status;',
+    '  }',
+    '}',
+    '',
+    'function status() {',
+    '  const result = runCli([\'doctor\', \'--project-root\', PROJECT_ROOT, \'--json\'], { capture: true, allowMissingCli: true });',
+    '  if (!result || result.missingCli) {',
+    '    printMissingCliStatus();',
+    '    return;',
+    '  }',
+    '  if (result.stdout) {',
+    '    try {',
+    '      printStatusFromDoctor(JSON.parse(result.stdout));',
+    '      return;',
+    '    } catch (_) {}',
+    '  }',
+    '  if (result.stdout) process.stdout.write(result.stdout);',
+    '  if (result.stderr) process.stderr.write(result.stderr);',
+    '  process.exitCode = 0;',
+    '}',
+    '',
+    'const actionToCliArgs = {',
+    '  zero: [\'zero\', \'--project-root\', PROJECT_ROOT],',
+    '  maintain: [\'maintain\', \'--project-root\', PROJECT_ROOT],',
+    '  init: [\'init\'],',
+    '  generate: [\'generate\', \'--project-root\', PROJECT_ROOT],',
+    '  validate: [\'validate\', \'--json\', \'--project-root\', PROJECT_ROOT],',
+    '  sync: [\'sync\', \'--project-root\', PROJECT_ROOT],',
+    '  audit: [\'sync\', \'--audit\', \'--project-root\', PROJECT_ROOT],',
+    '  \'sync-dry-run\': [\'sync\', \'--dry-run\', \'--project-root\', PROJECT_ROOT],',
+    '  \'sync-audit\': [\'sync\', \'--audit\', \'--project-root\', PROJECT_ROOT],',
+    '  setup: [\'setup\', \'--project-root\', PROJECT_ROOT]',
+    '};',
+    '',
+    'const slashInvocation = resolveSlashInvocation(ACTION, RAW_ARGS.slice(1));',
+    '',
+    'if (slashInvocation) {',
+    '  if (slashInvocation.kind === \'palette\') {',
+    '    console.log(renderSlashPalette(slashInvocation));',
+    '  } else if (slashInvocation.actionId === \'status\') {',
+    '    status();',
+    '  } else if (Object.prototype.hasOwnProperty.call(actionToCliArgs, slashInvocation.actionId)) {',
+    '    const result = runCli(actionToCliArgs[slashInvocation.actionId]);',
+    '    forwardResult(result);',
+    '  } else {',
+    '    console.log(renderSlashPalette(slashInvocation));',
+    '  }',
+    '} else if (ACTION === \'explain\') {',
+    '  explain();',
+    '} else if (ACTION === \'status\') {',
+    '  status();',
+    '} else if (Object.prototype.hasOwnProperty.call(actionToCliArgs, ACTION)) {',
+    '  const result = runCli(actionToCliArgs[ACTION]);',
+    '  forwardResult(result);',
+    '} else {',
+    '  console.error(`Unknown RoadmapSmith launcher action: ${ACTION}`);',
+    '  process.exitCode = 1;',
+    '}',
+    ''
+  ].join('\n');
+}
+
+function buildSetupFiles(projectRoot, options = {}) {
+  const editor = assertSupportedEditor(options.editor);
+  const hosts = parseHosts(options.hosts);
+  if (editor !== 'vscode') {
+    throw new Error(`Unsupported editor "${editor}"`);
+  }
+
+  const vscodeTasksPath = path.join(projectRoot, '.vscode', 'tasks.json');
+  const vscodeLauncherPath = path.join(projectRoot, VSCODE_LAUNCHER_RELATIVE_PATH);
+  const windowsTaskWrapperPath = path.join(projectRoot, WINDOWS_TASK_WRAPPER_RELATIVE_PATH);
+  const posixTaskWrapperPath = path.join(projectRoot, POSIX_TASK_WRAPPER_RELATIVE_PATH);
+  const files = [
+    {
+      path: vscodeTasksPath,
+      content: stringifyJson(mergeVsCodeTasks(readJsoncObject(vscodeTasksPath)))
+    },
+    {
+      path: vscodeLauncherPath,
+      content: renderVsCodeLauncher()
+    },
+    {
+      path: windowsTaskWrapperPath,
+      content: renderWindowsTaskWrapper()
+    },
+    {
+      path: posixTaskWrapperPath,
+      content: renderPosixTaskWrapper()
+    }
+  ];
+
+  if (hosts.includes('claude')) {
+    const claudeSettingsPath = path.join(projectRoot, '.claude', 'settings.json');
+    const claudeHookPath = path.join(projectRoot, CLAUDE_HOOK_RELATIVE_PATH);
+    files.push({
+      path: claudeSettingsPath,
+      content: stringifyJson(mergeClaudeSettings(readJsoncObject(claudeSettingsPath)))
+    });
+    files.push({
+      path: claudeHookPath,
+      content: renderClaudeHookScript()
+    });
+  }
+
+  return {
+    editor,
+    hosts,
+    files
+  };
+}
+
+function applySetupFiles(setupPlan, options = {}) {
+  return setupPlan.files.map((file) => {
+    return writeText(file.path, file.content, { dryRun: options.dryRun });
+  });
+}
+
+function findGlobalRoadmapsmith() {
+  const probe = process.platform === 'win32'
+    ? require('child_process').spawnSync('where', ['roadmapsmith'], { encoding: 'utf8' })
+    : require('child_process').spawnSync('which', ['roadmapsmith'], { encoding: 'utf8' });
+  if (probe.status !== 0 || !probe.stdout) {
+    return null;
+  }
+  return probe.stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean) || null;
+}
+
+function detectCliResolution(projectRoot) {
+  const workspaceDevCli = path.join(projectRoot, 'roadmap-skill', 'bin', 'cli.js');
+  if (fs.existsSync(workspaceDevCli)) {
+    return {
+      ready: true,
+      kind: 'workspace-dev-copy',
+      path: workspaceDevCli
+    };
+  }
+
+  const workspaceDependencyCli = path.join(projectRoot, 'node_modules', 'roadmapsmith', 'bin', 'cli.js');
+  if (fs.existsSync(workspaceDependencyCli)) {
+    return {
+      ready: true,
+      kind: 'workspace-dependency',
+      path: workspaceDependencyCli
+    };
+  }
+
+  const globalCommandPath = findGlobalRoadmapsmith();
+  if (globalCommandPath) {
+    return {
+      ready: true,
+      kind: 'global',
+      path: globalCommandPath
+    };
+  }
+
+  return {
+    ready: false,
+    kind: 'missing',
+    path: null
+  };
+}
+
+function inspectVsCodeTasks(projectRoot) {
+  const tasksPath = path.join(projectRoot, '.vscode', 'tasks.json');
+  const launcherPath = path.join(projectRoot, VSCODE_LAUNCHER_RELATIVE_PATH);
+  const windowsWrapperPath = path.join(projectRoot, WINDOWS_TASK_WRAPPER_RELATIVE_PATH);
+  const posixWrapperPath = path.join(projectRoot, POSIX_TASK_WRAPPER_RELATIVE_PATH);
+  const tasksConfig = readJsoncObject(tasksPath);
+  const tasks = Array.isArray(tasksConfig && tasksConfig.tasks) ? tasksConfig.tasks : [];
+  const presentLabels = tasks.map((task) => task && task.label).filter(Boolean);
+  const presentManagedLabels = ROADMAPSMITH_TASK_LABELS.filter((label) => presentLabels.includes(label));
+  const wrapperEntries = [
+    { path: windowsWrapperPath, exists: fs.existsSync(windowsWrapperPath) },
+    { path: posixWrapperPath, exists: fs.existsSync(posixWrapperPath) }
+  ];
+  const presentWrappers = wrapperEntries.filter((entry) => entry.exists);
+
+  return {
+    launcher: {
+      path: launcherPath,
+      exists: fs.existsSync(launcherPath)
+    },
+    wrappers: {
+      expectedCount: wrapperEntries.length,
+      presentCount: presentWrappers.length,
+      ready: wrapperEntries.every((entry) => entry.exists),
+      windows: wrapperEntries[0],
+      posix: wrapperEntries[1],
+      missingPaths: wrapperEntries.filter((entry) => !entry.exists).map((entry) => entry.path)
+    },
+    tasks: {
+      path: tasksPath,
+      exists: tasksConfig != null,
+      ready: ROADMAPSMITH_TASK_LABELS.every((label) => presentLabels.includes(label)) && fs.existsSync(launcherPath) && wrapperEntries.every((entry) => entry.exists),
+      expectedLabels: ROADMAPSMITH_TASK_LABELS.slice(),
+      presentLabels: presentManagedLabels,
+      missingLabels: ROADMAPSMITH_TASK_LABELS.filter((label) => !presentLabels.includes(label))
+    }
+  };
+}
+
+function inspectClaudeSetup(projectRoot) {
+  const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
+  const hookPath = path.join(projectRoot, CLAUDE_HOOK_RELATIVE_PATH);
+  const settings = readJsoncObject(settingsPath);
+  const postToolUse = Array.isArray(settings && settings.hooks && settings.hooks.PostToolUse)
+    ? settings.hooks.PostToolUse
+    : [];
+  const configured = postToolUse.some((entry) => isRoadmapSmithHookEntry(entry));
+
+  return {
+    settings: {
+      path: settingsPath,
+      exists: settings != null
+    },
+    hookFile: {
+      path: hookPath,
+      exists: fs.existsSync(hookPath)
+    },
+    configured,
+    ready: configured && fs.existsSync(hookPath)
+  };
+}
+
+function inspectHostSetup(projectRoot, options = {}) {
+  const roadmapFile = options.roadmapFile;
+  const agentsFile = options.agentsFile;
+  const runtime = detectNodeRuntime(options.env || process.env);
+  const cli = detectCliResolution(projectRoot);
+  const vscode = inspectVsCodeTasks(projectRoot);
+  const claude = inspectClaudeSetup(projectRoot);
+  const codexReady = cli.ready && vscode.tasks.ready && runtime.ready;
+  let codexMessage = 'VS Code tasks are ready for Codex/manual host workflows';
+  if (!cli.ready) {
+    codexMessage = 'Install the RoadmapSmith CLI and rerun setup';
+  } else if (!vscode.tasks.ready) {
+    codexMessage = 'Run roadmapsmith setup to regenerate the VS Code task surface';
+  } else if (!runtime.ready) {
+    codexMessage = 'Install Node.js or set ROADMAPSMITH_NODE so VS Code tasks can launch the wrapper';
+  }
+
+  return {
+    projectRoot,
+    cli,
+    runtime,
+    roadmap: {
+      path: roadmapFile,
+      exists: roadmapFile ? fs.existsSync(roadmapFile) : false
+    },
+    agents: {
+      path: agentsFile,
+      exists: agentsFile ? fs.existsSync(agentsFile) : false
+    },
+    vscode,
+    claude,
+    hosts: {
+      codex: {
+        ready: codexReady,
+        message: codexMessage
+      },
+      claude: {
+        ready: cli.ready && claude.ready,
+        message: cli.ready && claude.ready
+          ? 'Claude PostToolUse hook is configured'
+          : 'Run roadmapsmith setup with the claude host and verify node is available to Claude'
+      }
+    }
+  };
+}
+
+module.exports = {
+  CLAUDE_HOOK_COMMAND,
+  ROADMAPSMITH_TASK_LABELS,
+  applySetupFiles,
+  assertSupportedEditor,
+  buildSetupFiles,
+  detectNodeRuntime,
+  detectCliResolution,
+  inspectHostSetup,
+  mergeClaudeSettings,
+  mergeVsCodeTasks,
+  parseHosts,
+  parseJsonc,
+  readJsoncObject,
+  renderClaudeHookScript,
+  renderPosixTaskWrapper,
+  renderVsCodeLauncher,
+  renderWindowsTaskWrapper,
+  stringifyJson
+};

--- a/roadmap-skill/src/index.js
+++ b/roadmap-skill/src/index.js
@@ -6,6 +6,9 @@ module.exports = {
   sync: require('./sync'),
   validator: require('./validator'),
   config: require('./config'),
+  host: require('./host'),
+  slash: require('./slash'),
+  zero: require('./zero'),
   model: require('./model'),
   renderer: require('./renderer')
 };

--- a/roadmap-skill/src/slash.js
+++ b/roadmap-skill/src/slash.js
@@ -1,0 +1,226 @@
+'use strict';
+
+const SLASH_ACTIONS = [
+  {
+    id: 'zero',
+    description: 'Interview the developer in terminal and generate the first roadmap for an empty or low-context repo.',
+    classicCliExample: 'roadmapsmith zero',
+    slashExamples: ['/zero', '/road zero', '/roadmap-sync zero'],
+    taskLabel: 'RoadmapSmith: Zero Mode'
+  },
+  {
+    id: 'maintain',
+    description: 'Regenerate, sync, and audit the roadmap for an existing repository.',
+    classicCliExample: 'roadmapsmith maintain',
+    slashExamples: ['/maintain', '/road maintain', '/roadmap-sync maintain'],
+    taskLabel: 'RoadmapSmith: Maintain'
+  },
+  {
+    id: 'status',
+    description: 'Inspect CLI, roadmap, VS Code task, and Claude hook readiness.',
+    classicCliExample: 'roadmapsmith doctor --json',
+    slashExamples: ['/status', '/road status', '/roadmap-sync status'],
+    taskLabel: 'RoadmapSmith: Status'
+  },
+  {
+    id: 'init',
+    description: 'Create ROADMAP.md and AGENTS.md when they are missing.',
+    classicCliExample: 'roadmapsmith init',
+    slashExamples: ['/init', '/road init', '/roadmap-sync init'],
+    taskLabel: 'RoadmapSmith: Init'
+  },
+  {
+    id: 'generate',
+    description: 'Rebuild the managed roadmap block from repository context.',
+    classicCliExample: 'roadmapsmith generate --project-root .',
+    slashExamples: ['/generate', '/road generate', '/roadmap-sync generate'],
+    taskLabel: 'RoadmapSmith: Generate'
+  },
+  {
+    id: 'validate',
+    description: 'Inspect per-task evidence status as JSON.',
+    classicCliExample: 'roadmapsmith validate --json --project-root .',
+    slashExamples: ['/validate', '/road validate', '/roadmap-sync validate'],
+    taskLabel: 'RoadmapSmith: Validate'
+  },
+  {
+    id: 'sync',
+    description: 'Apply evidence-backed checklist sync to ROADMAP.md.',
+    classicCliExample: 'roadmapsmith sync --project-root .',
+    slashExamples: ['/sync', '/road sync', '/roadmap-sync sync'],
+    taskLabel: 'RoadmapSmith: Sync'
+  },
+  {
+    id: 'audit',
+    description: 'Run sync and print the post-sync mismatch summary.',
+    classicCliExample: 'roadmapsmith sync --audit --project-root .',
+    slashExamples: ['/audit', '/road audit', '/roadmap-sync audit'],
+    taskLabel: 'RoadmapSmith: Sync Audit'
+  },
+  {
+    id: 'setup',
+    description: 'Generate visible VS Code tasks and optional Claude hook wiring.',
+    classicCliExample: 'roadmapsmith setup',
+    slashExamples: ['/setup', '/road setup', '/roadmap-sync setup'],
+    taskLabel: 'RoadmapSmith: Refresh Setup'
+  }
+];
+
+const SLASH_ROOT_ALIASES = new Set(['/road', '/roadmap-sync']);
+
+const DIRECT_SLASH_ALIAS_TO_ACTION = Object.freeze({
+  '/zero': 'zero',
+  '/maintain': 'maintain',
+  '/status': 'status',
+  '/init': 'init',
+  '/generate': 'generate',
+  '/validate': 'validate',
+  '/sync': 'sync',
+  '/audit': 'audit',
+  '/setup': 'setup'
+});
+
+function normalizeActionId(value) {
+  return String(value || '').trim().toLowerCase().replace(/^\/+/, '');
+}
+
+function isSlashToken(value) {
+  return typeof value === 'string' && value.trim().startsWith('/');
+}
+
+function getSlashAction(actionId) {
+  const normalized = normalizeActionId(actionId);
+  return SLASH_ACTIONS.find((action) => action.id === normalized) || null;
+}
+
+function getSlashActionSpecs() {
+  return SLASH_ACTIONS.map((action) => ({ ...action }));
+}
+
+function getSlashSuggestions(query) {
+  const normalized = normalizeActionId(query);
+  if (!normalized) {
+    return getSlashActionSpecs();
+  }
+
+  const startsWithMatches = SLASH_ACTIONS.filter((action) => action.id.startsWith(normalized));
+  const containsMatches = SLASH_ACTIONS.filter((action) => {
+    return !action.id.startsWith(normalized) && action.id.includes(normalized);
+  });
+
+  return [...startsWithMatches, ...containsMatches].map((action) => ({ ...action }));
+}
+
+function resolveSlashInvocation(command, args = []) {
+  if (!isSlashToken(command)) {
+    return null;
+  }
+
+  const normalizedCommand = String(command).trim().toLowerCase();
+
+  if (Object.prototype.hasOwnProperty.call(DIRECT_SLASH_ALIAS_TO_ACTION, normalizedCommand)) {
+    return {
+      kind: 'execute',
+      actionId: DIRECT_SLASH_ALIAS_TO_ACTION[normalizedCommand],
+      query: normalizeActionId(normalizedCommand),
+      source: normalizedCommand,
+      suggestions: getSlashSuggestions(normalizedCommand)
+    };
+  }
+
+  if (SLASH_ROOT_ALIASES.has(normalizedCommand)) {
+    const queryToken = args.length > 0 ? normalizeActionId(args[0]) : '';
+    if (!queryToken) {
+      return {
+        kind: 'palette',
+        query: '',
+        source: normalizedCommand,
+        suggestions: getSlashSuggestions('')
+      };
+    }
+
+    const exactAction = getSlashAction(queryToken);
+    if (exactAction) {
+      return {
+        kind: 'execute',
+        actionId: exactAction.id,
+        query: queryToken,
+        source: normalizedCommand,
+        suggestions: getSlashSuggestions(queryToken)
+      };
+    }
+
+    return {
+      kind: 'palette',
+      query: queryToken,
+      source: normalizedCommand,
+      suggestions: getSlashSuggestions(queryToken)
+    };
+  }
+
+  return {
+    kind: 'palette',
+    query: normalizeActionId(normalizedCommand),
+    source: normalizedCommand,
+    suggestions: getSlashSuggestions(normalizedCommand)
+  };
+}
+
+function renderSlashPalette(options = {}) {
+  const source = options.source || '/road';
+  const query = normalizeActionId(options.query);
+  const suggestions = Array.isArray(options.suggestions) ? options.suggestions : getSlashSuggestions(query);
+  const lines = [];
+
+  lines.push('RoadmapSmith slash palette');
+  lines.push('');
+
+  if (query) {
+    lines.push(`Input: ${source} ${query}`);
+    if (suggestions.length > 0) {
+      lines.push('No exact slash match was executed. Related actions:');
+    } else {
+      lines.push('No exact slash match was executed.');
+    }
+  } else {
+    lines.push(`Entry point: ${source}`);
+    lines.push('Use an exact slash action to execute work. Incomplete or ambiguous input only shows suggestions.');
+  }
+
+  lines.push('');
+
+  if (suggestions.length === 0) {
+    lines.push('No related slash actions found.');
+  } else {
+    suggestions.forEach((action) => {
+      lines.push(`- /${action.id}: ${action.description}`);
+      lines.push(`  Classic CLI: ${action.classicCliExample}`);
+      lines.push(`  Skill form: /roadmap-sync ${action.id}`);
+      lines.push(`  VS Code task: ${action.taskLabel}`);
+    });
+  }
+
+  lines.push('');
+  lines.push('Examples:');
+  lines.push('- roadmapsmith zero');
+  lines.push('- roadmapsmith maintain');
+  lines.push('- roadmapsmith /road');
+  lines.push('- roadmapsmith /maintain');
+  lines.push('- roadmapsmith /roadmap-sync maintain');
+  lines.push('');
+  lines.push('Installing the skill alone does not expose CLI behavior in VS Code. Use roadmapsmith setup for the visible task/launcher layer.');
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  DIRECT_SLASH_ALIAS_TO_ACTION,
+  SLASH_ROOT_ALIASES,
+  getSlashAction,
+  getSlashActionSpecs,
+  getSlashSuggestions,
+  isSlashToken,
+  normalizeActionId,
+  renderSlashPalette,
+  resolveSlashInvocation
+};

--- a/roadmap-skill/src/zero.js
+++ b/roadmap-skill/src/zero.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const path = require('path');
+
+const ZERO_MODE_QUESTIONS = [
+  { id: 'productName', prompt: '1. What product are we building?' },
+  { id: 'primaryUser', prompt: '2. Who is the target user?' },
+  { id: 'problemStatement', prompt: '3. What problem does it solve?' },
+  { id: 'targetOutcome', prompt: '4. What is the desired v1.0 outcome?' },
+  { id: 'antiGoals', prompt: '5. What is explicitly out of scope? Separate multiple items with ;' },
+  { id: 'preferredStack', prompt: '6. What stack do you prefer, if any?' },
+  { id: 'constraints', prompt: '7. What constraints exist? Separate multiple items with ;' },
+  { id: 'doneCriteria', prompt: '8. What does "done" mean for the first usable version? Separate multiple items with ;' }
+];
+
+function splitListAnswer(value) {
+  return String(value || '')
+    .split(/(?:\r?\n|;)+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function joinListDefault(values) {
+  return Array.isArray(values) && values.length > 0 ? values.join('; ') : '';
+}
+
+function deriveDefaultProblemStatement(config) {
+  const explicit = config.zeroMode && config.zeroMode.problemStatement;
+  if (explicit) {
+    return explicit;
+  }
+  const positioning = String((config.product && config.product.positioning) || '').trim();
+  const prefix = 'Core problem: ';
+  if (positioning.startsWith(prefix)) {
+    return positioning.slice(prefix.length).trim();
+  }
+  return '';
+}
+
+function buildZeroModeDefaults(projectRoot, config) {
+  return {
+    productName: (config.product && config.product.name) || path.basename(projectRoot),
+    primaryUser: (config.product && config.product.primaryUser) || '',
+    problemStatement: deriveDefaultProblemStatement(config),
+    targetOutcome: (config.product && config.product.targetOutcome) || '',
+    antiGoals: joinListDefault(config.product && config.product.antiGoals),
+    preferredStack: (config.zeroMode && config.zeroMode.preferredStack) || '',
+    constraints: joinListDefault(config.zeroMode && config.zeroMode.constraints),
+    doneCriteria: joinListDefault(
+      (config.zeroMode && config.zeroMode.doneCriteria && config.zeroMode.doneCriteria.length > 0)
+        ? config.zeroMode.doneCriteria
+        : (config.product && config.product.successCriteria)
+    )
+  };
+}
+
+async function collectZeroModeAnswers(ask, defaults = {}) {
+  const answers = {};
+  for (const question of ZERO_MODE_QUESTIONS) {
+    const fallback = String(defaults[question.id] || '').trim();
+    const suffix = fallback ? ` [${fallback}]` : '';
+    const response = await ask(`${question.prompt}${suffix}: `);
+    const normalized = String(response || '').trim();
+    answers[question.id] = normalized || fallback;
+  }
+  return answers;
+}
+
+function deriveNorthStar(answers) {
+  const productName = String(answers.productName || '').trim();
+  const primaryUser = String(answers.primaryUser || '').trim();
+  const targetOutcome = String(answers.targetOutcome || '').trim();
+  if (productName && primaryUser && targetOutcome) {
+    return `${productName} helps ${primaryUser} achieve ${targetOutcome}.`;
+  }
+  if (productName && targetOutcome) {
+    return `${productName} exists to deliver ${targetOutcome}.`;
+  }
+  if (productName) {
+    return `Ship the first usable version of ${productName}.`;
+  }
+  return '';
+}
+
+function buildZeroModeConfigPatch(projectRoot, existingUserConfig, answers) {
+  const productName = String(answers.productName || '').trim() || path.basename(projectRoot);
+  const primaryUser = String(answers.primaryUser || '').trim();
+  const problemStatement = String(answers.problemStatement || '').trim();
+  const targetOutcome = String(answers.targetOutcome || '').trim();
+  const antiGoals = splitListAnswer(answers.antiGoals);
+  const constraints = splitListAnswer(answers.constraints);
+  const doneCriteria = splitListAnswer(answers.doneCriteria);
+  const preferredStack = String(answers.preferredStack || '').trim();
+
+  return {
+    ...existingUserConfig,
+    product: {
+      ...((existingUserConfig && existingUserConfig.product) || {}),
+      name: productName,
+      northStar: deriveNorthStar({ productName, primaryUser, targetOutcome }) || (((existingUserConfig || {}).product || {}).northStar || ''),
+      positioning: problemStatement ? `Core problem: ${problemStatement}` : ((((existingUserConfig || {}).product || {}).positioning) || ''),
+      primaryUser,
+      targetOutcome,
+      antiGoals,
+      risks: constraints.map((constraint) => `Constraint: ${constraint}`),
+      successCriteria: doneCriteria
+    },
+    zeroMode: {
+      ...((existingUserConfig && existingUserConfig.zeroMode) || {}),
+      problemStatement,
+      preferredStack,
+      constraints,
+      doneCriteria
+    }
+  };
+}
+
+function isInteractiveTerminal(input = process.stdin, output = process.stdout) {
+  return Boolean(input && input.isTTY && output && output.isTTY);
+}
+
+module.exports = {
+  ZERO_MODE_QUESTIONS,
+  buildZeroModeConfigPatch,
+  buildZeroModeDefaults,
+  collectZeroModeAnswers,
+  isInteractiveTerminal,
+  splitListAnswer
+};

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -3,14 +3,28 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const CLI = path.resolve(__dirname, '..', 'bin', 'cli.js');
+const LAUNCHER = path.resolve(__dirname, '..', '..', '.vscode', 'roadmapsmith-launcher.js');
 const CANONICAL_ROADMAP = 'ROADMAP.md';
 const LEGACY_ROADMAP = 'roadmap.md';
 const CASE_DISTINCT_ROADMAP_FILES = supportsCaseDistinctRoadmapFiles();
+const ROADMAPSMITH_TASK_LABELS = [
+  'RoadmapSmith: Zero Mode',
+  'RoadmapSmith: Maintain',
+  'RoadmapSmith: Status',
+  'RoadmapSmith: Explain Workflow',
+  'RoadmapSmith: Init',
+  'RoadmapSmith: Generate',
+  'RoadmapSmith: Validate',
+  'RoadmapSmith: Sync',
+  'RoadmapSmith: Sync Dry Run',
+  'RoadmapSmith: Sync Audit',
+  'RoadmapSmith: Refresh Setup'
+];
 
 function run(args, cwd) {
   return execFileSync(process.execPath, [CLI, ...args], {
@@ -19,8 +33,56 @@ function run(args, cwd) {
   });
 }
 
+function runResult(args, cwd, options = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: options.env || process.env
+  });
+}
+
+function runLauncherResult(args, cwd, options = {}) {
+  return spawnSync(process.execPath, [LAUNCHER, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: options.env || process.env
+  });
+}
+
+function runWrapperResult(projectRoot, action, options = {}) {
+  const env = options.env || process.env;
+  if (process.platform === 'win32') {
+    const command = env.ComSpec || path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'cmd.exe');
+    return spawnSync(command, ['/d', '/c', path.join(projectRoot, '.vscode', 'roadmapsmith-task.cmd'), action], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      env
+    });
+  }
+
+  return spawnSync('/bin/sh', [path.join(projectRoot, '.vscode', 'roadmapsmith-task.sh'), action], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env
+  });
+}
+
 function writePackageJson(projectRoot) {
   fs.writeFileSync(path.join(projectRoot, 'package.json'), JSON.stringify({ name: 'x', version: '1.0.0' }, null, 2));
+}
+
+function writeWorkspaceCliShim(projectRoot) {
+  const cliShimPath = path.join(projectRoot, 'roadmap-skill', 'bin', 'cli.js');
+  fs.mkdirSync(path.dirname(cliShimPath), { recursive: true });
+  fs.writeFileSync(
+    cliShimPath,
+    [
+      '\'use strict\';',
+      `require(${JSON.stringify(CLI)});`,
+      ''
+    ].join('\n'),
+    'utf8'
+  );
 }
 
 function hasEntry(projectRoot, fileName) {
@@ -50,6 +112,113 @@ test('cli init creates roadmap and agents files', () => {
   assert.equal(fs.existsSync(agents), true);
 });
 
+test('cli setup creates VS Code and Claude integration files', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-setup-'));
+
+  run(['setup'], projectRoot);
+
+  const tasksPath = path.join(projectRoot, '.vscode', 'tasks.json');
+  const launcherPath = path.join(projectRoot, '.vscode', 'roadmapsmith-launcher.js');
+  const windowsTaskWrapperPath = path.join(projectRoot, '.vscode', 'roadmapsmith-task.cmd');
+  const posixTaskWrapperPath = path.join(projectRoot, '.vscode', 'roadmapsmith-task.sh');
+  const claudeSettingsPath = path.join(projectRoot, '.claude', 'settings.json');
+  const claudeHookPath = path.join(projectRoot, '.claude', 'hooks', 'roadmap-sync.js');
+  const tasksConfig = JSON.parse(fs.readFileSync(tasksPath, 'utf8'));
+  const taskLabels = tasksConfig.tasks.map((task) => task.label);
+
+  assert.equal(fs.existsSync(launcherPath), true);
+  assert.equal(fs.existsSync(windowsTaskWrapperPath), true);
+  assert.equal(fs.existsSync(posixTaskWrapperPath), true);
+  assert.equal(fs.existsSync(claudeSettingsPath), true);
+  assert.equal(fs.existsSync(claudeHookPath), true);
+  assert.deepEqual(taskLabels.slice(0, ROADMAPSMITH_TASK_LABELS.length), ROADMAPSMITH_TASK_LABELS);
+  assert.equal(tasksConfig.tasks[0].command, 'sh');
+  assert.equal(tasksConfig.tasks[0].windows.command, 'cmd.exe');
+  assert.deepEqual(tasksConfig.tasks[0].args, ['.vscode/roadmapsmith-task.sh', 'zero']);
+});
+
+test('cli setup dry-run does not modify files', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-setup-dry-run-'));
+
+  const out = run(['setup', '--dry-run'], projectRoot);
+  const vscodeDir = path.join(projectRoot, '.vscode');
+  const claudeDir = path.join(projectRoot, '.claude');
+
+  assert.match(out, /Would create .*tasks\.json/);
+  assert.equal(fs.existsSync(vscodeDir), false);
+  assert.equal(fs.existsSync(claudeDir), false);
+});
+
+test('cli setup is idempotent on repeated runs', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-setup-idempotent-'));
+
+  run(['setup'], projectRoot);
+  const firstTasks = fs.readFileSync(path.join(projectRoot, '.vscode', 'tasks.json'), 'utf8');
+  const secondRun = run(['setup'], projectRoot);
+  const secondTasks = fs.readFileSync(path.join(projectRoot, '.vscode', 'tasks.json'), 'utf8');
+
+  assert.equal(secondTasks, firstTasks);
+  assert.match(secondRun, /No changes for .*tasks\.json/);
+});
+
+test('cli setup preserves unrelated VS Code tasks and Claude hooks', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-setup-merge-'));
+  fs.mkdirSync(path.join(projectRoot, '.vscode'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, '.claude', 'hooks'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, '.vscode', 'tasks.json'),
+    [
+      '{',
+      '  // Existing JSONC comment should survive parsing',
+      '  "version": "2.0.0",',
+      '  "tasks": [',
+      '    { "label": "Custom Task", "type": "shell", "command": "echo custom" },',
+      '  ]',
+      '}'
+    ].join('\n'),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(projectRoot, '.claude', 'settings.json'),
+    JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Write',
+            hooks: [{ type: 'command', command: 'node .claude/hooks/custom.js' }]
+          }
+        ]
+      }
+    }, null, 2),
+    'utf8'
+  );
+
+  run(['setup'], projectRoot);
+
+  const tasksConfig = JSON.parse(fs.readFileSync(path.join(projectRoot, '.vscode', 'tasks.json'), 'utf8'));
+  const settingsConfig = JSON.parse(fs.readFileSync(path.join(projectRoot, '.claude', 'settings.json'), 'utf8'));
+  const taskLabels = tasksConfig.tasks.map((task) => task.label);
+  const postToolUse = settingsConfig.hooks.PostToolUse;
+
+  assert.ok(taskLabels.includes('Custom Task'));
+  assert.ok(taskLabels.includes('RoadmapSmith: Status'));
+  assert.equal(postToolUse.some((entry) => entry.hooks.some((hook) => hook.command === 'node .claude/hooks/custom.js')), true);
+  assert.equal(postToolUse.some((entry) => entry.hooks.some((hook) => hook.command === 'node .claude/hooks/roadmap-sync.js')), true);
+});
+
+test('cli setup fails on invalid existing config without partial writes', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-setup-invalid-'));
+  fs.mkdirSync(path.join(projectRoot, '.vscode'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, '.vscode', 'tasks.json'), '{ invalid json', 'utf8');
+
+  const result = runResult(['setup'], projectRoot);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Invalid JSON/);
+  assert.equal(fs.existsSync(path.join(projectRoot, '.vscode', 'roadmapsmith-launcher.js')), false);
+  assert.equal(fs.existsSync(path.join(projectRoot, '.claude')), false);
+});
+
 test('cli generate writes managed roadmap content', () => {
   const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-generate-'));
   writePackageJson(projectRoot);
@@ -61,6 +230,21 @@ test('cli generate writes managed roadmap content', () => {
   const content = fs.readFileSync(roadmapPath, 'utf8');
   assert.match(content, /<!-- rs:managed:start -->/);
   assert.match(content, /## Release Milestones/);
+});
+
+test('cli maintain runs generate, sync, and audit in one invocation', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-maintain-'));
+  writePackageJson(projectRoot);
+  fs.mkdirSync(path.join(projectRoot, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'index.js'), 'export function main() { return true; }\n', 'utf8');
+
+  const out = run(['maintain'], projectRoot);
+  const roadmapPath = path.join(projectRoot, CANONICAL_ROADMAP);
+  const content = fs.readFileSync(roadmapPath, 'utf8');
+
+  assert.match(out, /Updated .*ROADMAP\.md|No changes for .*ROADMAP\.md/);
+  assert.match(out, /Audit summary:/);
+  assert.match(content, /<!-- rs:managed:start -->/);
 });
 
 test('cli sync dry-run does not modify file', () => {
@@ -217,4 +401,216 @@ test('-v prints the package version', () => {
 test('no args prints usage', () => {
   const out = run([], process.cwd());
   assert.match(out, /Usage:/);
+  assert.match(out, /roadmapsmith zero/);
+  assert.match(out, /roadmapsmith maintain/);
+});
+
+test('cli /road prints the contextual slash palette', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-palette-'));
+  const out = run(['/road'], projectRoot);
+
+  assert.match(out, /RoadmapSmith slash palette/);
+  assert.match(out, /roadmapsmith maintain/);
+});
+
+test('cli /maintain executes the one-command existing-repo flow', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-maintain-'));
+  writePackageJson(projectRoot);
+  fs.mkdirSync(path.join(projectRoot, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'index.js'), 'function main() { return true; }\n', 'utf8');
+
+  const out = run(['/maintain'], projectRoot);
+
+  assert.match(out, /Audit summary:/);
+  assert.equal(fs.existsSync(path.join(projectRoot, CANONICAL_ROADMAP)), true);
+});
+
+test('cli /road sync resolves to sync without changing dry-run behavior', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-sync-'));
+  writePackageJson(projectRoot);
+  fs.writeFileSync(
+    path.join(projectRoot, CANONICAL_ROADMAP),
+    ['## Phase P0', '- [ ] Implement missing module <!-- rs:task=implement-missing-module -->', ''].join('\n')
+  );
+
+  const before = fs.readFileSync(path.join(projectRoot, CANONICAL_ROADMAP), 'utf8');
+  const out = run(['/road', 'sync', '--dry-run'], projectRoot);
+  const after = fs.readFileSync(path.join(projectRoot, CANONICAL_ROADMAP), 'utf8');
+
+  assert.equal(after, before);
+  assert.match(out, /No changes for|Dry run:/);
+});
+
+test('cli /roadmap-sync validate resolves to validate', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-validate-'));
+  writePackageJson(projectRoot);
+  fs.writeFileSync(
+    path.join(projectRoot, CANONICAL_ROADMAP),
+    ['## Phase P0', '- [ ] Implement missing module <!-- rs:task=implement-missing-module -->', ''].join('\n')
+  );
+
+  const result = runResult(['/roadmap-sync', 'validate', '--json'], projectRoot);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /\[\s*\{/);
+});
+
+test('cli ambiguous slash input shows suggestions and does not execute', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-ambiguous-'));
+  const out = run(['/road', 's'], projectRoot);
+
+  assert.match(out, /No exact slash match was executed/);
+  assert.match(out, /\/status/);
+  assert.match(out, /\/sync/);
+  assert.match(out, /\/setup/);
+});
+
+test('cli unknown direct slash input shows related help safely', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-unknown-'));
+  const result = runResult(['/syn'], projectRoot);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /RoadmapSmith slash palette/);
+  assert.match(result.stdout, /\/sync/);
+});
+
+test('cli zero fails clearly in non-interactive mode', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-zero-noninteractive-'));
+  const result = runResult(['zero'], projectRoot);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /interactive terminal/i);
+});
+
+test('doctor --json reports missing integration state', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-doctor-missing-'));
+  run(['init'], projectRoot);
+
+  const result = runResult(['doctor', '--json', '--project-root', projectRoot], projectRoot);
+  const payload = JSON.parse(result.stdout);
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payload.cli.ready, false);
+  assert.equal(payload.vscode.tasks.ready, false);
+  assert.equal(payload.hosts.codex.ready, false);
+  assert.equal(payload.hosts.claude.ready, false);
+});
+
+test('doctor --json reports healthy configured integration state', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-doctor-ready-'));
+  run(['init'], projectRoot);
+  fs.mkdirSync(path.join(projectRoot, 'roadmap-skill', 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'roadmap-skill', 'bin', 'cli.js'), '\'use strict\';\n', 'utf8');
+  run(['setup'], projectRoot);
+
+  const result = runResult(['doctor', '--json', '--project-root', projectRoot], projectRoot);
+  const payload = JSON.parse(result.stdout);
+
+  assert.equal(result.status, 0);
+  assert.equal(payload.cli.ready, true);
+  assert.equal(payload.vscode.tasks.ready, true);
+  assert.equal(payload.runtime.ready, true);
+  assert.equal(payload.hosts.codex.ready, true);
+  assert.equal(payload.hosts.claude.ready, true);
+});
+
+test('doctor --json reports missing task runtime without downgrading Claude readiness', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-doctor-runtime-missing-'));
+  run(['init'], projectRoot);
+  fs.mkdirSync(path.join(projectRoot, 'roadmap-skill', 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'roadmap-skill', 'bin', 'cli.js'), '\'use strict\';\n', 'utf8');
+  run(['setup'], projectRoot);
+
+  const emptyRuntimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-empty-runtime-'));
+  const result = runResult(['doctor', '--json', '--project-root', projectRoot], projectRoot, {
+    env: {
+      PATH: '',
+      ROADMAPSMITH_NODE: '',
+      ProgramFiles: emptyRuntimeRoot,
+      'ProgramFiles(x86)': emptyRuntimeRoot,
+      LocalAppData: emptyRuntimeRoot
+    }
+  });
+  const payload = JSON.parse(result.stdout);
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payload.cli.ready, true);
+  assert.equal(payload.vscode.tasks.ready, true);
+  assert.equal(payload.runtime.ready, false);
+  assert.equal(payload.hosts.codex.ready, false);
+  assert.equal(payload.hosts.claude.ready, true);
+});
+
+test('launcher accepts /road and prints the same conceptual palette', () => {
+  const result = runLauncherResult(['/road'], path.resolve(__dirname, '..', '..'));
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /RoadmapSmith slash palette/);
+  assert.match(result.stdout, /\/roadmap-sync maintain/);
+});
+
+test('launcher keeps non-slash actions working', () => {
+  const result = runLauncherResult(['explain'], path.resolve(__dirname, '..', '..'));
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /RoadmapSmith layers/);
+  assert.match(result.stdout, /RoadmapSmith: Zero Mode/);
+});
+
+test('generated launcher accepts maintain for temp projects', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-launcher-maintain-'));
+  writePackageJson(projectRoot);
+  writeWorkspaceCliShim(projectRoot);
+  fs.mkdirSync(path.join(projectRoot, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'index.js'), 'function main() { return true; }\n', 'utf8');
+  run(['setup', '--hosts', 'codex', '--project-root', projectRoot], projectRoot);
+
+  const launcherPath = path.join(projectRoot, '.vscode', 'roadmapsmith-launcher.js');
+  const result = spawnSync(process.execPath, [launcherPath, 'maintain'], {
+    cwd: projectRoot,
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Audit summary:/);
+});
+
+test('task wrapper can launch the launcher via ROADMAPSMITH_NODE override', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-wrapper-override-'));
+  run(['setup', '--hosts', 'codex', '--project-root', projectRoot], projectRoot);
+
+  const result = runWrapperResult(projectRoot, 'explain', {
+    env: {
+      PATH: '',
+      ROADMAPSMITH_NODE: process.execPath,
+      ProgramFiles: '',
+      'ProgramFiles(x86)': '',
+      LocalAppData: ''
+    }
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /RoadmapSmith layers/);
+});
+
+test('task wrapper prints a friendly runtime diagnostic when Node cannot be resolved', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-wrapper-missing-runtime-'));
+  run(['setup', '--hosts', 'codex', '--project-root', projectRoot], projectRoot);
+  const emptyRuntimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-empty-runtime-'));
+  const missingRuntimeEnv = {
+    PATH: '',
+    ROADMAPSMITH_NODE: '',
+    ProgramFiles: emptyRuntimeRoot,
+    'ProgramFiles(x86)': emptyRuntimeRoot,
+    LocalAppData: emptyRuntimeRoot
+  };
+
+  const statusResult = runWrapperResult(projectRoot, 'status', { env: missingRuntimeEnv });
+  const syncResult = runWrapperResult(projectRoot, 'sync', { env: missingRuntimeEnv });
+
+  assert.equal(statusResult.status, 0);
+  assert.match(statusResult.stdout, /RoadmapSmith VS Code task runtime error/);
+  assert.match(statusResult.stdout, /ROADMAPSMITH_NODE/);
+  assert.notEqual(syncResult.status, 0);
+  assert.match(syncResult.stdout, /RoadmapSmith VS Code task runtime error/);
 });

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -577,6 +577,7 @@ test('generated launcher accepts maintain for temp projects', () => {
 
 test('task wrapper can launch the launcher via ROADMAPSMITH_NODE override', () => {
   const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-wrapper-override-'));
+  writeWorkspaceCliShim(projectRoot);
   run(['setup', '--hosts', 'codex', '--project-root', projectRoot], projectRoot);
 
   const result = runWrapperResult(projectRoot, 'explain', {

--- a/roadmap-skill/test/host.test.js
+++ b/roadmap-skill/test/host.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildSetupFiles,
+  detectNodeRuntime,
+  inspectHostSetup,
+  mergeClaudeSettings,
+  mergeVsCodeTasks,
+  parseHosts,
+  parseJsonc,
+  ROADMAPSMITH_TASK_LABELS
+} = require('../src/host');
+
+test('parseHosts defaults to codex and claude', () => {
+  assert.deepEqual(parseHosts(), ['codex', 'claude']);
+});
+
+test('parseHosts rejects unsupported hosts', () => {
+  assert.throws(() => parseHosts('claude,figma'), /Unsupported host/);
+});
+
+test('parseJsonc handles comments and trailing commas', () => {
+  const parsed = parseJsonc([
+    '{',
+    '  // comment',
+    '  "version": "2.0.0",',
+    '  "tasks": [',
+    '    { "label": "One", },',
+    '  ],',
+    '}'
+  ].join('\n'), 'tasks.json');
+
+  assert.equal(parsed.version, '2.0.0');
+  assert.equal(parsed.tasks[0].label, 'One');
+});
+
+test('mergeVsCodeTasks preserves unrelated tasks and replaces managed labels', () => {
+  const merged = mergeVsCodeTasks({
+    version: '2.0.0',
+    tasks: [
+      { label: 'RoadmapSmith: Status', type: 'shell', command: 'old' },
+      { label: 'Custom Task', type: 'shell', command: 'echo custom' }
+    ]
+  });
+
+  assert.deepEqual(merged.tasks.slice(0, ROADMAPSMITH_TASK_LABELS.length).map((task) => task.label), ROADMAPSMITH_TASK_LABELS);
+  assert.equal(merged.tasks.some((task) => task.label === 'Custom Task'), true);
+  assert.equal(merged.tasks.filter((task) => task.label === 'RoadmapSmith: Status').length, 1);
+  assert.equal(merged.tasks[0].type, 'process');
+  assert.equal(merged.tasks[0].command, 'sh');
+  assert.deepEqual(merged.tasks[0].args, ['.vscode/roadmapsmith-task.sh', 'zero']);
+  assert.equal(merged.tasks[0].windows.command, 'cmd.exe');
+  assert.deepEqual(merged.tasks[0].windows.args, ['/d', '/c', '.vscode\\roadmapsmith-task.cmd', 'zero']);
+});
+
+test('mergeClaudeSettings preserves unrelated hooks and replaces roadmapsmith hook', () => {
+  const merged = mergeClaudeSettings({
+    hooks: {
+      PostToolUse: [
+        {
+          matcher: 'Write',
+          hooks: [{ type: 'command', command: 'node .claude/hooks/custom.js' }]
+        },
+        {
+          matcher: 'Write|Edit|MultiEdit',
+          hooks: [{ type: 'command', command: 'node .claude/hooks/roadmap-sync.js', timeout: 10 }]
+        }
+      ]
+    }
+  });
+
+  assert.equal(merged.hooks.PostToolUse.some((entry) => entry.hooks.some((hook) => hook.command === 'node .claude/hooks/custom.js')), true);
+  assert.equal(merged.hooks.PostToolUse.filter((entry) => entry.hooks.some((hook) => hook.command === 'node .claude/hooks/roadmap-sync.js')).length, 1);
+  assert.equal(merged.hooks.PostToolUse[0].hooks[0].timeout, 30);
+});
+
+test('buildSetupFiles can target codex only without generating claude files', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-host-build-'));
+  const setupPlan = buildSetupFiles(projectRoot, { editor: 'vscode', hosts: 'codex' });
+  const plannedPaths = setupPlan.files.map((file) => path.relative(projectRoot, file.path).replace(/\\/g, '/'));
+
+  assert.deepEqual(setupPlan.hosts, ['codex']);
+  assert.equal(plannedPaths.includes('.vscode/tasks.json'), true);
+  assert.equal(plannedPaths.includes('.vscode/roadmapsmith-launcher.js'), true);
+  assert.equal(plannedPaths.includes('.vscode/roadmapsmith-task.cmd'), true);
+  assert.equal(plannedPaths.includes('.vscode/roadmapsmith-task.sh'), true);
+  assert.equal(plannedPaths.some((plannedPath) => plannedPath.startsWith('.claude/')), false);
+});
+
+test('detectNodeRuntime accepts an explicit ROADMAPSMITH_NODE override', () => {
+  const runtime = detectNodeRuntime({
+    ...process.env,
+    ROADMAPSMITH_NODE: process.execPath
+  });
+
+  assert.equal(runtime.ready, true);
+  assert.equal(runtime.kind, 'env-override');
+  assert.equal(runtime.path, process.execPath);
+});
+
+test('inspectHostSetup downgrades Codex readiness when task runtime is missing', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-host-runtime-missing-'));
+  fs.mkdirSync(path.join(projectRoot, '.vscode'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, '.claude', 'hooks'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, 'roadmap-skill', 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, '.vscode', 'tasks.json'), JSON.stringify(mergeVsCodeTasks({ version: '2.0.0', tasks: [] }), null, 2));
+  fs.writeFileSync(path.join(projectRoot, '.vscode', 'roadmapsmith-launcher.js'), '\'use strict\';\n');
+  fs.writeFileSync(path.join(projectRoot, '.vscode', 'roadmapsmith-task.cmd'), '@echo off\r\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, '.vscode', 'roadmapsmith-task.sh'), '#!/bin/sh\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, '.claude', 'settings.json'), JSON.stringify(mergeClaudeSettings({}), null, 2));
+  fs.writeFileSync(path.join(projectRoot, '.claude', 'hooks', 'roadmap-sync.js'), '\'use strict\';\n');
+  fs.writeFileSync(path.join(projectRoot, 'roadmap-skill', 'bin', 'cli.js'), '\'use strict\';\n');
+  fs.writeFileSync(path.join(projectRoot, 'ROADMAP.md'), '# roadmap\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, 'AGENTS.md'), '# agents\n', 'utf8');
+
+  const emptyRuntimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-empty-runtime-'));
+  const hostStatus = inspectHostSetup(projectRoot, {
+    roadmapFile: path.join(projectRoot, 'ROADMAP.md'),
+    agentsFile: path.join(projectRoot, 'AGENTS.md'),
+    env: {
+      PATH: '',
+      ROADMAPSMITH_NODE: '',
+      ProgramFiles: emptyRuntimeRoot,
+      'ProgramFiles(x86)': emptyRuntimeRoot,
+      LocalAppData: emptyRuntimeRoot
+    }
+  });
+
+  assert.equal(hostStatus.vscode.tasks.ready, true);
+  assert.equal(hostStatus.runtime.ready, false);
+  assert.equal(hostStatus.hosts.codex.ready, false);
+  assert.equal(hostStatus.hosts.claude.ready, true);
+});

--- a/roadmap-skill/test/slash.test.js
+++ b/roadmap-skill/test/slash.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveSlashInvocation, renderSlashPalette, getSlashSuggestions } = require('../src/slash');
+
+test('resolveSlashInvocation returns palette for /road', () => {
+  const route = resolveSlashInvocation('/road', []);
+  assert.equal(route.kind, 'palette');
+  assert.equal(route.source, '/road');
+  assert.ok(route.suggestions.length >= 9);
+});
+
+test('resolveSlashInvocation resolves direct exact slash aliases', () => {
+  const route = resolveSlashInvocation('/maintain', []);
+  assert.equal(route.kind, 'execute');
+  assert.equal(route.actionId, 'maintain');
+});
+
+test('resolveSlashInvocation resolves namespaced exact actions', () => {
+  const route = resolveSlashInvocation('/roadmap-sync', ['validate']);
+  assert.equal(route.kind, 'execute');
+  assert.equal(route.actionId, 'validate');
+});
+
+test('resolveSlashInvocation keeps partial root queries in palette mode', () => {
+  const route = resolveSlashInvocation('/road', ['syn']);
+  assert.equal(route.kind, 'palette');
+  assert.equal(route.query, 'syn');
+  assert.equal(route.suggestions.some((action) => action.id === 'sync'), true);
+});
+
+test('resolveSlashInvocation keeps unknown direct slash queries in palette mode', () => {
+  const route = resolveSlashInvocation('/syn', []);
+  assert.equal(route.kind, 'palette');
+  assert.equal(route.query, 'syn');
+});
+
+test('renderSlashPalette includes classic, skill, and task examples', () => {
+  const output = renderSlashPalette({ source: '/road', suggestions: getSlashSuggestions('sync') });
+  assert.match(output, /RoadmapSmith slash palette/);
+  assert.match(output, /Classic CLI:/);
+  assert.match(output, /Skill form: \/roadmap-sync/);
+  assert.match(output, /VS Code task:/);
+});

--- a/roadmap-skill/test/zero.test.js
+++ b/roadmap-skill/test/zero.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildZeroModeConfigPatch,
+  buildZeroModeDefaults,
+  collectZeroModeAnswers,
+  splitListAnswer
+} = require('../src/zero');
+
+test('splitListAnswer separates semicolon-delimited discovery answers', () => {
+  assert.deepEqual(splitListAnswer('one; two ;three'), ['one', 'two', 'three']);
+});
+
+test('collectZeroModeAnswers uses defaults when the user submits empty answers', async () => {
+  const prompts = [];
+  const answers = await collectZeroModeAnswers(async (prompt) => {
+    prompts.push(prompt);
+    return '';
+  }, {
+    productName: 'RoadmapSmith',
+    primaryUser: 'Developers'
+  });
+
+  assert.equal(prompts.length, 8);
+  assert.equal(answers.productName, 'RoadmapSmith');
+  assert.equal(answers.primaryUser, 'Developers');
+});
+
+test('buildZeroModeDefaults reads existing product and zeroMode config', () => {
+  const defaults = buildZeroModeDefaults(path.join(process.cwd(), 'demo-repo'), {
+    product: {
+      name: 'Demo Product',
+      primaryUser: 'Founders',
+      targetOutcome: 'ship the first internal beta',
+      antiGoals: ['No marketplace yet'],
+      successCriteria: ['First user can complete the core flow']
+    },
+    zeroMode: {
+      problemStatement: 'Planning is fragmented across sessions',
+      preferredStack: 'Node + React',
+      constraints: ['Bootstrap in 2 weeks']
+    }
+  });
+
+  assert.equal(defaults.productName, 'Demo Product');
+  assert.equal(defaults.problemStatement, 'Planning is fragmented across sessions');
+  assert.equal(defaults.preferredStack, 'Node + React');
+  assert.equal(defaults.constraints, 'Bootstrap in 2 weeks');
+  assert.equal(defaults.doneCriteria, 'First user can complete the core flow');
+});
+
+test('buildZeroModeConfigPatch persists interview answers into product and zeroMode blocks', () => {
+  const next = buildZeroModeConfigPatch(process.cwd(), {
+    roadmapProfile: 'professional',
+    product: {
+      name: 'Old Name'
+    }
+  }, {
+    productName: 'Launchpad',
+    primaryUser: 'Solo founders',
+    problemStatement: 'They lose roadmap continuity between agent sessions',
+    targetOutcome: 'ship a first usable planning workflow',
+    antiGoals: 'No team permissions yet; No billing system',
+    preferredStack: 'Next.js + Node',
+    constraints: '2 weeks; low budget',
+    doneCriteria: 'One founder can generate a roadmap; One founder can sync it after code changes'
+  });
+
+  assert.equal(next.roadmapProfile, 'professional');
+  assert.equal(next.product.name, 'Launchpad');
+  assert.equal(next.product.primaryUser, 'Solo founders');
+  assert.equal(next.product.targetOutcome, 'ship a first usable planning workflow');
+  assert.equal(next.product.positioning, 'Core problem: They lose roadmap continuity between agent sessions');
+  assert.deepEqual(next.product.antiGoals, ['No team permissions yet', 'No billing system']);
+  assert.deepEqual(next.product.risks, ['Constraint: 2 weeks', 'Constraint: low budget']);
+  assert.deepEqual(next.product.successCriteria, [
+    'One founder can generate a roadmap',
+    'One founder can sync it after code changes'
+  ]);
+  assert.equal(next.zeroMode.preferredStack, 'Next.js + Node');
+  assert.deepEqual(next.zeroMode.constraints, ['2 weeks', 'low budget']);
+});

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "description": "Production-grade roadmap generation and sync skill package for coding agents.",
+  "description": "One-command roadmap generation and maintenance for coding agents, with an optional roadmap-sync policy skill.",
   "triggers": [
     "roadmap",
     "sync roadmap",
@@ -10,22 +10,24 @@
   ],
   "usageExamples": [
     "npx skills add PapiScholz/roadmapsmith --skill roadmap-sync",
-    "roadmapsmith init",
-    "roadmapsmith generate --project-root .",
-    "roadmapsmith sync --audit",
+    "roadmapsmith setup",
+    "roadmapsmith zero",
+    "roadmapsmith maintain",
+    "roadmapsmith /road",
+    "roadmapsmith /maintain",
     "roadmapsmith validate --json"
   ],
   "install": {
     "command": "npx skills add PapiScholz/roadmapsmith --skill roadmap-sync",
     "source": "PapiScholz/roadmapsmith",
     "skill": "roadmap-sync",
-    "notes": "The install command adds the agent skill. The optional CLI package is intended to be published separately to npm as roadmapsmith."
+    "notes": "The install command adds agent instructions only. Install the roadmapsmith CLI and run roadmapsmith setup to expose the Zero Mode and Maintain workflows in VS Code."
   },
   "skills": [
     {
       "name": "roadmap-sync",
       "path": "skills/roadmap-sync",
-      "description": "Rules and operating procedure for roadmap generation, sync, and validation.",
+      "description": "Policy and operating rules for Zero Mode discovery plus ongoing roadmap generation, sync, and validation.",
       "version": "0.7.0"
     }
   ]

--- a/skills/roadmap-sync/agents/openai.yaml
+++ b/skills/roadmap-sync/agents/openai.yaml
@@ -1,3 +1,3 @@
 display_name: Roadmap Sync
-short_description: Deterministic roadmap generation, sync, and validation for agent execution.
-default_prompt: Generate or synchronize ROADMAP.md (or legacy roadmap.md) using phased priorities, milestone checklists, and evidence-based completion validation.
+short_description: One-command roadmap creation and maintenance with deterministic sync, validation, and slash-driven discovery.
+default_prompt: Prefer explicit RoadmapSmith commands over a free-form request: run roadmapsmith zero for empty repos, roadmapsmith maintain for existing repos, or discover slash entrypoints with /road. Namespaced forms like /roadmap-sync zero and /roadmap-sync maintain mirror the same actions when the host surface supports them.


### PR DESCRIPTION
## Summary
- add `roadmapsmith zero` and `roadmapsmith maintain` as the primary public entrypoints
- add slash routing and VS Code launcher/task support for the new flows
- document the new product contract across README, use-case docs, release docs, and changelogs

## Verification
- full package test suite passed with the absolute Node executable on Windows
- generated launcher/task flow verified in a temp project with a resolvable workspace CLI shim
- docs/release-ux-gate.md added to make publication checks explicit
