### PR TITLE
chore(release): v0.9.19

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
   "author": {
     "name": "PapiScholz"

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 - None yet.
 
+## v0.9.19 - 2026-06-18
+
+### Added
+- harden plugin bundle surfaces, preserve roadmap maintenance, and namespace slash commands (#26)
+- automate patch releases on main pushes (#27)
+
+### Fixed
+- make auto-release respect protected main (#28)
+- use release bot token for automated release PRs (#29)
+- unblock release CI loop on main (#31)
+
+### Changed
+- (release) v0.9.17 [skip ci] (#30)
+- (release) v0.9.18 (#32)
+
 ## v0.9.18 - 2026-06-18
 
 ### Added

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.9.18",
+      "version": "0.9.19",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
   "main": "src/index.js",
   "bin": {

--- a/skills.json
+++ b/skills.json
@@ -29,67 +29,67 @@
       "name": "roadmap",
       "path": "skills/roadmap",
       "description": "Native slash palette for RoadmapSmith commands and recommended entrypoints across supported hosts.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-zero",
       "path": "skills/roadmap-zero",
       "description": "Native slash entrypoint for the one-command Zero Mode CLI workflow.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-maintain",
       "path": "skills/roadmap-maintain",
       "description": "Native slash entrypoint for the preserve-first generate + sync + audit flow.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-status",
       "path": "skills/roadmap-status",
       "description": "Native slash readiness check grounded in roadmapsmith doctor JSON.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Native slash entrypoint for creating ROADMAP.md and AGENTS.md.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-generate",
       "path": "skills/roadmap-generate",
       "description": "Native slash entrypoint for managed roadmap updates that require --full-regen before destructive replacement.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-validate",
       "path": "skills/roadmap-validate",
       "description": "Native slash entrypoint for evidence-backed roadmap validation.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Native slash entrypoint for applying evidence-backed checklist sync.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-sync",
       "path": "skills/roadmap-sync",
       "description": "Legacy namespaced root plus policy guidance for RoadmapSmith slash workflows.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-audit",
       "path": "skills/roadmap-audit",
       "description": "Native slash entrypoint for the current sync-plus-audit workflow.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     },
     {
       "name": "roadmap-setup",
       "path": "skills/roadmap-setup",
       "description": "Native slash entrypoint for generating RoadmapSmith host integration files.",
-      "version": "0.9.18"
+      "version": "0.9.19"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- automated release PR for v0.9.19
- bumps package metadata and resets the changelog through the protected-branch path
- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode

## Notes
## v0.9.19 - 2026-06-18

### Added
- harden plugin bundle surfaces, preserve roadmap maintenance, and namespace slash commands (#26)
- automate patch releases on main pushes (#27)

### Fixed
- make auto-release respect protected main (#28)
- use release bot token for automated release PRs (#29)
- unblock release CI loop on main (#31)

### Changed
- (release) v0.9.17 [skip ci] (#30)
- (release) v0.9.18 (#32)