### PR TITLE
fix: use release bot token for automated release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Auto-patch release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
         run: node roadmap-skill/scripts/auto-release.js
 
   merge-release-pr:
@@ -131,5 +131,5 @@ jobs:
     steps:
       - name: Merge automated release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -29,6 +29,7 @@ Release work is not ready until the docs, host UX, and changelog all reflect tha
 - Installing only `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` exposes only the legacy `/roadmap-sync` root.
 - Patch versions advance on every successful push to `main`, regardless of whether the merged change was code, docs, or release-ops only.
 - Because `main` is PR-only, the release workflow writes that version back through an automated `release/vX.Y.Z` PR that squashes into `main` as `chore(release): vX.Y.Z [skip ci]`.
+- If GitHub blocks `GITHUB_TOKEN` from creating or merging PRs, the workflow must use a dedicated secret such as `RELEASE_BOT_TOKEN` with `repo` scope.
 - `roadmapsmith doctor --json` must report `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` separately from the VS Code task/hook layer.
 - If a legacy `~/.agents/skills/roadmap-sync` install coexists with the `roadmapsmith` Codex plugin, `doctor` should flag `/roadmap-sync` as a duplicate instead of silently calling the surface healthy.
 - The published `roadmapsmith` package now mirrors the shared Codex and Claude bundle files for downstream plugin/distribution surfaces, but CLI install alone still does not auto-register either host surface.

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -357,6 +357,7 @@ Repository-specific release note:
 - The canonical release automation lives in `.github/workflows/ci.yml`.
 - Every successful push to `main` now bumps `PATCH` through an automated `release/vX.Y.Z` PR, writes the version back with the squashed bot commit `chore(release): vX.Y.Z [skip ci]`, and then the follow-up `main` run publishes npm plus the GitHub Release.
 - Repair reruns on the bot release commit do not bump again; they only publish/create any missing artifacts left behind by a partial failure.
+- On repos where GitHub blocks `GITHUB_TOKEN` from creating or merging PRs, provide a dedicated secret such as `RELEASE_BOT_TOKEN` so the protected-branch release PR flow can complete.
 - Before any push, run the dual validation gate with separate owners: `QA/Regression` uses `npm run validate:qa-regression` and `Functional/Smoke` uses `npm run validate:functional-smoke`.
 - The release gate now includes packed-artifact verification for `skills.json`, `skills/*`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and the referenced Codex assets so the published surface matches the GitHub-source bundle for both hosts.
 - Before merging to `main`, verify the UX/release gate in `docs/release-ux-gate.md` and keep `CHANGELOG.md` ready for CI-managed version section generation.

--- a/roadmap-skill/test/release-automation.test.js
+++ b/roadmap-skill/test/release-automation.test.js
@@ -338,6 +338,7 @@ test('release workflow contract keeps auto-release on push to main with serializ
   assert.match(workflow, /merge-release-pr:/);
   assert.match(workflow, /if:\s*github\.event_name == 'pull_request' && startsWith\(github\.head_ref, 'release\/v'\)/);
   assert.match(workflow, /gh pr merge \$\{\{ github\.event\.pull_request\.number \}\} --squash --delete-branch/);
+  assert.match(workflow, /GH_TOKEN:\s*\$\{\{\s*secrets\.RELEASE_BOT_TOKEN \|\| secrets\.GITHUB_TOKEN\s*\}\}/);
 });
 
 test('release docs describe the protected-branch auto-release contract', () => {


### PR DESCRIPTION
## Summary
- use `RELEASE_BOT_TOKEN` with fallback to `GITHUB_TOKEN` for automated release PR creation and merge
- document the dedicated token requirement for protected-branch release automation
- lock the workflow contract test to the new token selection

## Validation
- `C:\Program Files\nodejs\node.exe roadmap-skill\scripts\run-tests.js`
- `C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js qa-regression`
- `C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js functional-smoke`