### PR TITLE
feat: add native Claude GUI slash bundle

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roadmapsmith",
   "version": "0.7.0",
-  "description": "Generate and maintain deterministic project roadmaps for AI coding agents. Provides one-command zero/maintain workflows, the roadmap-sync policy skill, and setup-generated VS Code host UX for visible tasks and status.",
+  "description": "Generate and maintain deterministic project roadmaps for AI coding agents. Provides native Claude GUI slash skills like /road, /zero, /maintain, /status, /sync, and /setup, plus the legacy /roadmap-sync skill and setup-generated VS Code host UX.",
   "author": {
     "name": "PapiScholz"
   },
@@ -16,6 +16,9 @@
     "sync",
     "validation",
     "cli",
-    "claude-code"
+    "claude-code",
+    "slash-commands",
+    "zero-mode",
+    "maintain"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ The generated task layer now resolves Node automatically where possible; if it c
 `RoadmapSmith: Status` now treats "ready" as runnable task UX, not merely generated files.
 You can also use slash entrypoints such as `roadmapsmith /road`, `roadmapsmith /zero`, `roadmapsmith /maintain`, or `roadmapsmith /roadmap-sync maintain`.
 
-Optional agent skill:
+Optional Claude Code skill bundle:
 
 ```bash
-npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 ```
 
-The skill guides the agent. The CLI executes actions. Slash routing improves invocation and discovery. `roadmapsmith setup` makes those actions visible in VS Code, generates per-platform task wrappers, and can also wire the repo-local Claude hook.
+This is the recommended install path if you want native Claude GUI slash commands such as `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, `/setup`, and the legacy `/roadmap-sync`.
+If you install only `--skill roadmap-sync`, Claude GUI will expose only `/roadmap-sync`.
+The skills guide the agent. The CLI executes actions. `roadmapsmith setup` makes those actions visible in VS Code, generates per-platform task wrappers, and can also wire the repo-local Claude hook, but it does not create native Claude GUI slash commands by itself.
 
 ## Demo
 
@@ -111,12 +113,12 @@ roadmapsmith /roadmap-sync maintain
 
 | Host | Current support |
 |---|---|
-| Claude Code | Supported through `roadmapsmith setup`: visible VS Code tasks, slash-capable launcher UX, and optional repo-local Claude hook wiring. |
+| Claude Code | Supported through the full RoadmapSmith skill bundle for native GUI slash commands (`/road`, `/zero`, `/maintain`, etc.), plus `roadmapsmith setup` for visible VS Code tasks and the optional repo-local Claude hook. |
 | Codex / Codex CLI | Supported through a visible VS Code task workflow and slash-capable launcher UX after `roadmapsmith setup`. Codex chat itself remains unchanged unless the host exposes native slash registration. |
 | CI | Usable in disposable checkouts, but `sync --audit` is still mutating. |
 | Other hosts | Use the skill instructions plus manual `generate`, `validate`, `sync`, and `sync --dry-run` commands. |
 
-Claude write-time autoupdate depends on the host environment being able to resolve `node` for the repo-local hook. VS Code tasks use generated wrappers and can also honor `ROADMAPSMITH_NODE` when PATH-based Node resolution is unreliable. That best-effort hook is separate from this repository's git `pre-commit` sync behavior. RoadmapSmith does not invent native chat slash APIs where the host does not expose them; the guaranteed UX surface in this iteration is VS Code Tasks plus the slash-capable launcher/status/help output.
+Claude write-time autoupdate depends on the host environment being able to resolve `node` for the repo-local hook. VS Code tasks use generated wrappers and can also honor `ROADMAPSMITH_NODE` when PATH-based Node resolution is unreliable. That best-effort hook is separate from this repository's git `pre-commit` sync behavior. Native Claude GUI slash commands come from the installed RoadmapSmith skill bundle; CLI slash routing (`roadmapsmith /road`, `roadmapsmith /zero`, and so on) is a separate surface that remains available in terminals and launchers.
 
 Windows note: prefer `roadmapsmith.cmd`, `npm.cmd`, or explicit `node` paths in shells where PowerShell execution policy or PATH resolution differs from `cmd.exe`.
 
@@ -167,7 +169,7 @@ Optional policy layer:
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
 
-The CLI executes the one-command workflow. The `roadmap-sync` skill remains the agent policy/governance layer for hosts that use skills.
+The CLI executes the one-command workflow. The `roadmap-sync` skill remains the agent policy/governance layer for hosts that use skills. For native Claude GUI slash commands, install the full Claude bundle instead of only `roadmap-sync`.
 
 ---
 
@@ -353,17 +355,40 @@ Do not use it if:
 | `roadmapsmith validate --json` | Validate roadmap task evidence and emit JSON results |
 | `roadmapsmith sync --audit` | Apply sync and print a mismatch summary; currently mutates `ROADMAP.md` |
 | `roadmapsmith doctor --json` | Check repository plus host readiness: CLI resolution, roadmap/rules, VS Code tasks, Node runtime, Claude hook |
-| `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` | Install the agent skill |
+| `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code` | Install the full Claude GUI skill bundle with native slash commands |
+| `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` | Install only the legacy `/roadmap-sync` skill |
 
-## Install: Agent Skill (Optional Policy Layer)
+## Install: Claude Code Skill Bundle
 
 ### skills.sh and agentskill.sh
+
+```bash
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
+```
+
+This is the recommended Claude Code install path. It exposes the full native GUI command set:
+
+- `/road`
+- `/zero`
+- `/maintain`
+- `/status`
+- `/init`
+- `/generate`
+- `/validate`
+- `/sync`
+- `/audit`
+- `/setup`
+- `/roadmap-sync`
+
+After installing or updating the bundle, run `/reload-skills`. If you installed RoadmapSmith through a Claude plugin, also run `/reload-plugins` in the current session.
+
+Compatibility path:
 
 ```bash
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
 
-This adds the `roadmap-sync` agent skill only. It does not install the CLI and it does not create visible VS Code actions by itself.
+That installs only the legacy `/roadmap-sync` skill. It does not install the CLI and it does not create visible VS Code actions by itself.
 
 ### aitmpl.com/skills
 
@@ -408,9 +433,17 @@ roadmapsmith /road
 ```bash
 npm install -g roadmapsmith
 roadmapsmith setup --hosts codex,claude
-npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 roadmapsmith zero
 ```
+
+Then, in Claude Code:
+
+1. Run `/reload-skills`
+2. If RoadmapSmith was installed through a Claude plugin, also run `/reload-plugins`
+3. Confirm the slash menu shows `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, `/setup`, and `/roadmap-sync`
+
+Native Claude GUI slash commands come from the installed skill bundle. CLI slash routing such as `roadmapsmith /road` remains available in terminals and launchers, but it does not by itself populate the Claude GUI slash menu.
 
 ## Updating RoadmapSmith
 
@@ -427,12 +460,13 @@ npm install roadmapsmith@latest
 npx roadmapsmith@latest sync --audit
 ```
 
-The `roadmap-sync` agent skill is separate from the CLI. Re-running the skills install updates the agent instructions, but it does not update the `roadmapsmith` npm binary or the generated VS Code host files:
+The RoadmapSmith Claude skill bundle is separate from the CLI. Re-running a skills install updates the Claude-facing instructions, but it does not update the `roadmapsmith` npm binary or the generated VS Code host files:
 
 ```bash
-npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 ```
 
+After updating the Claude skill bundle, run `/reload-skills` and, if applicable, `/reload-plugins`.
 After updating the CLI, rerun `roadmapsmith setup` in repositories where you want the latest VS Code tasks, launcher behavior, or Claude hook template.
 
 Fixes are available through `@latest` only after a new npm package version has been published. Before publication, install from a local checkout or a packed tarball for testing:
@@ -530,7 +564,7 @@ The `AGENTS.md` file (generated by `init`) provides the agent with explicit exec
 ## Use Cases
 
 **AI coding agents**
-Install `roadmap-sync` as a skill when you want the agent to follow the roadmap contract. Install the CLI and run `roadmapsmith setup` when you want visible VS Code actions. Claude Code can also use the generated repo-local hook. Codex/Codex CLI remains a VS Code task workflow in this iteration, not a native chat-pane integration. The `ROADMAP.md` becomes a reliable contract between sessions — not a note the model wrote to itself.
+Install the full RoadmapSmith skill bundle in Claude Code when you want native GUI slash commands like `/road`, `/zero`, and `/maintain`, or install only `roadmap-sync` when you want the legacy policy skill alone. Install the CLI and run `roadmapsmith setup` when you want visible VS Code actions and the optional repo-local Claude hook. Codex/Codex CLI remains a VS Code task workflow in this iteration, not a native chat-pane integration. The `ROADMAP.md` becomes a reliable contract between sessions — not a note the model wrote to itself.
 
 **Multi-session development workflows**
 Each session starts from the same `ROADMAP.md` ground truth. Completed tasks are backed by evidence; in-progress tasks are visible without reading git history or asking the agent to summarize its own work.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -14,14 +14,16 @@ Use this document for context and command runbook notes only.
 - `roadmapsmith setup` creates the visible VS Code host UX and optional Claude hook wiring.
 - `roadmapsmith zero` is the one-command empty-repo flow.
 - `roadmapsmith maintain` is the one-command existing-repo flow.
-- `roadmap-sync` remains an optional agent policy skill; skill install alone is not full product activation.
+- Native Claude GUI slash commands come from the full skill bundle: `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, `/setup`, plus legacy `/roadmap-sync`.
+- `roadmap-sync` remains the legacy/namespaced policy skill; installing only that skill is not full product activation.
 
 Release work is not ready until the docs, host UX, and changelog all reflect that contract consistently.
 
 ## Naming and Install Intent
 
 - Primary end-user install path is the CLI: `npm install -g roadmapsmith`.
-- The skill install command adds agent instructions only: `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync`.
+- Recommended Claude install path is the full bundle: `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`.
+- Installing only `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` exposes only the legacy `/roadmap-sync` entrypoint.
 - The `roadmapsmith` CLI and the `roadmap-sync` skill are versioned and updated independently.
 - `roadmapsmith setup` must be rerun when the generated VS Code task layer, launcher, wrappers, or Claude hook template changes.
 
@@ -31,6 +33,8 @@ Before publishing:
 
 1. Fresh install path is understandable:
    - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - `/reload-skills` and, if applicable, `/reload-plugins`
    - `roadmapsmith setup`
    - `roadmapsmith zero` in an empty repo
    - `roadmapsmith maintain` in a repo with code
@@ -41,7 +45,7 @@ Before publishing:
 3. Failure states are actionable:
    - CLI missing
    - Node runtime missing
-   - skill-only install
+   - skill-only legacy install (`/roadmap-sync` only)
    - invalid host config
    - `zero` in non-interactive mode
 4. Existing `.vscode/tasks.json` and `.claude/settings.json` survive additive merge.
@@ -72,5 +76,5 @@ On this Windows machine, prefer the absolute Node executable when PATH resolutio
 Before publish:
 
 - `README.md` and `roadmap-skill/README.md` must recommend `setup`, `zero`, and `maintain` first.
-- `skills.json`, `.claude-plugin/plugin.json`, and `skills/roadmap-sync/agents/openai.yaml` must describe the skill as policy/governance, not as the whole product.
-- `roadmap-skill/CHANGELOG.md` must include the user-visible CLI, slash, VS Code, and runtime changes for the next version.
+- `skills.json` and `.claude-plugin/plugin.json` must enumerate the full Claude GUI slash bundle, while `skills/roadmap-sync/agents/openai.yaml` stays aligned on the policy/governance layer.
+- `roadmap-skill/CHANGELOG.md` must include the user-visible CLI, Claude GUI slash, VS Code, and runtime changes for the next version.

--- a/docs/release-ux-gate.md
+++ b/docs/release-ux-gate.md
@@ -12,10 +12,12 @@ The public entrypoints must stay consistent across CLI help, VS Code tasks, laun
 - `roadmapsmith zero`
 - `roadmapsmith maintain`
 - `roadmapsmith /road`
+- Native Claude GUI slash commands: `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, `/setup`
 
-The optional skill remains a policy layer:
+The skill bundle remains a GUI/policy layer distinct from the CLI:
 
-- `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync`
+- `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+- `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` remains the legacy compatibility path
 
 Skill installation alone must never be described as full activation of the product.
 
@@ -69,6 +71,20 @@ And when `RoadmapSmith: Status` explains:
 - tasks/config ready or missing
 - skill install alone does not expose CLI behavior
 
+Pass when Claude GUI slash discovery shows at least:
+
+- `/road`
+- `/zero`
+- `/maintain`
+- `/status`
+- `/init`
+- `/generate`
+- `/validate`
+- `/sync`
+- `/audit`
+- `/setup`
+- `/roadmap-sync`
+
 ### 4. Failure clarity
 
 These cases must be tested:
@@ -79,6 +95,7 @@ These cases must be tested:
 - invalid `.claude/settings.json`
 - `roadmapsmith zero` in non-interactive mode
 - user installed only the skill
+- user installed only the legacy `roadmap-sync` skill
 
 Pass when each case tells the user:
 
@@ -102,6 +119,7 @@ Pass when:
 
 - `README.md` recommends `setup`, `zero`, and `maintain` first
 - `roadmap-skill/README.md` matches the same contract
+- Claude docs explain that native GUI slash commands come from the installed skill bundle, not from the CLI slash router alone
 - `docs/release-readiness.md` matches the actual release workflow
 - `roadmap-skill/CHANGELOG.md` includes the user-visible UX/runtime changes
 

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -6,19 +6,26 @@ Developers using Claude Code (the Anthropic CLI) as their primary AI coding agen
 - Solo developers running multi-session Claude Code projects
 - Teams using Claude Code with agent hooks for automated workflows
 - Anyone who wants the roadmap to stay honest across many agent sessions
+- Anyone who wants native Claude GUI slash commands instead of relying on a single legacy `/roadmap-sync` entrypoint
 
 ## When to use it
 
 Use the Claude Code integration when:
 
 - You run Claude Code sessions that implement tasks and want an optional repo-local hook after each session
+- You want the Claude GUI slash list to expose `/road`, `/zero`, `/maintain`, `/status`, `/sync`, and the rest of the RoadmapSmith surface directly
 - You want a pre-commit hook that validates roadmap state before every commit
 - You are using the `roadmap-sync` skill inside Claude Code and want it to stay evidence-backed
 - You want to resume a previous session and need ground truth on what is actually done
 
 ## How it works
 
-This repository includes an example `.claude/hooks/roadmap-sync.js` script for Claude Code. If you wire it into `.claude/settings.json`, it fires after every file write and runs `roadmapsmith sync`. That workflow is Claude-specific today; the visible UX surface still starts with `roadmapsmith setup`, `roadmapsmith zero`, and `roadmapsmith maintain`.
+This repository now has two Claude-facing layers:
+
+- Native Claude GUI skills that expose slash commands like `/road`, `/zero`, `/maintain`, `/status`, `/sync`, and `/setup`
+- An optional repo-local `.claude/hooks/roadmap-sync.js` hook that fires after writes and runs `roadmapsmith sync`
+
+The native slash list comes from the installed skill bundle, not from the CLI slash router by itself. The CLI still executes the real actions.
 
 The write-time hook is best-effort today. It depends on the Claude host environment being able to resolve `node` for the child process launched by the hook script.
 
@@ -41,15 +48,44 @@ roadmapsmith setup --hosts codex,claude
 
 This creates the visible VS Code task layer and upserts the repo-local Claude hook wiring.
 
-### Option 2: Install the optional skill
+### Option 2: Install the full Claude skill bundle
+
+```bash
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
+```
+
+Then refresh the current Claude session:
+
+```text
+/reload-skills
+/reload-plugins
+```
+
+This exposes the native Claude GUI slash commands:
+
+- `/road`
+- `/zero`
+- `/maintain`
+- `/status`
+- `/init`
+- `/generate`
+- `/validate`
+- `/sync`
+- `/audit`
+- `/setup`
+- `/roadmap-sync`
+
+It still does not install the CLI; the CLI must be installed separately for those commands to execute.
+
+### Option 3: Install only the legacy compatibility skill
 
 ```bash
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
 
-This installs the agent policy instructions only. It does not install the CLI.
+This installs only the legacy namespaced slash command `/roadmap-sync` plus the policy instructions. It does not expose the full Claude GUI command list.
 
-### Option 3: Manual hook setup
+### Option 4: Manual hook setup
 
 Copy `.claude/hooks/roadmap-sync.js` to your project's `.claude/hooks/` directory, then register it in `.claude/settings.json`:
 
@@ -74,9 +110,10 @@ Copy `.claude/hooks/roadmap-sync.js` to your project's `.claude/hooks/` director
 ## Typical workflow with Claude Code
 
 ```bash
-# 1. Install the visible host UX and optional skill
+# 1. Install the CLI and the native Claude GUI skill bundle
+npm install -g roadmapsmith
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 roadmapsmith setup --hosts codex,claude
-npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 
 # 2. For a new repo, create the first roadmap in one command
 roadmapsmith zero
@@ -84,25 +121,25 @@ roadmapsmith zero
 # 3. For an existing repo, run the maintenance flow in one command
 roadmapsmith maintain
 
-# 4. Start a Claude Code session — the skill guides the agent
-# 5. The agent implements tasks; the optional hook syncs the roadmap after each file write
-# 6. At the end of the session, verify the state is accurate
+# 4. At the end of the session, verify the state is accurate
 roadmapsmith sync --audit
 
-# 7. Commit — if you use a pre-commit hook, it can run a final sync
+# 5. Commit — if you use a pre-commit hook, it can run a final sync
 git commit -m "feat: implement task X"
 ```
 
+Then, inside Claude Code, run `/reload-skills` and, if applicable, `/reload-plugins`. Start the session with `/road` for discovery or jump straight to `/zero`, `/maintain`, `/sync`, and the other native slash commands.
+
 ## Skill integration
 
-The `roadmap-sync` skill in `.claude/skills/` (and platform-equivalent directories) tells the Claude Code agent:
+The RoadmapSmith Claude skill bundle tells the Claude Code agent:
 
 - How to read and interpret `ROADMAP.md`
 - When to run `roadmapsmith sync` vs. `validate` vs. `generate`
 - How to handle evidence-based task completion — never mark `[x]` without evidence
 - How to resume a previous session using `roadmapsmith validate --json`
 
-The skill enforces the core RoadmapSmith guarantee: task completion must be backed by real repository evidence, not the agent's self-report.
+The legacy `roadmap-sync` skill remains the namespaced compatibility entrypoint and policy/orchestration layer. The bundle enforces the core RoadmapSmith guarantee: task completion must be backed by real repository evidence, not the agent's self-report.
 
 ## Resuming a session
 
@@ -132,6 +169,8 @@ Use `validate --json` when you want to inspect per-task evidence before taking a
 ## Troubleshooting
 
 **Hook not firing:** Verify the hook is registered in `.claude/settings.json` and the file path is correct.
+
+**Slash commands not visible in Claude GUI:** Install the full skill bundle with `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`, then run `/reload-skills` and, if applicable, `/reload-plugins`. Installing only `--skill roadmap-sync` exposes only `/roadmap-sync`.
 
 **Hook runs but ROADMAP does not update:** Confirm the Claude hook environment can resolve `node`. Today the repo-local write-time hook is best-effort and depends on that host-level resolution.
 

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.9.16 - 2026-06-13
+
+### Added
+- Native Claude GUI slash skill bundle: `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, and `/setup`, while keeping `/roadmap-sync` as the legacy namespaced entrypoint.
+- Skill-manifest regression coverage to ensure `skills.json` stays aligned with the on-disk Claude bundle and install contract.
+
+### Changed
+- Claude onboarding now recommends installing the full RoadmapSmith skill bundle with `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code` instead of teaching `roadmap-sync` as the only visible slash command.
+- Root/package README, release-readiness docs, and Claude-use-case docs now separate the three layers explicitly: Claude GUI skills expose native slash commands, the CLI executes actions, and `setup` configures VS Code tasks plus the optional Claude hook.
+- Claude plugin metadata now advertises the full slash-command surface and tells users to reload skills/plugins in the current session after install or update.
+
 ## v0.9.15 - 2026-06-13
 
 ### Added

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -24,10 +24,12 @@ The generated VS Code task layer now resolves Node automatically where possible;
 ### Agent Skill
 
 ```bash
-npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 ```
 
-This adds the `roadmap-sync` agent skill only. It does not install the CLI and it does not create visible VS Code actions by itself.
+This is the recommended Claude Code install path for native GUI slash commands such as `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, `/setup`, and the legacy `/roadmap-sync`.
+If you install only `--skill roadmap-sync`, Claude GUI will expose only `/roadmap-sync`.
+The skill bundle does not install the CLI and it does not create visible VS Code actions by itself.
 
 ## Updating
 
@@ -44,12 +46,13 @@ npm install roadmapsmith@latest
 npx roadmapsmith@latest validate --json
 ```
 
-The `roadmap-sync` agent skill is separate from the CLI. Re-running the skills install updates the agent instructions, but it does not update the `roadmapsmith` npm binary or the generated VS Code host files:
+The Claude skill bundle is separate from the CLI. Re-running the skills install updates the Claude-facing instructions, but it does not update the `roadmapsmith` npm binary or the generated VS Code host files:
 
 ```bash
-npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 ```
 
+After updating the Claude skill bundle, run `/reload-skills` and, if applicable, `/reload-plugins`.
 After updating the CLI, rerun `roadmapsmith setup` in repositories where you want the latest VS Code tasks, task wrappers, launcher behavior, or Claude hook template.
 
 Fixes are available through `@latest` only after a new npm package version has been published. Before publication, install from a local checkout or a packed tarball for testing.
@@ -92,7 +95,7 @@ Use the lower-level commands only when you want manual control over generation, 
 
 | Host | Current support |
 |---|---|
-| Claude Code | Supported through `roadmapsmith setup`: visible VS Code tasks, slash-capable launcher UX, and optional repo-local Claude hook wiring. |
+| Claude Code | Supported through the full RoadmapSmith skill bundle for native GUI slash commands, plus `roadmapsmith setup` for visible VS Code tasks and the optional repo-local Claude hook. |
 | Codex / Codex CLI | Supported through a visible VS Code task workflow and slash-capable launcher UX after `roadmapsmith setup`. Codex chat itself remains unchanged unless the host exposes native slash registration. |
 | CI | Use disposable checkouts if you run `sync --audit`, because it still mutates the roadmap today. |
 | Other hosts | Use the skill plus manual CLI commands. |
@@ -117,6 +120,22 @@ roadmapsmith sync [--roadmap-file <path>] [--project-root <path>] [--config <pat
 roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json]
 roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]
 ```
+
+## Claude Code native slash commands
+
+Install the full skill bundle for Claude Code:
+
+```bash
+npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
+```
+
+Then reload the session:
+
+1. Run `/reload-skills`
+2. If RoadmapSmith was installed through a Claude plugin, also run `/reload-plugins`
+3. Confirm the slash menu shows `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, `/setup`, and `/roadmap-sync`
+
+Native Claude GUI slash commands come from the installed skill bundle. CLI slash routing such as `roadmapsmith /road` is a separate surface and does not populate the Claude GUI menu by itself.
 
 ## Behavior
 

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.9.15",
+      "version": "0.9.16",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.15",
-  "description": "Evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
+  "version": "0.9.16",
+  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents.",
   "main": "src/index.js",
   "bin": {
     "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/test/skills-manifest.test.js
+++ b/roadmap-skill/test/skills-manifest.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SKILLS_JSON_PATH = path.join(REPO_ROOT, 'skills.json');
+const EXPECTED_SKILL_NAMES = [
+  'road',
+  'zero',
+  'maintain',
+  'status',
+  'init',
+  'generate',
+  'validate',
+  'sync',
+  'audit',
+  'setup',
+  'roadmap-sync'
+];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('skills.json lists the complete Claude GUI skill bundle', () => {
+  const manifest = readJson(SKILLS_JSON_PATH);
+  const names = manifest.skills.map((skill) => skill.name);
+
+  assert.deepEqual(names, EXPECTED_SKILL_NAMES);
+  assert.match(manifest.install.command, /--skill '\*' -a claude-code/);
+  assert.match(manifest.install.notes, /\/road/);
+  assert.match(manifest.install.notes, /\/roadmap-sync/);
+});
+
+test('every skill listed in skills.json exists and exposes the expected name', () => {
+  const manifest = readJson(SKILLS_JSON_PATH);
+
+  manifest.skills.forEach((skill) => {
+    const skillFile = path.join(REPO_ROOT, skill.path, 'SKILL.md');
+    const content = fs.readFileSync(skillFile, 'utf8');
+
+    assert.equal(fs.existsSync(skillFile), true, `missing ${skillFile}`);
+    assert.match(content, new RegExp(`name:\\s+${skill.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+    assert.match(content, /description:/);
+  });
+});

--- a/skills.json
+++ b/skills.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "description": "One-command roadmap generation and maintenance for coding agents, with an optional roadmap-sync policy skill.",
+  "description": "One-command roadmap generation and maintenance for coding agents, with native Claude GUI slash skills plus the roadmap-sync policy skill.",
   "triggers": [
     "roadmap",
     "sync roadmap",
@@ -9,6 +9,7 @@
     "agent roadmap"
   ],
   "usageExamples": [
+    "npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code",
     "npx skills add PapiScholz/roadmapsmith --skill roadmap-sync",
     "roadmapsmith setup",
     "roadmapsmith zero",
@@ -18,16 +19,76 @@
     "roadmapsmith validate --json"
   ],
   "install": {
-    "command": "npx skills add PapiScholz/roadmapsmith --skill roadmap-sync",
+    "command": "npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code",
     "source": "PapiScholz/roadmapsmith",
-    "skill": "roadmap-sync",
-    "notes": "The install command adds agent instructions only. Install the roadmapsmith CLI and run roadmapsmith setup to expose the Zero Mode and Maintain workflows in VS Code."
+    "skill": "*",
+    "notes": "Recommended Claude Code install path for native GUI slash commands like /road, /zero, /maintain, /status, /init, /generate, /validate, /sync, /audit, and /setup. If you install only --skill roadmap-sync, Claude GUI will expose only /roadmap-sync. Install the roadmapsmith CLI separately for actual command execution, then run /reload-skills and, if applicable, /reload-plugins."
   },
   "skills": [
     {
+      "name": "road",
+      "path": "skills/road",
+      "description": "Native Claude GUI palette for RoadmapSmith commands and recommended entrypoints.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "zero",
+      "path": "skills/zero",
+      "description": "Native Claude GUI entrypoint for the one-command Zero Mode CLI workflow.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "maintain",
+      "path": "skills/maintain",
+      "description": "Native Claude GUI entrypoint for the default generate + sync + audit flow.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "status",
+      "path": "skills/status",
+      "description": "Native Claude GUI readiness check grounded in roadmapsmith doctor JSON.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "init",
+      "path": "skills/init",
+      "description": "Native Claude GUI entrypoint for creating ROADMAP.md and AGENTS.md.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "generate",
+      "path": "skills/generate",
+      "description": "Native Claude GUI entrypoint for regenerating the managed roadmap block.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "validate",
+      "path": "skills/validate",
+      "description": "Native Claude GUI entrypoint for evidence-backed roadmap validation.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "sync",
+      "path": "skills/sync",
+      "description": "Native Claude GUI entrypoint for applying evidence-backed checklist sync.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "audit",
+      "path": "skills/audit",
+      "description": "Native Claude GUI entrypoint for the current sync-plus-audit workflow.",
+      "version": "0.7.0"
+    },
+    {
+      "name": "setup",
+      "path": "skills/setup",
+      "description": "Native Claude GUI entrypoint for generating RoadmapSmith host integration files.",
+      "version": "0.7.0"
+    },
+    {
       "name": "roadmap-sync",
       "path": "skills/roadmap-sync",
-      "description": "Policy and operating rules for Zero Mode discovery plus ongoing roadmap generation, sync, and validation.",
+      "description": "Policy and operating rules for RoadmapSmith plus the legacy /roadmap-sync Claude entrypoint.",
       "version": "0.7.0"
     }
   ]

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: audit
+description: Run the current RoadmapSmith sync-plus-audit workflow through the CLI.
+---
+
+# RoadmapSmith Audit
+
+Use this command when the user wants the current audit workflow from Claude GUI.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith sync --audit --project-root .`.
+2. Be explicit that today's audit behavior is the mutating sync path plus a mismatch summary, not a read-only audit mode.
+3. If the CLI is missing, explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Summarize both the sync result and the audit summary.

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: generate
+description: Rebuild the managed roadmap block from repository context through the RoadmapSmith CLI.
+---
+
+# RoadmapSmith Generate
+
+Use this command when the user wants the roadmap regenerated from repository evidence without running the full maintain shortcut.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith generate --project-root .`.
+2. Treat this command as CLI-backed.
+3. If the CLI is missing, explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Summarize whether the roadmap changed and mention audit output if the user requested it separately.

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: init
+description: Create ROADMAP.md and AGENTS.md through the RoadmapSmith CLI.
+---
+
+# RoadmapSmith Init
+
+Use this command when the governance files are missing and the user wants them created without running the full Zero Mode interview.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith init` from the repository root.
+2. Treat this command as CLI-backed.
+3. If the CLI is missing, explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Summarize whether `ROADMAP.md` and `AGENTS.md` were created or skipped because they already existed.

--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: maintain
+description: Run the one-command existing-repository maintenance workflow through the RoadmapSmith CLI.
+---
+
+# RoadmapSmith Maintain
+
+Use this command when the repository already has code, tests, docs, or an existing roadmap and the user wants the default maintenance flow.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith maintain --project-root .` from the repository root.
+2. Treat this command as CLI-backed. Do not silently replace it with manual generate/sync reasoning when the CLI is unavailable.
+3. If the CLI is missing, explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Mention that this workflow runs generate, sync, and audit in one invocation.
+
+## Success criteria
+
+- The command uses the CLI-backed maintain flow.
+- The response summarizes the resulting roadmap/audit outcome.

--- a/skills/road/SKILL.md
+++ b/skills/road/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: road
+description: Show the RoadmapSmith Claude GUI command palette without side effects.
+---
+
+# RoadmapSmith Palette
+
+Use this command as the native Claude GUI discovery entrypoint for RoadmapSmith.
+
+## Required behavior
+
+1. Treat `/road` as a no-side-effects palette. Do not run mutating commands from this skill.
+2. If the `roadmapsmith` CLI is available, you may run `roadmapsmith /road` from the project root and use that output directly.
+3. If the CLI is missing, provide the palette manually and explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Explain the preferred native Claude GUI entrypoints:
+   - `/zero` for empty or low-context repositories
+   - `/maintain` for existing repositories
+   - `/status` for readiness checks
+   - `/init`, `/generate`, `/validate`, `/sync`, `/audit`, and `/setup` for advanced/manual control
+5. Mention that `/roadmap-sync` remains valid as the legacy/namespaced RoadmapSmith skill.
+
+## Output contract
+
+- Show what each command does in one sentence.
+- Include both native Claude examples and CLI equivalents.
+- Do not modify files or generate a roadmap from this command alone.

--- a/skills/roadmap-sync/SKILL.md
+++ b/skills/roadmap-sync/SKILL.md
@@ -7,6 +7,18 @@ description: Generate, synchronize, and validate project roadmap checklist state
 
 Use this skill to keep roadmap execution state accurate and deterministic.
 
+## Preferred Claude GUI entrypoints
+
+When the full RoadmapSmith skill bundle is installed in Claude Code, prefer these native GUI commands:
+
+- `/road` for discovery/palette help
+- `/zero` for empty or low-context repositories
+- `/maintain` for the default existing-repository flow
+- `/status` for readiness checks
+- `/init`, `/generate`, `/validate`, `/sync`, `/audit`, and `/setup` for advanced/manual control
+
+`/roadmap-sync` remains valid as the legacy or namespaced entrypoint and should continue to work for backward compatibility.
+
 ## Mode Selection
 
 Before generating or updating `ROADMAP.md`, determine which mode applies.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: setup
+description: Generate RoadmapSmith host integration files through the CLI.
+---
+
+# RoadmapSmith Setup
+
+Use this command when the user wants RoadmapSmith host integration files generated or refreshed for the current repository.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith setup --project-root . --hosts codex,claude`.
+2. Explain that setup affects the repository host layer: VS Code tasks, launcher/wrappers, and the optional repo-local Claude hook.
+3. Do not claim that setup alone creates native Claude GUI slash commands; those come from the installed RoadmapSmith skill bundle.
+4. If the CLI is missing, explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: status
+description: Inspect RoadmapSmith readiness through doctor JSON and summarize the result.
+---
+
+# RoadmapSmith Status
+
+Use this command to inspect whether the CLI, roadmap files, VS Code task UX, runtime, and Claude hook are ready.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith doctor --json --project-root .` from the repository root.
+2. Parse and summarize the JSON output for the user in plain language.
+3. If the CLI is missing, explain the installation path instead of fabricating a status result:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Highlight whether Claude GUI skills, CLI resolution, and task/runtime readiness are healthy or not.
+
+## Success criteria
+
+- The command is grounded in doctor JSON, not a guess.
+- The response clearly distinguishes missing CLI vs missing host wiring.

--- a/skills/sync/SKILL.md
+++ b/skills/sync/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: sync
+description: Apply evidence-backed roadmap checklist synchronization through the RoadmapSmith CLI.
+---
+
+# RoadmapSmith Sync
+
+Use this command when the user wants validation outcomes applied back into `ROADMAP.md`.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith sync --project-root .`.
+2. Treat this command as CLI-backed and mutating.
+3. If the CLI is missing, explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Remind the user that sync updates checklist state based on repository evidence, not model claims.

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: validate
+description: Inspect roadmap task evidence through the RoadmapSmith validate command.
+---
+
+# RoadmapSmith Validate
+
+Use this command when the user wants evidence-backed validation details for roadmap tasks.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith validate --json --project-root .`.
+2. Keep the JSON grounding and summarize the key pass/fail results for the user.
+3. If the CLI is missing, explain the installation path:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Do not claim task completion without validation output.

--- a/skills/zero/SKILL.md
+++ b/skills/zero/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: zero
+description: Run the one-command Zero Mode workflow through the RoadmapSmith CLI.
+---
+
+# RoadmapSmith Zero Mode
+
+Use this command when the repository is empty or low-context and the user wants the first roadmap.
+
+## Required behavior
+
+1. Prefer running `roadmapsmith zero --project-root .` from the repository root.
+2. Treat this command as CLI-backed. Do not replace it with a handcrafted discovery interview unless the user explicitly asks to work without the CLI.
+3. If the CLI is missing, stop and explain the required setup:
+   - `npm install -g roadmapsmith`
+   - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
+   - run `/reload-skills`
+   - if RoadmapSmith was installed as a Claude plugin, also run `/reload-plugins`
+4. Mention that `/roadmap-sync` remains valid, but `/zero` is the preferred Claude GUI entrypoint for this workflow.
+
+## Success criteria
+
+- The command runs the actual Zero Mode CLI flow.
+- The response summarizes that Zero Mode covers discovery, governance-file creation, and roadmap generation.


### PR DESCRIPTION
## Summary
- add native Claude GUI slash skills for `/road`, `/zero`, `/maintain`, `/status`, `/init`, `/generate`, `/validate`, `/sync`, `/audit`, and `/setup`
- keep `/roadmap-sync` as the legacy compatibility skill and align manifests/plugin metadata/docs around the full Claude bundle install path
- bump the npm package to `0.9.16` and document the release contract across README, Claude docs, changelog, and release-readiness docs

## Verification
- `C:\Program Files\nodejs\node.exe --test roadmap-skill\test\*.test.js`
- `C:\Program Files\nodejs\npm.cmd pack --dry-run`
- `C:\Program Files\nodejs\npm.cmd view roadmapsmith version` -> `0.9.15` before merge/publish
