### PR TITLE
fix: unblock release CI loop on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Merge automated release PR
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -28,7 +28,7 @@ Release work is not ready until the docs, host UX, and changelog all reflect tha
 - Recommended Claude install path is the full bundle: `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`.
 - Installing only `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` exposes only the legacy `/roadmap-sync` root.
 - Patch versions advance on every successful push to `main`, regardless of whether the merged change was code, docs, or release-ops only.
-- Because `main` is PR-only, the release workflow writes that version back through an automated `release/vX.Y.Z` PR that squashes into `main` as `chore(release): vX.Y.Z [skip ci]`.
+- Because `main` is PR-only, the release workflow writes that version back through an automated `release/vX.Y.Z` PR that squashes into `main` as `chore(release): vX.Y.Z`.
 - If GitHub blocks `GITHUB_TOKEN` from creating or merging PRs, the workflow must use a dedicated secret such as `RELEASE_BOT_TOKEN` with `repo` scope.
 - `roadmapsmith doctor --json` must report `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` separately from the VS Code task/hook layer.
 - If a legacy `~/.agents/skills/roadmap-sync` install coexists with the `roadmapsmith` Codex plugin, `doctor` should flag `/roadmap-sync` as a duplicate instead of silently calling the surface healthy.

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -56,7 +56,7 @@ npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 After updating the Claude skill bundle, run `/reload-skills` and, if applicable, `/reload-plugins`.
 After updating the CLI, rerun `roadmapsmith setup` in repositories where you want the latest VS Code tasks, task wrappers, launcher behavior, or Claude hook template. Published npm/plugin artifacts now include the Codex and Claude bundle files for downstream host loaders, but native UX still depends on the host loading the correct surface.
 
-Fixes are available through `@latest` after the automated release path completes on `main`. In this repo, a successful push to `main` now opens or refreshes an automated `release/vX.Y.Z` PR, that PR squashes back into `main` as the bot release commit, and the follow-up `main` run publishes the new patch version. Before that completes, install from a local checkout or a packed tarball for testing.
+Fixes are available through `@latest` after the automated release path completes on `main`. In this repo, a successful push to `main` now opens or refreshes an automated `release/vX.Y.Z` PR, that PR squashes back into `main` as the bot release commit `chore(release): vX.Y.Z`, and the follow-up `main` run publishes the new patch version. Before that completes, install from a local checkout or a packed tarball for testing.
 
 ## Operating Modes
 
@@ -355,7 +355,7 @@ npm test
 Repository-specific release note:
 
 - The canonical release automation lives in `.github/workflows/ci.yml`.
-- Every successful push to `main` now bumps `PATCH` through an automated `release/vX.Y.Z` PR, writes the version back with the squashed bot commit `chore(release): vX.Y.Z [skip ci]`, and then the follow-up `main` run publishes npm plus the GitHub Release.
+- Every successful push to `main` now bumps `PATCH` through an automated `release/vX.Y.Z` PR, writes the version back with the squashed bot commit `chore(release): vX.Y.Z`, and then the follow-up `main` run publishes npm plus the GitHub Release.
 - Repair reruns on the bot release commit do not bump again; they only publish/create any missing artifacts left behind by a partial failure.
 - On repos where GitHub blocks `GITHUB_TOKEN` from creating or merging PRs, provide a dedicated secret such as `RELEASE_BOT_TOKEN` so the protected-branch release PR flow can complete.
 - Before any push, run the dual validation gate with separate owners: `QA/Regression` uses `npm run validate:qa-regression` and `Functional/Smoke` uses `npm run validate:functional-smoke`.

--- a/roadmap-skill/scripts/release-version.js
+++ b/roadmap-skill/scripts/release-version.js
@@ -6,7 +6,7 @@ const { syncBundleMetadata } = require('./plugin-bundle');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, '..');
-const RELEASE_COMMIT_PATTERN = /^chore\(release\): v(\d+\.\d+\.\d+) \[skip ci\]$/;
+const RELEASE_COMMIT_PATTERN = /^chore\(release\): v(\d+\.\d+\.\d+)$/;
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -52,7 +52,7 @@ function buildReleaseTag(version) {
 }
 
 function buildReleaseCommitMessage(version) {
-  return `chore(release): ${buildReleaseTag(version)} [skip ci]`;
+  return `chore(release): ${buildReleaseTag(version)}`;
 }
 
 function detectReleaseMode(commitMessage) {

--- a/roadmap-skill/test/release-automation.test.js
+++ b/roadmap-skill/test/release-automation.test.js
@@ -156,7 +156,7 @@ test('prepareReleaseVersion keeps release commits in repair mode without bumping
   const result = prepareReleaseVersion({
     repoRoot: fixture.repoRoot,
     packageRoot: fixture.packageRoot,
-    commitMessage: 'chore(release): v1.2.4 [skip ci]',
+    commitMessage: 'chore(release): v1.2.4',
     write: true
   });
 
@@ -176,7 +176,7 @@ test('buildReleaseSection groups commits and falls back to Changed while excludi
       'fix(ci): keep release idempotent',
       'docs: explain auto patching',
       'ship the docs cleanup',
-      'chore(release): v1.2.4 [skip ci]'
+      'chore(release): v1.2.4'
     ]
   });
 
@@ -232,7 +232,7 @@ test('runAutoRelease normal mode simulates bump, commit, publish, and GitHub Rel
     'git checkout -B release/v1.2.4': { stdout: "Switched to branch 'release/v1.2.4'\n" },
     'git push --force-with-lease origin HEAD:refs/heads/release/v1.2.4': { stdout: 'pushed\n' },
     'gh pr list --state open --base main --head release/v1.2.4 --json number,url,title': { stdout: '[]\n' },
-    'gh pr create --base main --head release/v1.2.4 --title chore(release): v1.2.4 [skip ci] --body ## Summary\n- automated release PR for v1.2.4\n- bumps package metadata and resets the changelog through the protected-branch path\n- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode\n\n## Notes\n## v1.2.4 - 2026-06-18\n\n### Added\n- auto patch releases\n\n### Fixed\n- keep release idempotent\n\n### Changed\n- explain main publish contract': {
+    'gh pr create --base main --head release/v1.2.4 --title chore(release): v1.2.4 --body ## Summary\n- automated release PR for v1.2.4\n- bumps package metadata and resets the changelog through the protected-branch path\n- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode\n\n## Notes\n## v1.2.4 - 2026-06-18\n\n### Added\n- auto patch releases\n\n### Fixed\n- keep release idempotent\n\n### Changed\n- explain main publish contract': {
       stdout: 'https://github.com/PapiScholz/roadmapsmith/pull/99\n'
     }
   }, calls);
@@ -251,9 +251,9 @@ test('runAutoRelease normal mode simulates bump, commit, publish, and GitHub Rel
   assert.equal(report.publication, null);
   assert.equal(JSON.parse(fs.readFileSync(path.join(fixture.packageRoot, 'package.json'), 'utf8')).version, '1.2.4');
   assert.match(fs.readFileSync(path.join(fixture.packageRoot, 'CHANGELOG.md'), 'utf8'), /## v1\.2\.4 - 2026-06-18/);
-  assert.ok(calls.some((call) => call.key === 'git commit -m chore(release): v1.2.4 [skip ci]'));
+  assert.ok(calls.some((call) => call.key === 'git commit -m chore(release): v1.2.4'));
   assert.ok(calls.some((call) => call.key === 'git push --force-with-lease origin HEAD:refs/heads/release/v1.2.4'));
-  assert.ok(calls.some((call) => call.key.startsWith('gh pr create --base main --head release/v1.2.4 --title chore(release): v1.2.4 [skip ci] --body ')));
+  assert.ok(calls.some((call) => call.key.startsWith('gh pr create --base main --head release/v1.2.4 --title chore(release): v1.2.4 --body ')));
   assert.ok(!calls.some((call) => call.key === 'npm publish --access public'));
   assert.ok(!calls.some((call) => call.key.startsWith('gh release create v1.2.4 --title v1.2.4 --notes-file ')));
 });
@@ -280,7 +280,7 @@ test('runAutoRelease repair mode republishes missing artifacts without a second 
 
   const calls = [];
   const runner = createRunner({
-    'git log -1 --pretty=%s': { stdout: 'chore(release): v1.2.4 [skip ci]\n' },
+    'git log -1 --pretty=%s': { stdout: 'chore(release): v1.2.4\n' },
     'git rev-parse -q --verify refs/tags/v1.2.4': { stdout: 'refs/tags/v1.2.4\n' },
     'npm view roadmapsmith version': { stdout: '1.2.3\n' },
     'gh release view v1.2.4': { status: 1, stderr: 'missing release\n' }
@@ -312,7 +312,7 @@ test('runAutoRelease normal mode reuses an existing release PR when present', ()
     'git checkout -B release/v1.2.4': { stdout: "Switched to branch 'release/v1.2.4'\n" },
     'git push --force-with-lease origin HEAD:refs/heads/release/v1.2.4': { stdout: 'pushed\n' },
     'gh pr list --state open --base main --head release/v1.2.4 --json number,url,title': {
-      stdout: '[{"number":99,"url":"https://github.com/PapiScholz/roadmapsmith/pull/99","title":"chore(release): v1.2.4 [skip ci]"}]\n'
+      stdout: '[{"number":99,"url":"https://github.com/PapiScholz/roadmapsmith/pull/99","title":"chore(release): v1.2.4"}]\n'
     }
   }, calls);
 
@@ -337,7 +337,7 @@ test('release workflow contract keeps auto-release on push to main with serializ
   assert.match(workflow, /node roadmap-skill\/scripts\/auto-release\.js/);
   assert.match(workflow, /merge-release-pr:/);
   assert.match(workflow, /if:\s*github\.event_name == 'pull_request' && startsWith\(github\.head_ref, 'release\/v'\)/);
-  assert.match(workflow, /gh pr merge \$\{\{ github\.event\.pull_request\.number \}\} --squash --delete-branch/);
+  assert.match(workflow, /merge-release-pr:[\s\S]*- name: Checkout[\s\S]*actions\/checkout@v4[\s\S]*gh pr merge \$\{\{ github\.event\.pull_request\.number \}\} --squash --delete-branch/);
   assert.match(workflow, /GH_TOKEN:\s*\$\{\{\s*secrets\.RELEASE_BOT_TOKEN \|\| secrets\.GITHUB_TOKEN\s*\}\}/);
 });
 


### PR DESCRIPTION
## Summary
- remove the [skip ci] suffix from automated release commit detection and generation
- add checkout to the merge-release-pr job so gh has a git worktree
- align release docs and workflow contract tests with the real protected-main flow

## Verification
- C:\Program Files\nodejs\node.exe --test roadmap-skill\test\release-automation.test.js
- C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js qa-regression
- C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js functional-smoke