### PR TITLE
fix: tighten roadmap sync warning semantics

### DIFF
--- a/roadmap-skill/scripts/verify-pack-surface.js
+++ b/roadmap-skill/scripts/verify-pack-surface.js
@@ -52,18 +52,35 @@ function parsePackJson(raw) {
   }
 }
 
-function runNpmPackJson(packDestination) {
-  const npmInvocation = resolveNpmInvocation();
-  const raw = execFileSync(
-    npmInvocation.command,
-    [...npmInvocation.prefixArgs, 'pack', '--json', '--pack-destination', packDestination],
-    {
-      cwd: PACKAGE_ROOT,
-      encoding: 'utf8'
-    }
-  );
+function buildNpmPackEnv(cacheDirectory) {
+  return {
+    ...process.env,
+    npm_config_cache: cacheDirectory
+  };
+}
 
-  return parsePackJson(raw);
+function runNpmPackJson(packDestination, options = {}) {
+  const npmInvocation = resolveNpmInvocation();
+  const cacheDirectory = options.cacheDirectory || fs.mkdtempSync(path.join(os.tmpdir(), 'roadmapsmith-npm-cache-'));
+  const ownsCacheDirectory = !options.cacheDirectory;
+  fs.mkdirSync(cacheDirectory, { recursive: true });
+  try {
+    const raw = execFileSync(
+      npmInvocation.command,
+      [...npmInvocation.prefixArgs, 'pack', '--json', '--pack-destination', packDestination],
+      {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf8',
+        env: buildNpmPackEnv(cacheDirectory)
+      }
+    );
+
+    return parsePackJson(raw);
+  } finally {
+    if (ownsCacheDirectory) {
+      fs.rmSync(cacheDirectory, { recursive: true, force: true });
+    }
+  }
 }
 
 function assertPackSurface(files) {
@@ -125,6 +142,7 @@ if (require.main === module) {
 
 module.exports = {
   assertPackSurface,
+  buildNpmPackEnv,
   parsePackJson,
   resolveNpmInvocation,
   runNpmPackJson

--- a/roadmap-skill/src/sync/index.js
+++ b/roadmap-skill/src/sync/index.js
@@ -13,13 +13,65 @@ function formatWarning(indent, reason) {
   return `${indent}  - ⚠️ attempted but validation failed: ${reason}`;
 }
 
+function isWhitespaceCharacter(char) {
+  return char === ' ' || char === '\t' || char === '\n' || char === '\r' || char === '\f' || char === '\v';
+}
+
+function stripLeadingWarningMarker(value) {
+  let index = 0;
+  const source = String(value || '');
+  while (index < source.length && isWhitespaceCharacter(source[index])) {
+    index += 1;
+  }
+  if (source.slice(index, index + 2) === '⚠️') {
+    index += 2;
+  }
+  while (index < source.length && isWhitespaceCharacter(source[index])) {
+    index += 1;
+  }
+  return source.slice(index);
+}
+
+function splitWarningReasonSegments(value) {
+  const source = String(value || '');
+  const segments = [];
+  let current = '';
+  let index = 0;
+
+  while (index < source.length) {
+    const char = source[index];
+    if (char === ';') {
+      const trimmed = current.trim();
+      if (trimmed) {
+        segments.push(trimmed);
+      }
+      current = '';
+      index += 1;
+      while (index < source.length && isWhitespaceCharacter(source[index])) {
+        index += 1;
+      }
+      continue;
+    }
+
+    current += char;
+    index += 1;
+  }
+
+  const trimmed = current.trim();
+  if (trimmed) {
+    segments.push(trimmed);
+  }
+
+  return segments;
+}
+
 function normalizeWarningReason(reason) {
   let normalized = String(reason || '').trim();
   if (!normalized) {
     return '';
   }
 
-  normalized = normalized.replace(/^⚠️\s*/, '').trim();
+  normalized = stripLeadingWarningMarker(normalized).trim();
   const prefixIndex = normalized.indexOf(WARNING_REASON_PREFIX);
   if (prefixIndex >= 0) {
     normalized = normalized.slice(prefixIndex + WARNING_REASON_PREFIX.length).trim();
@@ -32,7 +84,7 @@ function normalizeWarningReasons(reasons) {
   const normalized = [];
   const seen = new Set();
   for (const reason of Array.isArray(reasons) ? reasons : [reasons]) {
-    for (const chunk of String(reason || '').split(/\s*;\s*/)) {
+    for (const chunk of splitWarningReasonSegments(reason)) {
       const clean = normalizeWarningReason(chunk);
       if (!clean || seen.has(clean)) {
         continue;

--- a/roadmap-skill/src/sync/index.js
+++ b/roadmap-skill/src/sync/index.js
@@ -3,12 +3,51 @@
 const { parseRoadmap } = require('../parser');
 const { ensureTrailingNewline } = require('../utils');
 
+const WARNING_REASON_PREFIX = 'attempted but validation failed:';
+
 function setChecklistState(line, checked) {
   return line.replace(/- \[( |x|X)\]/, `- [${checked ? 'x' : ' '}]`);
 }
 
 function formatWarning(indent, reason) {
   return `${indent}  - ⚠️ attempted but validation failed: ${reason}`;
+}
+
+function normalizeWarningReason(reason) {
+  let normalized = String(reason || '').trim();
+  if (!normalized) {
+    return '';
+  }
+
+  normalized = normalized.replace(/^⚠️\s*/, '').trim();
+  const prefixIndex = normalized.indexOf(WARNING_REASON_PREFIX);
+  if (prefixIndex >= 0) {
+    normalized = normalized.slice(prefixIndex + WARNING_REASON_PREFIX.length).trim();
+  }
+
+  return normalized;
+}
+
+function normalizeWarningReasons(reasons) {
+  const normalized = [];
+  const seen = new Set();
+  for (const reason of Array.isArray(reasons) ? reasons : [reasons]) {
+    for (const chunk of String(reason || '').split(/\s*;\s*/)) {
+      const clean = normalizeWarningReason(chunk);
+      if (!clean || seen.has(clean)) {
+        continue;
+      }
+      seen.add(clean);
+      normalized.push(clean);
+    }
+  }
+  return normalized;
+}
+
+function shouldPreserveExistingWarning(existingReason, newReason) {
+  const cleanExisting = normalizeWarningReason(existingReason);
+  const cleanNew = normalizeWarningReason(newReason) || 'validation failed';
+  return cleanNew === 'validation failed' && cleanExisting && cleanExisting !== cleanNew;
 }
 
 function applySync(content, parsedTasks, results) {
@@ -30,7 +69,7 @@ function applySync(content, parsedTasks, results) {
 
     lines[lineIndex] = setChecklistState(lines[lineIndex], result.passed);
 
-    const reason = result.reasons.join('; ');
+    const reason = normalizeWarningReasons(result.reasons).join('; ');
     const warningText = formatWarning(task.indent || '', reason || 'validation failed');
     const hasWarning = task.warningLineIndex != null;
     const warningIndex = hasWarning ? task.warningLineIndex + offset : null;
@@ -47,9 +86,7 @@ function applySync(content, parsedTasks, results) {
     if (warningIndex != null && warningIndex >= 0 && warningIndex < lines.length) {
       const existingReason = lines[warningIndex].split('validation failed:')[1];
       const newReason = reason || 'validation failed';
-      // Preserve existing warning when it's more descriptive than the new generic message.
-      const existingIsMoreSpecific = existingReason && existingReason.trim().length > newReason.length;
-      if (!existingIsMoreSpecific) {
+      if (!shouldPreserveExistingWarning(existingReason, newReason)) {
         lines[warningIndex] = warningText;
       }
     } else {

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -373,6 +373,10 @@ function isDocTask(taskText) {
   return /\b(add|create|write|update|init|initialize|introduce|setup|document)\b/.test(normalized);
 }
 
+function isImplementationTask(taskText) {
+  return !isDocTask(taskText) && (isCodeTask(taskText) || taskDescribesChange(taskText));
+}
+
 function findFilesByPathHints(pathHints, fileIndex) {
   const matches = [];
   for (const hint of pathHints) {
@@ -1177,7 +1181,13 @@ function validateTask(task, context, config, plugins) {
     uniqueReasons = Array.isArray(overrideResult.reasons) ? Array.from(new Set(overrideResult.reasons)) : [];
   }
 
-  const attempted = hasStrongEvidence || hasWeakEvidence || pathHints.length > 0 || symbolHints.length > 0 || authoritativeEvidence.active;
+  const hasConcreteReferenceEvidence = filesFromPurePathHints.length > 0 || filesFromSymbols.length > 0;
+  const attempted = authoritativeEvidence.active
+    || hasRuleGrantedEvidence
+    || evidence.code
+    || evidence.test
+    || evidence.artifact
+    || hasConcreteReferenceEvidence;
   const { categories: strongEvidenceCategories } = countStrongEvidenceCategories(task.text, evidence);
   const strongEvidenceCount = strongEvidenceCategories.length;
   // Only pure path hints (not line-reference hints like file.ts:169) count as direct evidence.
@@ -1220,6 +1230,7 @@ function validateTask(task, context, config, plugins) {
   // WHERE to implement, not that implementation is done. Unchecked tasks need authoritative
   // evidence, artifact evidence, or strong code+test threshold to pass.
   // Already-checked tasks with found path hints are preserved via shouldPreserveCheckedTask.
+  const hasHighConfidenceImplementationEvidence = meetsStrongThreshold && evidence.code && evidence.test;
   let passed = authoritativeEvidence.passed || hasArtifactTaskPass || hasTrustedRuleEvidencePass || meetsStrongThreshold;
 
   if (!passed && !task.checked && hasDirectReferencePass) {
@@ -1234,30 +1245,29 @@ function validateTask(task, context, config, plugins) {
   // human/agent judgment that the feature is incomplete.
   if (task.warningText && !task.checked && passed && !authoritativeEvidence.passed) {
     passed = false;
-    uniqueReasons.push(task.warningText);
-    uniqueReasons = Array.from(new Set(uniqueReasons));
+    if (uniqueReasons.length === 0) {
+      uniqueReasons.push('validation failed');
+    }
   }
   if (negativeSignalMatches.length > 0) {
     passed = false;
   }
 
-  // Action-verb gate (Causa 3): unchecked tasks that describe a change to be made
-  // (Agregar, Configurar, Add, Fix, Manejo, Recovery path, …) cannot pass on code token overlap alone.
-  // Requires either: an Evidence line (authoritativeEvidence.passed), high-confidence evidence
-  // (code + test), grant-evidence from config (hasTrustedRuleEvidencePass), or canonical artifact
-  // evidence (hasArtifactTaskPass — e.g. "Add SECURITY.md").
+  // Unchecked implementation tasks need explicit evidence or high-confidence implementation
+  // evidence. Weak token overlap, direct file references, or code-only matches are not enough.
   if (
     !task.checked &&
     passed &&
-    taskDescribesChange(task.text) &&
+    isImplementationTask(task.text) &&
     !authoritativeEvidence.passed &&
     !hasTrustedRuleEvidencePass &&
-    !hasArtifactTaskPass
+    !hasArtifactTaskPass &&
+    !hasHighConfidenceImplementationEvidence
   ) {
     passed = false;
-    const actionVerbReason = 'action task requires Evidence line or high-confidence evidence (code + test) to be marked complete';
-    if (!uniqueReasons.includes(actionVerbReason)) {
-      uniqueReasons.push(actionVerbReason);
+    const implementationReason = 'implementation task requires Evidence line or high-confidence evidence (code + test) to be marked complete';
+    if (!uniqueReasons.includes(implementationReason)) {
+      uniqueReasons.push(implementationReason);
     }
   }
 

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -79,6 +79,13 @@ function writePackageJson(projectRoot) {
   fs.writeFileSync(path.join(projectRoot, 'package.json'), JSON.stringify({ name: 'x', version: '1.0.0' }, null, 2));
 }
 
+function setupFixture(name) {
+  const source = path.resolve(__dirname, 'fixtures', name);
+  const target = fs.mkdtempSync(path.join(os.tmpdir(), `roadmap-skill-cli-${name}-`));
+  fs.cpSync(source, target, { recursive: true });
+  return target;
+}
+
 function writeWorkspaceCliShim(projectRoot) {
   const cliShimPath = path.join(projectRoot, 'roadmap-skill', 'bin', 'cli.js');
   fs.mkdirSync(path.dirname(cliShimPath), { recursive: true });
@@ -320,6 +327,34 @@ test('cli /roadmap-update --dry-run is stable for the RoadmapSmith repo roadmap'
   assert.equal(after, before);
 });
 
+test('cli /roadmap-update and /roadmap-sync update share stable warning output', () => {
+  const projectRoot = setupFixture('warning-sync');
+  fs.writeFileSync(
+    path.join(projectRoot, CANONICAL_ROADMAP),
+    [
+      '## Phase P1',
+      '- [ ] Implement backup database module for GET /api/backup <!-- rs:task=implement-backup-module -->',
+      '  - Evidence: src/missing-backup.js',
+      '  - ⚠️ attempted but validation failed: evidence file(s) not found: src/missing-backup.js; evidence file(s) not found: src/missing-backup.js',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  const before = fs.readFileSync(path.join(projectRoot, CANONICAL_ROADMAP), 'utf8');
+  const namespaced = runResult(['/roadmap-update', '--project-root', projectRoot, '--dry-run'], projectRoot);
+  const legacy = runResult(['/roadmap-sync', 'update', '--project-root', projectRoot, '--dry-run'], projectRoot);
+  const after = fs.readFileSync(path.join(projectRoot, CANONICAL_ROADMAP), 'utf8');
+
+  assert.equal(namespaced.status, 0);
+  assert.equal(legacy.status, 0);
+  assert.equal(after, before);
+  assert.equal(legacy.stdout, namespaced.stdout);
+  assert.match(legacy.stderr, /deprecated/i);
+  assert.match(namespaced.stdout, /L4 \+   - ⚠️ attempted but validation failed: evidence file\(s\) not found: src\/missing-backup\.js/);
+  assert.doesNotMatch(namespaced.stdout, /L4 \+.*evidence file\(s\) not found: src\/missing-backup\.js; evidence file\(s\) not found: src\/missing-backup\.js/);
+});
+
 test('cli generate refuses to replace a substantive custom managed block without --full-regen', () => {
   const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-generate-refuse-'));
   writePackageJson(projectRoot);
@@ -496,13 +531,13 @@ test('cli sync preserves existing managed block structure on weak path-only fail
   const content = fs.readFileSync(path.join(projectRoot, CANONICAL_ROADMAP), 'utf8');
   const warningMatches = content.match(/⚠️ attempted but validation failed/g) || [];
 
-  assert.equal(warningMatches.length, 1);
+  assert.equal(warningMatches.length, 0);
   assert.match(content, /## Phase Alfa: Desktop Shell Comercial/);
   assert.match(content, /Contexto de negocio: el shell Electron mantiene Next\.js embebido para demos offline\./);
   assert.match(content, /### Criterio de avance/);
   assert.match(content, /La experiencia de escritorio debe iniciar sin depender de servicios externos\./);
   assert.match(content, /- \[ \] Configurar Electron con Next\.js como servidor embebido/);
-  assert.match(content, /weak path-only evidence lacks content-specific token match/);
+  assert.doesNotMatch(content, /weak path-only evidence lacks content-specific token match/);
   assert.match(content, /- \[ \] Implement app module <!-- rs:task=outside-implement-app-module -->/);
   assert.doesNotMatch(content, /Add SEO metadata/);
   assert.doesNotMatch(content, /Implement responsive/);

--- a/roadmap-skill/test/fixtures/warning-sync/package.json
+++ b/roadmap-skill/test/fixtures/warning-sync/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixture-warning-sync",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/roadmap-skill/test/fixtures/warning-sync/src/backup.js
+++ b/roadmap-skill/test/fixtures/warning-sync/src/backup.js
@@ -1,0 +1,3 @@
+export async function backupDatabase() {
+  return { ok: true };
+}

--- a/roadmap-skill/test/package-surface.test.js
+++ b/roadmap-skill/test/package-surface.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { execFileSync } = require('child_process');
+const { buildNpmPackEnv } = require('../scripts/verify-pack-surface');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
@@ -28,6 +29,12 @@ function resolveNpmRunInvocation() {
     args: ['run', 'verify-pack-surface', '--silent']
   };
 }
+
+test('verify-pack-surface forces npm pack to use a dedicated cache directory', () => {
+  const env = buildNpmPackEnv(path.join(PACKAGE_ROOT, '.tmp-pack-cache'));
+
+  assert.equal(env.npm_config_cache, path.join(PACKAGE_ROOT, '.tmp-pack-cache'));
+});
 
 test('npm pack includes the full Codex and Claude bundle surface', (t) => {
   if (!process.env.npm_execpath) {

--- a/roadmap-skill/test/sync.test.js
+++ b/roadmap-skill/test/sync.test.js
@@ -78,7 +78,7 @@ test('sync inserts warning after Evidence lines when validation fails', () => {
   assert.match(next, /  - Evidence: src\/lib\/inventory-sync\.ts\n  - ⚠️ attempted but validation failed: evidence file\(s\) not found: src\/lib\/inventory-sync\.ts/);
 });
 
-test('sync leaves weak path-only Mercado Pago Point task unchecked with warning', () => {
+test('sync leaves weak path-only Mercado Pago Point task unchecked without warning', () => {
   const projectRoot = setupFixture('generic');
   fs.mkdirSync(path.join(projectRoot, 'src', 'app', 'api', 'mercadopago', 'preference'), { recursive: true });
   fs.writeFileSync(
@@ -108,9 +108,9 @@ test('sync leaves weak path-only Mercado Pago Point task unchecked with warning'
   const second = applySync(first, secondParsed.tasks, results);
 
   const warningMatches = second.match(/⚠️ attempted but validation failed/g) || [];
-  assert.equal(warningMatches.length, 1);
+  assert.equal(warningMatches.length, 0);
   assert.match(second, /- \[ \] Integración Mercado Pago Point/);
-  assert.match(second, /weak path-only evidence lacks content-specific token match/);
+  assert.doesNotMatch(second, /weak path-only evidence lacks content-specific token match/);
 });
 
 test('sync pipeline: low-confidence task stays unchecked when minimumConfidence is medium', () => {
@@ -136,7 +136,7 @@ test('sync pipeline: high-confidence task gets checked when minimumConfidence is
   assert.ok(next.includes('- [x] implement xyzzy module'), 'Task should be checked');
 });
 
-test('sync does not overwrite an existing warning with checked state on weak evidence', () => {
+test('sync removes stale warning when the task has no real attempt signal', () => {
   const projectRoot = setupFixture('generic');
   fs.mkdirSync(path.join(projectRoot, 'src', 'app', 'api', 'mercadopago', 'preference'), { recursive: true });
   fs.writeFileSync(
@@ -164,7 +164,7 @@ test('sync does not overwrite an existing warning with checked state on weak evi
   const next = applySync(content, parsed.tasks, results);
 
   assert.match(next, /- \[ \] Integración Mercado Pago Point/);
-  assert.match(next, /⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match/);
+  assert.doesNotMatch(next, /⚠️ attempted but validation failed/);
 });
 
 test('sync preserves an already checked task with no evidence or path hints', () => {
@@ -233,4 +233,28 @@ test('applySync preserves more specific existing warning over generic new messag
     /missing referenced file\(s\): src\/pos\/page\.tsx/,
     'specific existing warning must be preserved when new message is more generic'
   );
+});
+
+test('applySync deduplicates warning reasons from a prior /api route sync run', () => {
+  const projectRoot = setupFixture('warning-sync');
+  const config = loadConfig({ projectRoot });
+  const content = [
+    '## Phase P1',
+    '- [ ] Implement backup database module for GET /api/backup <!-- rs:task=implement-backup-module -->',
+    '  - Evidence: src/missing-backup.js',
+    '  - ⚠️ attempted but validation failed: evidence file(s) not found: src/missing-backup.js; evidence file(s) not found: src/missing-backup.js',
+    ''
+  ].join('\n');
+
+  const parsed = parseRoadmap(content);
+  const context = buildValidationContext(projectRoot, config, []);
+  const results = validateTasks(parsed.tasks, context, config, []);
+  const next = applySync(content, parsed.tasks, results);
+
+  const warningMatches = next.match(/⚠️ attempted but validation failed/g) || [];
+  const missingEvidenceMatches = next.match(/evidence file\(s\) not found: src\/missing-backup\.js/g) || [];
+
+  assert.equal(warningMatches.length, 1);
+  assert.equal(missingEvidenceMatches.length, 1);
+  assert.doesNotMatch(next, /missing referenced file\(s\): \/api\/backup/);
 });

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -961,7 +961,7 @@ test('weak path-token evidence finds files even without explicit path hints', ()
   const result = validateTask({ id: 'electron-main', text: 'Configurar Electron con Next.js como servidor embebido' }, context, config, []);
 
   assert.equal(result.passed, false);
-  assert.equal(result.attempted, true);
+  assert.equal(result.attempted, false);
   assert.equal(result.confidence, 'low');
   assert.ok(result.evidence.weakPathFiles.some((p) => p.includes('electron/main.ts')));
   assert.ok(result.reasons.includes('weak path-only evidence lacks content-specific token match'));
@@ -991,7 +991,7 @@ test('weak path-only evidence does not complete Mercado Pago Point integration t
   );
 
   assert.equal(result.passed, false);
-  assert.equal(result.attempted, true);
+  assert.equal(result.attempted, false);
   assert.equal(result.confidence, 'low');
   assert.ok(result.evidence.weakPathFiles.includes('src/app/api/mercadopago/preference/route.ts'));
   assert.deepEqual(result.evidence.weakPathContentTokens, []);
@@ -1346,7 +1346,7 @@ test('Action-verb task with path hint and code tokens stays unchecked without Ev
     context, config, []
   );
   assert.equal(result.passed, false, 'action-verb task without Evidence line must stay unchecked');
-  assert.ok(result.reasons.some((r) => r.includes('action task requires')), 'reason must indicate action task requirement');
+  assert.ok(result.reasons.some((r) => r.includes('implementation task requires')), 'reason must indicate implementation task requirement');
 });
 
 // Causa 3b: same action-verb task WITH Evidence line passes
@@ -1372,7 +1372,7 @@ test('Action-verb task WITH Evidence line passes despite no test evidence', () =
     context, config, []
   );
   assert.equal(result.passed, true, 'action-verb task WITH Evidence line must pass');
-  assert.ok(!result.reasons.some((r) => r.includes('action task requires')), 'action task reason must not appear when Evidence line is present');
+  assert.ok(!result.reasons.some((r) => r.includes('implementation task requires')), 'implementation task reason must not appear when Evidence line is present');
 });
 
 test('taskDescribesChange catches noun form "Manejo" and two-word "Recovery path"', () => {
@@ -1394,14 +1394,14 @@ test('taskDescribesChange catches noun form "Manejo" and two-word "Recovery path
     context, config, []
   );
   assert.equal(r1.passed, false, '"Manejo" must be caught as an action task');
-  assert.ok(r1.reasons.some((r) => r.includes('action task requires')));
+  assert.ok(r1.reasons.some((r) => r.includes('implementation task requires')));
 
   const r2 = validateTask(
     { id: 'recovery-cash', text: 'Recovery path para cash sessions huérfanas en src/lib/db.ts', checked: false },
     context, config, []
   );
   assert.equal(r2.passed, false, '"Recovery path" must be caught as an action task');
-  assert.ok(r2.reasons.some((r) => r.includes('action task requires')));
+  assert.ok(r2.reasons.some((r) => r.includes('implementation task requires')));
 });
 
 test('Action task without Evidence line stays unchecked despite token match in generic fixture', () => {
@@ -1422,7 +1422,7 @@ test('Action task without Evidence line stays unchecked despite token match in g
     context, config, []
   );
   assert.equal(result.passed, false, 'action task must stay unchecked even when file exists with matching tokens');
-  assert.ok(result.reasons.some((r) => r.includes('action task requires')), 'reason must mention Evidence line or high-confidence');
+  assert.ok(result.reasons.some((r) => r.includes('implementation task requires')), 'reason must mention Evidence line or high-confidence');
 });
 
 test('Action task WITH Evidence line is marked complete', () => {
@@ -1446,7 +1446,7 @@ test('Action task WITH Evidence line is marked complete', () => {
     context, config, []
   );
   assert.equal(result.passed, true, 'action task WITH Evidence line must pass');
-  assert.ok(!result.reasons.some((r) => r.includes('action task requires')));
+  assert.ok(!result.reasons.some((r) => r.includes('implementation task requires')));
 });
 
 test('Non-action task with token match can pass without Evidence line', () => {
@@ -1464,7 +1464,7 @@ test('Non-action task with token match can pass without Evidence line', () => {
     { id: 'stock-management', text: 'Stock management module in inventory/page.tsx', checked: false },
     context, config, []
   );
-  assert.ok(!result.reasons.some((r) => r.includes('action task requires')), 'non-action task must not be blocked by action gate');
+  assert.ok(!result.reasons.some((r) => r.includes('implementation task requires')), 'non-action task must not be blocked by implementation gate');
 });
 
 test('/api/* HTTP route paths do not produce missing-file failures', () => {
@@ -1487,7 +1487,7 @@ test('/api/* HTTP route paths do not produce missing-file failures', () => {
   }
 });
 
-test('action task stays unchecked even when BOTH code and test files match its tokens', () => {
+test('implementation task passes when BOTH code and test files match its tokens', () => {
   const projectRoot = setupFixture('generic');
 
   fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
@@ -1522,11 +1522,9 @@ test('action task stays unchecked even when BOTH code and test files match its t
   );
 
   assert.equal(
-    result.passed, false,
-    'action task must stay unchecked even when code + test files both match tokens'
+    result.passed, true,
+    'implementation task should pass when code + test files both match tokens'
   );
-  assert.ok(
-    result.reasons.some((r) => r.includes('action task requires')),
-    `expected "action task requires" in reasons, got: ${JSON.stringify(result.reasons)}`
-  );
+  assert.equal(result.confidence, 'high');
+  assert.ok(!result.reasons.some((r) => r.includes('implementation task requires')));
 });


### PR DESCRIPTION
## Summary
- make `/roadmap-update` warning rendering idempotent so repeated sync runs do not duplicate machine-generated reasons
- tighten validator semantics so weak path hints do not count as attempted work and implementation tasks need stronger proof before auto-checking
- harden `verify-pack-surface` to use an isolated temporary npm cache so the pre-push QA gate does not fail on Windows cache EPERM noise

## Validation
- `C:\Program Files\nodejs\node.exe --test roadmap-skill\test\*.test.js`
- dual-agent pre-push gate reconciled on the final tree:
  - `qa-regression` PASS
  - `functional-smoke` PASS
- direct packed-surface verification PASS:
  - `C:\Program Files\nodejs\node.exe scripts\verify-pack-surface.js`

## Notes
- local `gh auth` is stale on this machine, so PR/merge are being driven through the GitHub connector while git push uses the existing remote credentials.