### PR TITLE
fix: stabilize self-hosting roadmap maintenance

### DIFF
--- a/roadmap-skill/scripts/pre-push-gate.js
+++ b/roadmap-skill/scripts/pre-push-gate.js
@@ -11,6 +11,7 @@ const LAUNCHER_PATH = path.join(REPO_ROOT, '.vscode', 'roadmapsmith-launcher.js'
 const TEST_RUNNER_PATH = path.join(PACKAGE_ROOT, 'scripts', 'run-tests.js');
 const ELECTRON_FIXTURE_ROOT = path.join(PACKAGE_ROOT, 'test', 'fixtures', 'electron-pos');
 const ELECTRON_FIXTURE_ROADMAP = path.join(ELECTRON_FIXTURE_ROOT, 'ROADMAP.md');
+const SELF_HOSTING_ROADMAP = path.join(REPO_ROOT, 'ROADMAP.md');
 const GATE_PROFILE = 'Amplio';
 
 function readText(filePath) {
@@ -109,6 +110,24 @@ function buildFunctionalSmokeChecks(nodePath = process.execPath) {
         assert(/Audit summary:/i.test(result.stdout), 'maintain --dry-run must still run sync/audit.');
         assert(!/Add SEO metadata|Lighthouse performance score/i.test(result.stdout), 'Electron fixture smoke must not surface web-only tasks.');
         assert(readText(ELECTRON_FIXTURE_ROADMAP) === context.roadmapBefore, 'maintain --dry-run must not mutate the Electron fixture roadmap.');
+      }
+    },
+    {
+      id: 'maintain-dry-run-self-hosting',
+      label: 'Maintain preserve-mode dry-run on the RoadmapSmith repo',
+      command: nodePath,
+      args: [CLI_PATH, 'maintain', '--project-root', REPO_ROOT, '--dry-run'],
+      cwd: PACKAGE_ROOT,
+      covers: ['self-hosting roadmap', 'preserve-mode no diff', 'generic backlog suppression'],
+      prepare() {
+        return { roadmapBefore: readText(SELF_HOSTING_ROADMAP) };
+      },
+      validate(result, context) {
+        assert(result.status === 0, 'maintain --dry-run must exit 0 on the RoadmapSmith repo.');
+        assert(/No changes for .*ROADMAP\.md/i.test(result.stdout), 'self-hosting maintain dry-run must report no roadmap changes.');
+        assert(/Audit summary:/i.test(result.stdout), 'self-hosting maintain dry-run must still run sync/audit.');
+        assert(!/Add SEO metadata|Lighthouse performance score|responsive and mobile-first layout|accessibility baseline/i.test(result.stdout), 'self-hosting maintain dry-run must not surface generic web backlog.');
+        assert(readText(SELF_HOSTING_ROADMAP) === context.roadmapBefore, 'self-hosting maintain --dry-run must not mutate the repo roadmap.');
       }
     },
     {

--- a/roadmap-skill/src/classifier/index.js
+++ b/roadmap-skill/src/classifier/index.js
@@ -21,6 +21,7 @@ const ELECTRON_CONFIGS = [
   'forge.config.ts'
 ];
 const LANDING_ROUTE_RE = /(?:^|\/)(?:contact|services|about|pricing|hero|cta|landing)(?:\/|\.)/i;
+const FIXTURE_PATH_RE = /(^|\/)(?:test|tests)\/fixtures\//i;
 
 function readPackageDeps(projectRoot) {
   if (!projectRoot) return [];
@@ -52,6 +53,9 @@ function hasWorkspaces(projectRoot) {
 }
 
 function classifyProject({ projectRoot, files }) {
+  const candidateFiles = Array.isArray(files)
+    ? files.filter((file) => !FIXTURE_PATH_RE.test(String(file || '')))
+    : [];
   const signals = [];
 
   if (hasWorkspaces(projectRoot)) {
@@ -59,8 +63,8 @@ function classifyProject({ projectRoot, files }) {
     return { type: 'monorepo', confidence: 'high', signals };
   }
 
-  const hasPy = hasFilename(files, 'pyproject.toml') || hasFilename(files, 'setup.py');
-  if (hasPy && !files.some((f) => /\.[jt]sx?$/.test(f))) {
+  const hasPy = hasFilename(candidateFiles, 'pyproject.toml') || hasFilename(candidateFiles, 'setup.py');
+  if (hasPy && !candidateFiles.some((f) => /\.[jt]sx?$/.test(f))) {
     signals.push('pyproject.toml / setup.py, no JS files');
     return { type: 'python-package', confidence: 'high', signals };
   }
@@ -82,72 +86,72 @@ function classifyProject({ projectRoot, files }) {
   }
 
   for (const dir of WEB_DIRS) {
-    if (hasDir(files, dir)) {
+    if (hasDir(candidateFiles, dir)) {
       webScore += 2;
       signals.push(`directory: ${dir.replace(/\/$/, '')}`);
     }
   }
 
   for (const dir of ASSET_DIRS) {
-    if (hasDir(files, dir)) {
+    if (hasDir(candidateFiles, dir)) {
       webScore += 1;
       signals.push(`directory: ${dir.replace(/\/$/, '')}`);
     }
   }
 
-  if (hasDir(files, 'electron/')) {
+  if (hasDir(candidateFiles, 'electron/')) {
     electronScore += 3;
     signals.push('directory: electron');
   }
 
-  if (files.some((file) => /^electron\/.+\.(js|ts|cjs|mjs)$/.test(file))) {
+  if (candidateFiles.some((file) => /^electron\/.+\.(js|ts|cjs|mjs)$/.test(file))) {
     electronScore += 2;
     signals.push('electron main/preload sources');
   }
 
   for (const cfg of ELECTRON_CONFIGS) {
-    if (hasFilename(files, cfg)) {
+    if (hasFilename(candidateFiles, cfg)) {
       electronScore += 2;
       signals.push(`config: ${cfg}`);
     }
   }
 
   for (const cfg of WEB_CONFIGS) {
-    if (hasFilename(files, cfg)) {
+    if (hasFilename(candidateFiles, cfg)) {
       webScore += 3;
       signals.push(`config: ${cfg}`);
     }
   }
 
   for (const cfg of STYLE_CONFIGS) {
-    if (hasFilename(files, cfg)) {
+    if (hasFilename(candidateFiles, cfg)) {
       webScore += 1;
       signals.push(`config: ${cfg}`);
     }
   }
 
-  if (files.some((f) => /\.css$/.test(f))) {
+  if (candidateFiles.some((f) => /\.css$/.test(f))) {
     webScore += 1;
     signals.push('CSS files present');
   }
 
-  const landingRoutes = files.filter((f) => LANDING_ROUTE_RE.test(f));
+  const landingRoutes = candidateFiles.filter((f) => LANDING_ROUTE_RE.test(f));
   if (landingRoutes.length > 0) {
     landingScore += landingRoutes.length * 2;
     signals.push(`landing/service routes: ${landingRoutes.length}`);
   }
 
-  if (hasFilename(files, 'favicon.ico') || hasFilename(files, 'logo.png') || hasFilename(files, 'logo.svg')) {
+  if (hasFilename(candidateFiles, 'favicon.ico') || hasFilename(candidateFiles, 'logo.png') || hasFilename(candidateFiles, 'logo.svg')) {
     landingScore += 1;
     signals.push('branding asset in public/');
   }
 
-  if (webScore === 0 && (files.some((f) => f.startsWith('bin/')) || hasFilename(files, 'cli.js'))) {
+  if (webScore === 0 && (candidateFiles.some((f) => f.startsWith('bin/')) || hasFilename(candidateFiles, 'cli.js'))) {
     signals.push('bin/ directory or cli.js');
     return { type: 'cli-tool', confidence: 'medium', signals };
   }
 
-  if (webScore === 0 && hasFilename(files, 'package.json')) {
+  if (webScore === 0 && hasFilename(candidateFiles, 'package.json')) {
     signals.push('package.json, no web signals');
     return { type: 'npm-package', confidence: 'low', signals };
   }

--- a/roadmap-skill/src/generator/index.js
+++ b/roadmap-skill/src/generator/index.js
@@ -207,6 +207,10 @@ function renderAdditionTask(task) {
   return `- [ ] ${task.text} <!-- rs:task=${task.id} -->`;
 }
 
+function isGenericPreserveModeCandidate(candidate) {
+  return candidate && ['default', 'classifier', 'todo-hint'].includes(candidate.source);
+}
+
 function buildManagedAdditionsLines(tasks, options = {}) {
   const groups = groupByPhase(tasks);
   const lines = [];
@@ -463,6 +467,10 @@ function insertPreserveModeTasks(existingContent, parsedRoadmap, tasks) {
   }
 
   return nextLines.join('\n');
+}
+
+function filterPreserveModeCandidates(candidates) {
+  return candidates.filter((candidate) => !isGenericPreserveModeCandidate(candidate));
 }
 
 function mergeWithExisting(candidates, existingTasks, options = {}) {
@@ -810,14 +818,18 @@ function generateRoadmapDocument(options) {
 
   if (hasSubstantiveManagedBlock(existing) && preserveManagedBlock && !forceFullRegenerate) {
     const unmatchedCandidates = allCandidates.filter((candidate) => {
-      return !findBestTaskMatch(candidate, existingManagedTasks, { allowFuzzy: false });
+      return !findBestTaskMatch(candidate, existingManagedTasks, {
+        allowFuzzy: true,
+        minScore: 0.72
+      });
     });
+    const preserveModeCandidates = filterPreserveModeCandidates(unmatchedCandidates);
 
-    if (unmatchedCandidates.length === 0) {
+    if (preserveModeCandidates.length === 0) {
       return existingContent;
     }
 
-    return insertPreserveModeTasks(existingContent, existing, unmatchedCandidates);
+    return insertPreserveModeTasks(existingContent, existing, preserveModeCandidates);
   }
 
   if (hasSubstantiveManagedBlock(existing) && !forceFullRegenerate) {

--- a/roadmap-skill/test/classifier.test.js
+++ b/roadmap-skill/test/classifier.test.js
@@ -49,6 +49,23 @@ test('classifier identifies Electron fixtures as electron-app instead of web', (
   assert.notEqual(result.type, 'landing-site');
 });
 
+test('classifier ignores nested landing-site fixtures when scanning a repo-like project', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-classifier-nested-fixtures-'));
+  fs.mkdirSync(path.join(projectRoot, 'assets'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, 'test', 'fixtures', 'landing-site', 'app', 'contact'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'package.json'), JSON.stringify({ name: 'repo-like', version: '1.0.0' }, null, 2));
+  fs.writeFileSync(path.join(projectRoot, 'assets', 'palette.png'), 'asset\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, 'test', 'fixtures', 'landing-site', 'next.config.js'), 'module.exports = {};\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, 'test', 'fixtures', 'landing-site', 'tailwind.config.js'), 'module.exports = {};\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, 'test', 'fixtures', 'landing-site', 'app', 'contact', 'page.tsx'), 'export default function Page() { return null; }\n', 'utf8');
+
+  const files = walkFiles(projectRoot);
+  const result = classifyProject({ projectRoot, files });
+
+  assert.notEqual(result.type, 'landing-site');
+  assert.notEqual(result.type, 'frontend-web');
+});
+
 test('classifier returns unknown-generic for empty project', () => {
   const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-empty-'));
   const result = classifyProject({ projectRoot, files: [] });

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -9,6 +9,7 @@ const assert = require('node:assert/strict');
 
 const CLI = path.resolve(__dirname, '..', 'bin', 'cli.js');
 const LAUNCHER = path.resolve(__dirname, '..', '..', '.vscode', 'roadmapsmith-launcher.js');
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const CANONICAL_ROADMAP = 'ROADMAP.md';
 const LEGACY_ROADMAP = 'roadmap.md';
 const CASE_DISTINCT_ROADMAP_FILES = supportsCaseDistinctRoadmapFiles();
@@ -294,6 +295,29 @@ test('cli maintain preserves a substantive custom managed block for Electron des
   assert.match(content, /#### Paso operativo/);
   assert.doesNotMatch(content, /Add SEO metadata/i);
   assert.doesNotMatch(content, /Lighthouse performance score/i);
+});
+
+test('cli maintain --dry-run is stable for the RoadmapSmith repo roadmap', () => {
+  const before = fs.readFileSync(path.join(REPO_ROOT, CANONICAL_ROADMAP), 'utf8');
+  const result = runResult(['maintain', '--project-root', REPO_ROOT, '--dry-run'], REPO_ROOT);
+  const after = fs.readFileSync(path.join(REPO_ROOT, CANONICAL_ROADMAP), 'utf8');
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /No changes for .*ROADMAP\.md/);
+  assert.match(result.stdout, /Audit summary:/);
+  assert.doesNotMatch(result.stdout, /Add SEO metadata|Lighthouse performance score|responsive and mobile-first layout|accessibility baseline/i);
+  assert.equal(after, before);
+});
+
+test('cli /roadmap-update --dry-run is stable for the RoadmapSmith repo roadmap', () => {
+  const before = fs.readFileSync(path.join(REPO_ROOT, CANONICAL_ROADMAP), 'utf8');
+  const result = runResult(['/roadmap-update', '--project-root', REPO_ROOT, '--dry-run'], REPO_ROOT);
+  const after = fs.readFileSync(path.join(REPO_ROOT, CANONICAL_ROADMAP), 'utf8');
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /No changes for .*ROADMAP\.md|Dry run: .*ROADMAP\.md/i);
+  assert.doesNotMatch(result.stdout, /Add SEO metadata|Lighthouse performance score|responsive and mobile-first layout|accessibility baseline/i);
+  assert.equal(after, before);
 });
 
 test('cli generate refuses to replace a substantive custom managed block without --full-regen', () => {

--- a/roadmap-skill/test/generator.test.js
+++ b/roadmap-skill/test/generator.test.js
@@ -183,6 +183,26 @@ test('maintain preserve mode keeps authored north star, phase headings, and evid
   assert.doesNotMatch(output, /Lighthouse performance score/i);
 });
 
+test('maintain preserve mode leaves the RoadmapSmith repo roadmap unchanged', () => {
+  const projectRoot = path.resolve(__dirname, '..', '..');
+  const config = loadConfig({ projectRoot });
+  const existingContent = fs.readFileSync(path.join(projectRoot, 'ROADMAP.md'), 'utf8');
+
+  const output = generateRoadmapDocument({
+    projectRoot,
+    existingContent,
+    config,
+    plugins: [],
+    preserveManagedBlock: true
+  });
+
+  assert.equal(output, existingContent);
+  assert.doesNotMatch(output, /Add SEO metadata/i);
+  assert.doesNotMatch(output, /Lighthouse performance score/i);
+  assert.doesNotMatch(output, /accessibility baseline/i);
+  assert.doesNotMatch(output, /responsive and mobile-first layout/i);
+});
+
 test('regenerate intentionally rebuilds a substantive custom managed block', () => {
   const projectRoot = setupFixture('electron-pos');
   const config = loadConfig({ projectRoot });

--- a/roadmap-skill/test/pre-push-gate.test.js
+++ b/roadmap-skill/test/pre-push-gate.test.js
@@ -38,6 +38,7 @@ test('functional-smoke plan covers preserve safety, slash flows, and launcher sm
   assert.equal(report.status, 'planned');
   assert.deepEqual(ids, [
     'maintain-dry-run-electron',
+    'maintain-dry-run-self-hosting',
     'doctor-json',
     'direct-slash-update-dry-run',
     'generate-refuses-without-full-regen',


### PR DESCRIPTION
## Summary
- keep RoadmapSmith self-hosting repos out of generic landing-site classification by ignoring nested test fixtures during project detection
- harden preserve-mode so mature managed roadmaps skip generic default/classifier backlog insertion when no safe phase-compatible target exists
- add self-hosting regression coverage and extend the pre-push functional smoke gate to require a no-diff maintain dry-run on the repo itself

## Test Plan
- C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js qa-regression
- C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js functional-smoke
- C:\Program Files\nodejs\node.exe roadmap-skill\scripts\pre-push-gate.js all --json
