### PR TITLE
fix: make auto-release respect protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -116,3 +117,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node roadmap-skill/scripts/auto-release.js
+
+  merge-release-pr:
+    name: Merge release PR
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/v')
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Merge automated release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 After updating the Claude skill bundle, run `/reload-skills` and, if applicable, `/reload-plugins`.
 After updating the CLI, rerun `roadmapsmith setup` in repositories where you want the latest VS Code tasks, launcher behavior, or Claude hook template. Published npm/plugin artifacts now include the Codex and Claude bundle files for downstream host loaders, but native GUI visibility still depends on the host loading the correct surface.
 
-Fixes are available through `@latest` after the next successful push to `main`, because release automation now publishes a new patch version on every merge. Before that push lands, install from a local checkout or a packed tarball for testing:
+Fixes are available through `@latest` after the automated release path completes on `main`. In this repo, a successful push to `main` now opens or refreshes an automated release PR, that PR merges back as the bot release commit, and the follow-up `main` run publishes the new patch version. Before that completes, install from a local checkout or a packed tarball for testing:
 
 ```bash
 npm install C:\Users\ezesc\Github\roadmapsmith\roadmap-skill

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-Published as the `roadmapsmith` npm package. Every successful push to `main` now publishes a new patch release automatically, including docs-only merges.
+Published as the `roadmapsmith` npm package. Every successful push to `main` now advances toward a new patch release automatically, including docs-only merges, through a protected-branch-safe release PR flow.
 
 ## Canonical Checklist
 
@@ -28,6 +28,7 @@ Release work is not ready until the docs, host UX, and changelog all reflect tha
 - Recommended Claude install path is the full bundle: `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`.
 - Installing only `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` exposes only the legacy `/roadmap-sync` root.
 - Patch versions advance on every successful push to `main`, regardless of whether the merged change was code, docs, or release-ops only.
+- Because `main` is PR-only, the release workflow writes that version back through an automated `release/vX.Y.Z` PR that squashes into `main` as `chore(release): vX.Y.Z [skip ci]`.
 - `roadmapsmith doctor --json` must report `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` separately from the VS Code task/hook layer.
 - If a legacy `~/.agents/skills/roadmap-sync` install coexists with the `roadmapsmith` Codex plugin, `doctor` should flag `/roadmap-sync` as a duplicate instead of silently calling the surface healthy.
 - The published `roadmapsmith` package now mirrors the shared Codex and Claude bundle files for downstream plugin/distribution surfaces, but CLI install alone still does not auto-register either host surface.
@@ -61,7 +62,7 @@ Before merging to `main`:
    - invalid host config
    - `zero` in non-interactive mode
 4. Existing `.vscode/tasks.json` and `.claude/settings.json` survive additive merge.
-5. Commit subjects are ready for CI-managed changelog generation; versioned sections are no longer maintained by hand.
+5. Commit subjects are ready for CI-managed changelog generation; versioned sections are no longer maintained by hand, and the protected-branch release PR is allowed to merge after checks pass.
 6. Packed artifact is self-consistent:
    - `npm run verify-pack-surface`
    - extract the tarball and confirm `package/skills.json`, `package/.codex-plugin/plugin.json`, `package/.claude-plugin/plugin.json`, every manifest-listed `package/skills/<name>/SKILL.md`, and the Codex manifest assets exist
@@ -103,4 +104,4 @@ Before merging to `main`:
 - `README.md` and `roadmap-skill/README.md` must recommend `setup`, `zero`, and `maintain` first.
 - `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and `skills.json` must stay aligned on shared metadata and the full bundle surface, while `skills/roadmap-sync/agents/openai.yaml` stays aligned on the policy/governance layer.
 - The packed npm artifact must contain the same Codex and Claude bundle files advertised in those manifests.
-- `roadmap-skill/CHANGELOG.md` must keep `## Unreleased` present with its empty placeholder so CI can generate the next `## vX.Y.Z - YYYY-MM-DD` section automatically.
+- `roadmap-skill/CHANGELOG.md` must keep `## Unreleased` present with its empty placeholder so CI can generate the next `## vX.Y.Z - YYYY-MM-DD` section automatically when the automated release PR is prepared.

--- a/docs/release-ux-gate.md
+++ b/docs/release-ux-gate.md
@@ -4,7 +4,7 @@ Use this document before merging a change that will publish the next `roadmapsmi
 
 The goal is simple: a new user must understand how to start, recover from common failures, and avoid damaging existing workspace config.
 
-Every successful push to `main` publishes a new patch release automatically, including docs-only merges.
+Every successful push to `main` now prepares a new patch release automatically, including docs-only merges, by opening or refreshing an automated `release/vX.Y.Z` PR. When that PR passes checks it merges back into `main`, and the follow-up `main` run publishes npm plus the GitHub Release in repair mode.
 
 ## Required User Contract
 

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -56,7 +56,7 @@ npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 After updating the Claude skill bundle, run `/reload-skills` and, if applicable, `/reload-plugins`.
 After updating the CLI, rerun `roadmapsmith setup` in repositories where you want the latest VS Code tasks, task wrappers, launcher behavior, or Claude hook template. Published npm/plugin artifacts now include the Codex and Claude bundle files for downstream host loaders, but native UX still depends on the host loading the correct surface.
 
-Fixes are available through `@latest` after the next successful push to `main`, because release automation now publishes a new patch version on every merge. Before that push lands, install from a local checkout or a packed tarball for testing.
+Fixes are available through `@latest` after the automated release path completes on `main`. In this repo, a successful push to `main` now opens or refreshes an automated `release/vX.Y.Z` PR, that PR squashes back into `main` as the bot release commit, and the follow-up `main` run publishes the new patch version. Before that completes, install from a local checkout or a packed tarball for testing.
 
 ## Operating Modes
 
@@ -355,7 +355,7 @@ npm test
 Repository-specific release note:
 
 - The canonical release automation lives in `.github/workflows/ci.yml`.
-- Every successful push to `main` now bumps `PATCH`, writes the version back with `chore(release): vX.Y.Z [skip ci]`, publishes to npm, and creates the GitHub Release automatically.
+- Every successful push to `main` now bumps `PATCH` through an automated `release/vX.Y.Z` PR, writes the version back with the squashed bot commit `chore(release): vX.Y.Z [skip ci]`, and then the follow-up `main` run publishes npm plus the GitHub Release.
 - Repair reruns on the bot release commit do not bump again; they only publish/create any missing artifacts left behind by a partial failure.
 - Before any push, run the dual validation gate with separate owners: `QA/Regression` uses `npm run validate:qa-regression` and `Functional/Smoke` uses `npm run validate:functional-smoke`.
 - The release gate now includes packed-artifact verification for `skills.json`, `skills/*`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and the referenced Codex assets so the published surface matches the GitHub-source bundle for both hosts.

--- a/roadmap-skill/scripts/auto-release.js
+++ b/roadmap-skill/scripts/auto-release.js
@@ -115,6 +115,10 @@ function ensureLocalTag(runner, repoRoot, tag) {
   return true;
 }
 
+function buildReleaseBranchName(version) {
+  return `release/v${version}`;
+}
+
 function writeReleaseNotesFile(notes) {
   const filePath = path.join(os.tmpdir(), `roadmapsmith-release-notes-${process.pid}.md`);
   fs.writeFileSync(filePath, `${String(notes || '').trim()}\n`, 'utf8');
@@ -157,6 +161,83 @@ function ensurePublishedArtifacts(runner, options = {}) {
   };
 }
 
+function pushReleaseBranch(runner, repoRoot, branchName) {
+  runChecked(runner, 'git', ['push', '--force-with-lease', 'origin', `HEAD:refs/heads/${branchName}`], { cwd: repoRoot });
+}
+
+function findOpenPullRequest(runner, repoRoot, branchName) {
+  const result = runChecked(runner, 'gh', [
+    'pr',
+    'list',
+    '--state',
+    'open',
+    '--base',
+    'main',
+    '--head',
+    branchName,
+    '--json',
+    'number,url,title'
+  ], {
+    cwd: repoRoot,
+    env: process.env
+  });
+
+  const pullRequests = JSON.parse(result.stdout || '[]');
+  return pullRequests[0] || null;
+}
+
+function ensureReleasePullRequest(runner, options = {}) {
+  const {
+    repoRoot = REPO_ROOT,
+    branchName,
+    version,
+    notes
+  } = options;
+
+  const existing = findOpenPullRequest(runner, repoRoot, branchName);
+  if (existing) {
+    return {
+      number: existing.number,
+      url: existing.url,
+      title: existing.title,
+      created: false
+    };
+  }
+
+  const body = [
+    '## Summary',
+    `- automated release PR for ${buildReleaseTag(version)}`,
+    '- bumps package metadata and resets the changelog through the protected-branch path',
+    '- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode',
+    '',
+    '## Notes',
+    notes || `Release ${buildReleaseTag(version)}`
+  ].join('\n');
+
+  const result = runChecked(runner, 'gh', [
+    'pr',
+    'create',
+    '--base',
+    'main',
+    '--head',
+    branchName,
+    '--title',
+    buildReleaseCommitMessage(version),
+    '--body',
+    body
+  ], {
+    cwd: repoRoot,
+    env: process.env
+  });
+
+  return {
+    number: null,
+    url: trimOutput(result.stdout),
+    title: buildReleaseCommitMessage(version),
+    created: true
+  };
+}
+
 function commitReleaseState(runner, repoRoot, version) {
   const files = [
     'roadmap-skill/package.json',
@@ -170,11 +251,6 @@ function commitReleaseState(runner, repoRoot, version) {
 
   runChecked(runner, 'git', ['add', '--', ...files], { cwd: repoRoot });
   runChecked(runner, 'git', ['commit', '-m', buildReleaseCommitMessage(version)], { cwd: repoRoot });
-}
-
-function pushReleaseState(runner, repoRoot, tag) {
-  runChecked(runner, 'git', ['push', 'origin', 'HEAD:main'], { cwd: repoRoot });
-  runChecked(runner, 'git', ['push', 'origin', `refs/tags/${tag}`], { cwd: repoRoot });
 }
 
 function runAutoRelease(options = {}) {
@@ -197,6 +273,9 @@ function runAutoRelease(options = {}) {
 
   let notes;
   let previousTag = null;
+  let releaseBranch = null;
+  let pullRequest = null;
+  let publication = null;
 
   if (versionResult.mode === 'normal') {
     previousTag = getPreviousTag(runner, repoRoot);
@@ -209,22 +288,28 @@ function runAutoRelease(options = {}) {
       write: true
     }).notes;
 
+    releaseBranch = buildReleaseBranchName(versionResult.version);
+    runChecked(runner, 'git', ['checkout', '-B', releaseBranch], { cwd: repoRoot });
     commitReleaseState(runner, repoRoot, versionResult.version);
-    ensureLocalTag(runner, repoRoot, versionResult.tag);
-    pushReleaseState(runner, repoRoot, versionResult.tag);
+    pushReleaseBranch(runner, repoRoot, releaseBranch);
+    pullRequest = ensureReleasePullRequest(runner, {
+      repoRoot,
+      branchName: releaseBranch,
+      version: versionResult.version,
+      notes
+    });
   } else {
     ensureLocalTag(runner, repoRoot, versionResult.tag);
     runChecked(runner, 'git', ['push', 'origin', `refs/tags/${versionResult.tag}`], { cwd: repoRoot });
     const changelogContent = fs.readFileSync(path.join(packageRoot, 'CHANGELOG.md'), 'utf8');
     notes = extractReleaseNotes(changelogContent, versionResult.version);
+    publication = ensurePublishedArtifacts(runner, {
+      repoRoot,
+      packageRoot,
+      version: versionResult.version,
+      notes
+    });
   }
-
-  const publication = ensurePublishedArtifacts(runner, {
-    repoRoot,
-    packageRoot,
-    version: versionResult.version,
-    notes
-  });
 
   return {
     mode: versionResult.mode,
@@ -232,6 +317,8 @@ function runAutoRelease(options = {}) {
     version: versionResult.version,
     tag: versionResult.tag,
     previousTag,
+    releaseBranch,
+    pullRequest,
     publication
   };
 }
@@ -260,12 +347,15 @@ module.exports = {
   createProcessRunner,
   ensureLocalTag,
   ensurePublishedArtifacts,
+  ensureReleasePullRequest,
+  findOpenPullRequest,
   getCommitSubjects,
   getHeadCommitSubject,
   getPreviousTag,
   hasGitHubRelease,
   main,
-  pushReleaseState,
+  buildReleaseBranchName,
+  pushReleaseBranch,
   runAutoRelease,
   runChecked,
   tryReadPublishedVersion,

--- a/roadmap-skill/test/release-automation.test.js
+++ b/roadmap-skill/test/release-automation.test.js
@@ -229,9 +229,12 @@ test('runAutoRelease normal mode simulates bump, commit, publish, and GitHub Rel
     'git log --pretty=%s --reverse v1.2.3..HEAD': {
       stdout: 'feat: auto patch releases\nfix: keep release idempotent\ndocs: explain main publish contract\n'
     },
-    'git rev-parse -q --verify refs/tags/v1.2.4': { status: 1, stderr: 'missing\n' },
-    'npm view roadmapsmith version': { stdout: '1.2.3\n' },
-    'gh release view v1.2.4': { status: 1, stderr: 'missing release\n' }
+    'git checkout -B release/v1.2.4': { stdout: "Switched to branch 'release/v1.2.4'\n" },
+    'git push --force-with-lease origin HEAD:refs/heads/release/v1.2.4': { stdout: 'pushed\n' },
+    'gh pr list --state open --base main --head release/v1.2.4 --json number,url,title': { stdout: '[]\n' },
+    'gh pr create --base main --head release/v1.2.4 --title chore(release): v1.2.4 [skip ci] --body ## Summary\n- automated release PR for v1.2.4\n- bumps package metadata and resets the changelog through the protected-branch path\n- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode\n\n## Notes\n## v1.2.4 - 2026-06-18\n\n### Added\n- auto patch releases\n\n### Fixed\n- keep release idempotent\n\n### Changed\n- explain main publish contract': {
+      stdout: 'https://github.com/PapiScholz/roadmapsmith/pull/99\n'
+    }
   }, calls);
 
   const report = runAutoRelease({
@@ -243,11 +246,16 @@ test('runAutoRelease normal mode simulates bump, commit, publish, and GitHub Rel
 
   assert.equal(report.mode, 'normal');
   assert.equal(report.version, '1.2.4');
+  assert.equal(report.releaseBranch, 'release/v1.2.4');
+  assert.equal(report.pullRequest.url, 'https://github.com/PapiScholz/roadmapsmith/pull/99');
+  assert.equal(report.publication, null);
   assert.equal(JSON.parse(fs.readFileSync(path.join(fixture.packageRoot, 'package.json'), 'utf8')).version, '1.2.4');
   assert.match(fs.readFileSync(path.join(fixture.packageRoot, 'CHANGELOG.md'), 'utf8'), /## v1\.2\.4 - 2026-06-18/);
   assert.ok(calls.some((call) => call.key === 'git commit -m chore(release): v1.2.4 [skip ci]'));
-  assert.ok(calls.some((call) => call.key === 'npm publish --access public'));
-  assert.ok(calls.some((call) => call.key.startsWith('gh release create v1.2.4 --title v1.2.4 --notes-file ')));
+  assert.ok(calls.some((call) => call.key === 'git push --force-with-lease origin HEAD:refs/heads/release/v1.2.4'));
+  assert.ok(calls.some((call) => call.key.startsWith('gh pr create --base main --head release/v1.2.4 --title chore(release): v1.2.4 [skip ci] --body ')));
+  assert.ok(!calls.some((call) => call.key === 'npm publish --access public'));
+  assert.ok(!calls.some((call) => call.key.startsWith('gh release create v1.2.4 --title v1.2.4 --notes-file ')));
 });
 
 test('runAutoRelease repair mode republishes missing artifacts without a second bump or commit', () => {
@@ -294,6 +302,32 @@ test('runAutoRelease repair mode republishes missing artifacts without a second 
   assert.ok(calls.some((call) => call.key.startsWith('gh release create v1.2.4 --title v1.2.4 --notes-file ')));
 });
 
+test('runAutoRelease normal mode reuses an existing release PR when present', () => {
+  const fixture = createReleaseFixture('1.2.3');
+  const calls = [];
+  const runner = createRunner({
+    'git log -1 --pretty=%s': { stdout: 'feat: auto patch releases\n' },
+    'git describe --tags --abbrev=0': { stdout: 'v1.2.3\n' },
+    'git log --pretty=%s --reverse v1.2.3..HEAD': { stdout: 'feat: auto patch releases\n' },
+    'git checkout -B release/v1.2.4': { stdout: "Switched to branch 'release/v1.2.4'\n" },
+    'git push --force-with-lease origin HEAD:refs/heads/release/v1.2.4': { stdout: 'pushed\n' },
+    'gh pr list --state open --base main --head release/v1.2.4 --json number,url,title': {
+      stdout: '[{"number":99,"url":"https://github.com/PapiScholz/roadmapsmith/pull/99","title":"chore(release): v1.2.4 [skip ci]"}]\n'
+    }
+  }, calls);
+
+  const report = runAutoRelease({
+    runner,
+    repoRoot: fixture.repoRoot,
+    packageRoot: fixture.packageRoot,
+    now: new Date('2026-06-18T10:00:00Z')
+  });
+
+  assert.equal(report.pullRequest.number, 99);
+  assert.equal(report.pullRequest.created, false);
+  assert.ok(!calls.some((call) => call.key.startsWith('gh pr create ')));
+});
+
 test('release workflow contract keeps auto-release on push to main with serialized release concurrency', () => {
   const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
 
@@ -301,9 +335,12 @@ test('release workflow contract keeps auto-release on push to main with serializ
   assert.match(workflow, /if:\s*github\.ref == 'refs\/heads\/main' && github\.event_name == 'push'/);
   assert.match(workflow, /concurrency:\s*\n\s*group:\s*release-main/);
   assert.match(workflow, /node roadmap-skill\/scripts\/auto-release\.js/);
+  assert.match(workflow, /merge-release-pr:/);
+  assert.match(workflow, /if:\s*github\.event_name == 'pull_request' && startsWith\(github\.head_ref, 'release\/v'\)/);
+  assert.match(workflow, /gh pr merge \$\{\{ github\.event\.pull_request\.number \}\} --squash --delete-branch/);
 });
 
-test('release docs describe automatic patch publishing on every main push', () => {
+test('release docs describe the protected-branch auto-release contract', () => {
   const docs = [
     fs.readFileSync(path.join(REPO_ROOT, 'README.md'), 'utf8'),
     fs.readFileSync(path.join(REPO_ROOT, 'roadmap-skill', 'README.md'), 'utf8'),
@@ -311,6 +348,6 @@ test('release docs describe automatic patch publishing on every main push', () =
     fs.readFileSync(path.join(REPO_ROOT, 'docs', 'release-ux-gate.md'), 'utf8')
   ].join('\n');
 
-  assert.match(docs, /every successful push to `main` publishes a new patch release/i);
+  assert.match(docs, /every successful push to `main`.*automated `release\/vX\.Y\.Z` PR|protected-branch-safe release PR flow/i);
   assert.doesNotMatch(docs, /npm version patch\s+# or minor \/ major/i);
 });


### PR DESCRIPTION
## Summary
- change auto-release normal mode to open or refresh an automated `release/vX.Y.Z` PR instead of pushing directly to protected `main`
- add PR-side merge automation for release branches after tests pass
- update docs and release-automation coverage for the protected-branch contract

## Validation
- `C:\Program Files\nodejs\node.exe roadmap-skill\scripts\run-tests.js`
- `C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js qa-regression`
- `C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js functional-smoke`