### PR TITLE
fix: detect release squash commits in repair mode

### DIFF
--- a/roadmap-skill/scripts/release-version.js
+++ b/roadmap-skill/scripts/release-version.js
@@ -6,7 +6,7 @@ const { syncBundleMetadata } = require('./plugin-bundle');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, '..');
-const RELEASE_COMMIT_PATTERN = /^chore\(release\): v(\d+\.\d+\.\d+)$/;
+const RELEASE_COMMIT_PATTERN = /^chore\(release\): v(\d+\.\d+\.\d+)(?: \(#\d+\))?$/;
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));

--- a/roadmap-skill/test/release-automation.test.js
+++ b/roadmap-skill/test/release-automation.test.js
@@ -156,7 +156,7 @@ test('prepareReleaseVersion keeps release commits in repair mode without bumping
   const result = prepareReleaseVersion({
     repoRoot: fixture.repoRoot,
     packageRoot: fixture.packageRoot,
-    commitMessage: 'chore(release): v1.2.4',
+    commitMessage: 'chore(release): v1.2.4 (#99)',
     write: true
   });
 
@@ -280,7 +280,7 @@ test('runAutoRelease repair mode republishes missing artifacts without a second 
 
   const calls = [];
   const runner = createRunner({
-    'git log -1 --pretty=%s': { stdout: 'chore(release): v1.2.4\n' },
+    'git log -1 --pretty=%s': { stdout: 'chore(release): v1.2.4 (#99)\n' },
     'git rev-parse -q --verify refs/tags/v1.2.4': { stdout: 'refs/tags/v1.2.4\n' },
     'npm view roadmapsmith version': { stdout: '1.2.3\n' },
     'gh release view v1.2.4': { status: 1, stderr: 'missing release\n' }


### PR DESCRIPTION
## Summary
- accept GitHub squash-merge release subjects like chore(release): vX.Y.Z (#NN)
- keep repair mode from opening a fresh release branch when the release PR has already merged
- extend release automation coverage for the real merged subject shape

## Verification
- C:\Program Files\nodejs\node.exe --test roadmap-skill\test\release-automation.test.js
- C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js qa-regression
- C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js functional-smoke