### PR TITLE
chore(release): bump roadmapsmith to v0.9.15

### DIFF
--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.9.15 - Unreleased
+## v0.9.15 - 2026-06-13
 
 ### Added
 - `roadmapsmith zero`: one-command Zero Mode flow for empty or low-context repositories. Runs the terminal discovery interview, persists the brief into config, creates governance files when needed, and generates the first roadmap.

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.9.14",
+      "version": "0.9.15",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- bump the published package version from 0.9.14 to 0.9.15
- mark the v0.9.15 changelog entry as released on 2026-06-13
- prepare main for npm publish and GitHub Release via the existing release workflow

## Verification
- full test suite via absolute node path
- npm pack --dry-run
- cli --version smoke test
- cli help/init/generate/validate/sync/doctor smoke checks via absolute node path