### PR TITLE
fix: tighten validator sync and status surface

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roadmapsmith",
   "version": "0.9.24",
-  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
+  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "author": {
     "name": "PapiScholz"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roadmapsmith",
   "version": "0.9.24",
-  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
+  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "author": {
     "name": "PapiScholz"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Zero Mode and Sync/Audit Mode documentation now match the real CLI and VS Code task flows.
 - Host documentation now separates the native Codex plugin surface, the Claude skill-bundle surface, and the CLI plus VS Code fallback surface explicitly.
 - `roadmapsmith doctor --json` now separates native slash surfaces (`claudeGui`, `claudeCli`, `codexGui`, `codexCli`) from the VS Code task plus Claude hook setup layer.
+- `roadmapsmith status` is now the visible classic readiness command, with `roadmapsmith doctor` kept as a compatibility alias to the same inspection payload.
 - `maintain` and `generate` are now documented as preserve-first updates for existing substantive managed blocks, while `/roadmap-update` replaces direct `/roadmap-sync` usage as the visible sync slash entrypoint.
 - The public slash namespace now prefers `/roadmap*` commands, uses `/roadmap-update` as the visible direct sync command, keeps `/roadmap-sync <action>` as the legacy root, and requires `--full-regen` before destructive regeneration.
 - Release and maintainer docs now require independent subagent-owned validation passes before push, and CI reuses the same gate commands.
@@ -25,6 +26,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Codex loader metadata for `skills/roadmap-sync/agents/openai.yaml` now parses cleanly instead of being ignored as invalid YAML.
 - `doctor` now detects the common duplicate-`/roadmap-sync` case where a legacy `~/.agents/skills/roadmap-sync` install coexists with the full `roadmapsmith` Codex plugin.
+- Validator/sync now distinguish concrete implementation attempts from no-evidence tasks, ignore backticked HTTP/MIME/formula tokens as file paths, exempt HTTP expectation lines from standalone test requirements, and keep implicit duplicate task text deterministic via unique per-occurrence IDs.
 
 ## [0.7.0] — 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ roadmapsmith /roadmap-sync validate
 
 **`validate`** runs the multi-pass evidence scan. Each task is scored against: backtick-quoted paths in task text, symbol names, code token matching (threshold: 2+ matches for multi-token tasks), test file matching, and artifact presence. Results include the reason a task passed or failed.
 
-**`sync`** writes only within a `<!-- rs:managed:start/end -->` block, leaving the rest of your `ROADMAP.md` untouched. It marks passing tasks `[x]` and appends `⚠️ attempted but validation failed: <reason>` for failing ones. `sync --audit` currently runs that same mutation path and then prints a mismatch summary; it is not yet a separate read-only audit mode.
+**`sync`** writes only within a `<!-- rs:managed:start/end -->` block, leaving the rest of your `ROADMAP.md` untouched. It marks passing tasks `[x]` and appends warning lines for failing ones: `⚠️ attempted but validation failed: <reason>` when there is concrete attempt evidence, or `⚠️ no implementation evidence found yet: <reason>` when there is not. `sync --audit` currently runs that same mutation path and then prints a mismatch summary; it is not yet a separate read-only audit mode.
 
 ## Host Support Today
 
@@ -369,7 +369,8 @@ Do not use it if:
 | `roadmapsmith generate --project-root . --full-regen` | Explicit full managed-block rebuild |
 | `roadmapsmith validate --json` | Validate roadmap task evidence and emit JSON results |
 | `roadmapsmith sync --audit` | Apply sync and print a mismatch summary; currently mutates `ROADMAP.md` |
-| `roadmapsmith doctor --json` | Check repository plus host readiness, plus native slash surfaces for `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` |
+| `roadmapsmith status --json` | Check repository plus host readiness, plus native slash surfaces for `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` |
+| `roadmapsmith doctor --json` | Compatibility alias for `roadmapsmith status --json` |
 | `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code` | Install the full Claude GUI skill bundle with native slash commands |
 | `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` | Install only the legacy `/roadmap-sync` skill |
 
@@ -473,7 +474,7 @@ Then restart Codex, open the plugin directory, install `roadmapsmith` from the `
 
 Codex native support means plugin install and enablement inside Codex. It does not reuse Claude's `/reload-skills` flow. If you are not using the plugin directory, the supported fallback remains `roadmapsmith setup` plus the VS Code task and launcher workflow.
 
-`roadmapsmith doctor --json` now separates native surfaces from the repo-local task layer:
+`roadmapsmith status --json` now separates native surfaces from the repo-local task layer (`doctor --json` remains a compatibility alias):
 
 - `claudeGui`
 - `claudeCli`
@@ -612,7 +613,7 @@ The validation pipeline combines multiple evidence signals with a configurable c
 This maps to a concrete safety principle: **autonomous execution requires traceable justification**. An agent that marks a task complete should point to the change. If it cannot, the task does not advance.
 
 Current guardrails built into the system:
-- Tasks with insufficient evidence emit `⚠️ attempted but validation failed: <reason>` in the roadmap
+- Tasks with insufficient evidence emit `⚠️ attempted but validation failed: <reason>` when there is concrete attempt evidence, or `⚠️ no implementation evidence found yet: <reason>` when there is not
 - `sync --audit` surfaces tasks marked complete without passing validation
 - `validate --json` traces exactly why each task passed or failed — every evidence signal is reported
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -30,7 +30,7 @@ Release work is not ready until the docs, host UX, and changelog all reflect tha
 - Patch versions advance on every successful push to `main`, regardless of whether the merged change was code, docs, or release-ops only.
 - Because `main` is PR-only, the release workflow writes that version back through an automated `release/vX.Y.Z` PR that squashes into `main` as `chore(release): vX.Y.Z`.
 - If GitHub blocks `GITHUB_TOKEN` from creating or merging PRs, the workflow must use a dedicated secret such as `RELEASE_BOT_TOKEN` with `repo` scope.
-- `roadmapsmith doctor --json` must report `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` separately from the VS Code task/hook layer.
+- `roadmapsmith status --json` must report `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` separately from the VS Code task/hook layer. `doctor --json` remains a compatibility alias.
 - If a legacy `~/.agents/skills/roadmap-sync` install coexists with the `roadmapsmith` Codex plugin, `doctor` should flag `/roadmap-sync` as a duplicate instead of silently calling the surface healthy.
 - The published `roadmapsmith` package now mirrors the shared Codex and Claude bundle files for downstream plugin/distribution surfaces, but CLI install alone still does not auto-register either host surface.
 - `roadmapsmith setup` must be rerun when the generated VS Code task layer, launcher, wrappers, or Claude hook template changes.

--- a/docs/release-ux-gate.md
+++ b/docs/release-ux-gate.md
@@ -121,8 +121,8 @@ Pass when:
 - unrelated Claude hooks/settings are preserved
 - invalid host config causes a hard failure
 - invalid host config leaves no partial writes behind
-- `roadmapsmith doctor --json` separates `claudeGui`, `claudeCli`, `codexGui`, and `codexCli`
-- `roadmapsmith doctor --json` reports `/roadmap-sync` as duplicated when a legacy `~/.agents/skills/roadmap-sync` install coexists with the Codex plugin
+- `roadmapsmith status --json` separates `claudeGui`, `claudeCli`, `codexGui`, and `codexCli` (`doctor --json` remains a compatibility alias)
+- `roadmapsmith status --json` reports `/roadmap-sync` as duplicated when a legacy `~/.agents/skills/roadmap-sync` install coexists with the Codex plugin
 
 ### 6. Docs and release notes
 

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -171,7 +171,7 @@ Use `validate --json` when you want to inspect per-task evidence before taking a
 
 **Slash commands not visible in Claude GUI:** Install or update the full skill bundle with `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`, then run `/reload-skills` and, if applicable, `/reload-plugins`. Installing only `--skill roadmap-sync` exposes only `/roadmap-sync`. If you are consuming a published package/plugin artifact instead of a GitHub-source install, confirm that your Claude host is actually loading the bundled `skills.json` plus `skills/*` surface rather than only the Codex plugin metadata.
 
-`roadmapsmith doctor --json` now separates the native slash surfaces (`claudeGui`, `claudeCli`, `codexGui`, `codexCli`) from the repo-local VS Code task and Claude hook layer. Use that output when you need to distinguish “the bundle exists” from “the host actually loaded it.”
+`roadmapsmith status --json` now separates the native slash surfaces (`claudeGui`, `claudeCli`, `codexGui`, `codexCli`) from the repo-local VS Code task and Claude hook layer. `roadmapsmith doctor --json` remains a compatibility alias. Use that output when you need to distinguish “the bundle exists” from “the host actually loaded it.”
 
 **Hook runs but ROADMAP does not update:** Confirm the Claude hook environment can resolve `node`. Today the repo-local write-time hook is best-effort and depends on that host-level resolution.
 

--- a/docs/use-cases/sync-audit-mode.md
+++ b/docs/use-cases/sync-audit-mode.md
@@ -58,7 +58,8 @@ An AI agent that marks a task `[x]` without calling `sync` is making an assertio
 
 When `sync` runs:
 - Tasks with passing evidence are marked `[x]`
-- Tasks without evidence emit `⚠️ attempted but validation failed: <reason>` in the roadmap
+- Tasks with concrete attempt evidence emit `⚠️ attempted but validation failed: <reason>` in the roadmap
+- Tasks without concrete attempt evidence emit `⚠️ no implementation evidence found yet: <reason>` in the roadmap
 - `--audit` surfaces tasks that claim completion but have no evidence, and tasks that have evidence but are still unchecked
 
 This means a PR reviewer can run `sync --audit` and see a factual mismatch report — not just the agent's word.

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roadmapsmith",
   "version": "0.9.24",
-  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
+  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "author": {
     "name": "PapiScholz"
   },

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -120,7 +120,8 @@ roadmapsmith init [--roadmap-file <path>] [--agents-file <path>] [--dry-run]
 roadmapsmith generate [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--dry-run] [--audit] [--full-regen]
 roadmapsmith sync [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run] [--audit]
 roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json]
-roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]
+roadmapsmith status [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]
+roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]   # compatibility alias
 ```
 
 ## Claude Code native slash commands
@@ -153,7 +154,7 @@ Then restart Codex, open the plugin directory, install `roadmapsmith` from the `
 
 Codex native plugin support means install/enable discovery inside Codex. It is separate from Claude-specific `/reload-skills` behavior, and the VS Code task layer remains the fallback/manual workflow when you are not using the plugin directory.
 
-`roadmapsmith doctor --json` now reports native slash surfaces separately from the VS Code task layer:
+`roadmapsmith status --json` now reports native slash surfaces separately from the VS Code task layer (`doctor --json` remains a compatibility alias):
 
 - `claudeGui`
 - `claudeCli`
@@ -179,7 +180,8 @@ The repo does not remove user-global skills automatically. Use the `doctor` outp
   - code OR test OR artifact evidence required.
   - test evidence required for code tasks when test frameworks are detected.
 - Validation failures in sync write warning lines:
-  - `- ⚠️ attempted but validation failed: <reason>`
+  - `- ⚠️ attempted but validation failed: <reason>` when there is concrete attempt evidence
+  - `- ⚠️ no implementation evidence found yet: <reason>` when there is not
 - Preserves unmanaged markdown content by updating only the managed roadmap block.
 
 ## Defaults

--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -31,7 +31,8 @@ function printHelp() {
     '  roadmapsmith generate [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--dry-run] [--audit] [--full-regen]',
     '  roadmapsmith sync [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run] [--audit]',
     '  roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json]',
-    '  roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]'
+    '  roadmapsmith status [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]',
+    '  roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]   # compatibility alias'
   ].join('\n'));
 }
 
@@ -245,7 +246,7 @@ function printHumanStatus(payload) {
 function runStatusCommand(projectRoot, config, flags, options = {}) {
   const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
   const agentsFile = resolveAgentsFile(projectRoot, config, flags['agents-file']);
-  const payload = inspectHostSetup(projectRoot, { roadmapFile, agentsFile });
+  const payload = inspectHostSetup(projectRoot, { roadmapFile, agentsFile, currentCliPath: __filename });
 
   if (options.json) {
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
@@ -443,7 +444,7 @@ async function run() {
     return;
   }
 
-  if (effectiveCommand === 'doctor') {
+  if (effectiveCommand === 'status' || effectiveCommand === 'doctor') {
     const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
     let ok = true;
     const jsonMode = isEnabled(flags.json);

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roadmapsmith",
   "version": "0.9.24",
-  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude.",
+  "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "main": "src/index.js",
   "bin": {
     "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/src/host.js
+++ b/roadmap-skill/src/host.js
@@ -921,7 +921,7 @@ function renderVsCodeLauncher() {
     'function explain() {',
     '  console.log(\'RoadmapSmith layers:\\n\');',
     '  console.log(\'1. The roadmap-sync skill guides the agent. It does not add VS Code buttons or install the CLI.\');',
-    '  console.log(\'2. The roadmapsmith CLI executes zero/maintain plus init/generate/validate/sync/setup/doctor, with --full-regen reserved for destructive replacement.\');',
+    '  console.log(\'2. The roadmapsmith CLI executes zero/maintain plus init/generate/validate/sync/setup/status, with doctor kept as a compatibility alias and --full-regen reserved for destructive replacement.\');',
     '  console.log(\'3. roadmapsmith setup makes the CLI visible in VS Code through tasks and optional Claude hook wiring.\\n\');',
     '  console.log(\'Typical VS Code workflow:\');',
     '  console.log(\'- Run "RoadmapSmith: Status" to inspect readiness.\');',
@@ -1020,7 +1020,7 @@ function renderVsCodeLauncher() {
     '}',
     '',
     'function status() {',
-    '  const result = runCli([\'doctor\', \'--project-root\', PROJECT_ROOT, \'--json\'], { capture: true, allowMissingCli: true });',
+    '  const result = runCli([\'status\', \'--project-root\', PROJECT_ROOT, \'--json\'], { capture: true, allowMissingCli: true });',
     '  if (!result || result.missingCli) {',
     '    printMissingCliStatus();',
     '    return;',
@@ -1143,7 +1143,26 @@ function findGlobalRoadmapsmith() {
   return findCommandPath('roadmapsmith');
 }
 
-function detectCliResolution(projectRoot) {
+function isRoadmapsmithCliEntrypoint(filePath) {
+  const normalized = String(filePath || '').replace(/\\/g, '/').toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return normalized.endsWith('/roadmap-skill/bin/cli.js')
+    || normalized.endsWith('/roadmapsmith/bin/cli.js')
+    || /(?:^|[\\/])roadmapsmith(?:\.(?:cmd|exe|bat|ps1))?$/.test(normalized);
+}
+
+function detectCliResolution(projectRoot, options = {}) {
+  const currentCliPath = options.currentCliPath || process.argv[1] || null;
+  if (currentCliPath && isRoadmapsmithCliEntrypoint(currentCliPath)) {
+    return {
+      ready: true,
+      kind: 'current-process',
+      path: currentCliPath
+    };
+  }
+
   const workspaceDevCli = path.join(projectRoot, 'roadmap-skill', 'bin', 'cli.js');
   if (fs.existsSync(workspaceDevCli)) {
     return {
@@ -1244,7 +1263,7 @@ function inspectHostSetup(projectRoot, options = {}) {
   const roadmapFile = options.roadmapFile;
   const agentsFile = options.agentsFile;
   const runtime = detectNodeRuntime(options.env || process.env);
-  const cli = detectCliResolution(projectRoot);
+  const cli = detectCliResolution(projectRoot, { currentCliPath: options.currentCliPath });
   const vscode = inspectVsCodeTasks(projectRoot);
   const claude = inspectClaudeSetup(projectRoot);
   const bundle = inspectSharedBundleSurface();

--- a/roadmap-skill/src/parser/index.js
+++ b/roadmap-skill/src/parser/index.js
@@ -4,7 +4,12 @@ const { slugify } = require('../utils');
 
 const MANAGED_START = '<!-- rs:managed:start -->';
 const MANAGED_END = '<!-- rs:managed:end -->';
-const WARNING_PREFIX = '⚠️ attempted but validation failed:';
+const WARNING_PREFIX = '⚠️';
+const WARNING_REASON_PREFIXES = [
+  'attempted but validation failed:',
+  'no implementation evidence found yet:',
+  'validation failed:'
+];
 
 function getIndentWidth(text) {
   return String(text || '').replace(/\t/g, '    ').length;
@@ -86,7 +91,14 @@ function parseEvidenceLine(content) {
 
 function parseWarningLine(content) {
   if (!content.startsWith(WARNING_PREFIX)) return null;
-  return content.slice(WARNING_PREFIX.length).trim();
+  let normalized = content.slice(WARNING_PREFIX.length).trim();
+  for (const prefix of WARNING_REASON_PREFIXES) {
+    if (normalized.startsWith(prefix)) {
+      normalized = normalized.slice(prefix.length).trim();
+      break;
+    }
+  }
+  return normalized;
 }
 
 function parseBlockedByLine(content) {
@@ -98,6 +110,7 @@ function parseRoadmap(content) {
   const lines = String(content || '').split(/\r?\n/);
   const managedRange = findManagedRange(lines);
   const tasks = [];
+  const implicitIdCounts = new Map();
   let section = '';
 
   for (let index = 0; index < lines.length; index += 1) {
@@ -162,7 +175,12 @@ function parseRoadmap(content) {
       }
     }
 
-    const id = markerId || slugify(text);
+    const baseId = markerId || slugify(text);
+    const nextImplicitCount = markerId ? 1 : (implicitIdCounts.get(baseId) || 0) + 1;
+    if (!markerId) {
+      implicitIdCounts.set(baseId, nextImplicitCount);
+    }
+    const id = markerId || (nextImplicitCount === 1 ? baseId : `${baseId}-${nextImplicitCount}`);
     tasks.push({
       id,
       text,

--- a/roadmap-skill/src/slash.js
+++ b/roadmap-skill/src/slash.js
@@ -16,7 +16,7 @@ const SLASH_ACTIONS = [
   {
     id: 'status',
     description: 'Inspect CLI, roadmap, VS Code task, Codex, and Claude readiness.',
-    classicCliExample: 'roadmapsmith doctor --json',
+    classicCliExample: 'roadmapsmith status --json',
     taskLabel: 'RoadmapSmith: Status'
   },
   {

--- a/roadmap-skill/src/sync/index.js
+++ b/roadmap-skill/src/sync/index.js
@@ -3,14 +3,21 @@
 const { parseRoadmap } = require('../parser');
 const { ensureTrailingNewline } = require('../utils');
 
-const WARNING_REASON_PREFIX = 'attempted but validation failed:';
+const ATTEMPTED_WARNING_REASON_PREFIX = 'attempted but validation failed:';
+const NO_EVIDENCE_WARNING_REASON_PREFIX = 'no implementation evidence found yet:';
+const WARNING_REASON_PREFIXES = [
+  ATTEMPTED_WARNING_REASON_PREFIX,
+  NO_EVIDENCE_WARNING_REASON_PREFIX,
+  'validation failed:'
+];
 
 function setChecklistState(line, checked) {
   return line.replace(/- \[( |x|X)\]/, `- [${checked ? 'x' : ' '}]`);
 }
 
-function formatWarning(indent, reason) {
-  return `${indent}  - ⚠️ attempted but validation failed: ${reason}`;
+function formatWarning(indent, reason, attempted) {
+  const prefix = attempted ? ATTEMPTED_WARNING_REASON_PREFIX : NO_EVIDENCE_WARNING_REASON_PREFIX;
+  return `${indent}  - ⚠️ ${prefix} ${reason}`;
 }
 
 function isWhitespaceCharacter(char) {
@@ -72,9 +79,12 @@ function normalizeWarningReason(reason) {
   }
 
   normalized = stripLeadingWarningMarker(normalized).trim();
-  const prefixIndex = normalized.indexOf(WARNING_REASON_PREFIX);
-  if (prefixIndex >= 0) {
-    normalized = normalized.slice(prefixIndex + WARNING_REASON_PREFIX.length).trim();
+  for (const prefix of WARNING_REASON_PREFIXES) {
+    const prefixIndex = normalized.indexOf(prefix);
+    if (prefixIndex >= 0) {
+      normalized = normalized.slice(prefixIndex + prefix.length).trim();
+      break;
+    }
   }
 
   return normalized;
@@ -122,12 +132,12 @@ function applySync(content, parsedTasks, results) {
     lines[lineIndex] = setChecklistState(lines[lineIndex], result.passed);
 
     const reason = normalizeWarningReasons(result.reasons).join('; ');
-    const warningText = formatWarning(task.indent || '', reason || 'validation failed');
+    const warningText = formatWarning(task.indent || '', reason || 'validation failed', result.attempted);
     const hasWarning = task.warningLineIndex != null;
     const warningIndex = hasWarning ? task.warningLineIndex + offset : null;
     const lastChildLineIndex = (task.lastChildLineIndex != null ? task.lastChildLineIndex : task.lineIndex) + offset;
 
-    if (result.passed || !result.attempted) {
+    if (result.passed) {
       if (warningIndex != null && warningIndex >= 0 && warningIndex < lines.length) {
         lines.splice(warningIndex, 1);
         offset -= 1;
@@ -136,7 +146,7 @@ function applySync(content, parsedTasks, results) {
     }
 
     if (warningIndex != null && warningIndex >= 0 && warningIndex < lines.length) {
-      const existingReason = lines[warningIndex].split('validation failed:')[1];
+      const existingReason = normalizeWarningReason(lines[warningIndex]);
       const newReason = reason || 'validation failed';
       if (!shouldPreserveExistingWarning(existingReason, newReason)) {
         lines[warningIndex] = warningText;

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -197,18 +197,9 @@ function hasFileExtension(token) {
 }
 
 function isLikelyPath(token) {
-  if (token.includes('*') || token.includes('?')) return false; // glob/wildcard
-  if (/^\/api\//i.test(token)) return false; // HTTP API route paths are not file paths
-  if (/^\.{1,2}\/|^\//.test(token)) {
-    // Bare "/" or "./" with nothing after is not a real path (e.g. "API / ESC-POS" → "/")
-    return /[A-Za-z0-9_]/.test(token);
-  }
-  if (hasFileExtension(token)) return true;
-  if (KNOWN_PATH_ROOTS.some((root) => token.startsWith(root))) return true;
-  // The ">= 2 slashes" rule was intentionally removed: it caused conceptual slash phrases
-  // like "code/test/artifact" or "build/test/deploy" to be treated as file paths.
-  // Real multi-segment paths are caught by the extension or known-root rules above.
-  return false;
+  if (isRealFilePath(token)) return true;
+  // Preserve the legacy extension-only fallback for standalone path-looking tokens.
+  return hasFileExtension(token);
 }
 
 // Matches standalone filenames without a slash — e.g. "roadmap-skill.config.json",
@@ -228,6 +219,54 @@ function hasKnownFileExtension(token) {
   const lastDot = token.lastIndexOf('.');
   if (lastDot < 0) return false;
   return KNOWN_FILE_EXTENSIONS.has(token.slice(lastDot).toLowerCase());
+}
+
+function startsWithKnownPathRoot(token) {
+  const normalized = String(token || '').replace(/\\/g, '/').toLowerCase();
+  return KNOWN_PATH_ROOTS.some((root) => normalized.startsWith(root.toLowerCase()));
+}
+
+function isHttpRouteToken(token) {
+  const normalized = String(token || '').trim();
+  if (!normalized) return false;
+  if (/^(GET|POST|PUT|PATCH|DELETE)\s+\/\S+$/i.test(normalized)) {
+    return true;
+  }
+  return /^\/api\//i.test(normalized);
+}
+
+function isMimeTypeToken(token) {
+  return /^[A-Za-z0-9.+-]+\/[A-Za-z0-9.+-]+$/.test(String(token || '').trim());
+}
+
+function looksLikeFormulaToken(token) {
+  return /[=×÷]/.test(String(token || '').trim());
+}
+
+function isRealFilePath(token) {
+  const normalized = String(token || '').trim().replace(/\\/g, '/');
+  if (!normalized) return false;
+  if (normalized.includes('*') || normalized.includes('?')) return false;
+  if (/\s/.test(normalized)) return false;
+  if (looksLikeFormulaToken(normalized)) return false;
+  if (isHttpRouteToken(normalized)) return false;
+
+  const looksLikePath =
+    hasKnownFileExtension(normalized) ||
+    startsWithKnownPathRoot(normalized) ||
+    /^\.{1,2}\//.test(normalized) ||
+    /^\//.test(normalized);
+  if (!looksLikePath) return false;
+
+  if (!hasKnownFileExtension(normalized) && !startsWithKnownPathRoot(normalized) && isMimeTypeToken(normalized)) {
+    return false;
+  }
+
+  if (/^\.{1,2}\/|^\//.test(normalized)) {
+    return /[A-Za-z0-9_]/.test(normalized);
+  }
+
+  return true;
 }
 
 function isAsciiAlphaNumeric(char) {
@@ -278,39 +317,49 @@ function collectPathishTokens(text) {
 // to lineReferenceHints and excluded from hasDirectReferencePass scoring.
 const LINE_REF_RE = /^(.+?):(\d+)(?:-\d+)?$/;
 
+function normalizeExplicitPathCandidate(rawToken) {
+  const clean = stripTrailingPathPunctuation(String(rawToken || '').trim());
+  if (!clean || clean.includes('*') || clean.includes('?')) {
+    return null;
+  }
+
+  const lineMatch = LINE_REF_RE.exec(clean);
+  if (lineMatch) {
+    const linePath = stripTrailingPathPunctuation(lineMatch[1]);
+    if (isRealFilePath(linePath)) {
+      return { path: linePath, isLineReference: true };
+    }
+    return null;
+  }
+
+  if (!isRealFilePath(clean)) {
+    return null;
+  }
+
+  return { path: clean, isLineReference: false };
+}
+
 function extractExplicitPaths(text) {
   const results = new Set();
   const lineReferenceHints = new Set();
 
   const quoted = String(text).match(/`([^`]+)`/g) || [];
   for (const token of quoted) {
-    const clean = token.slice(1, -1);
-    if (clean.includes('*') || clean.includes('?')) continue; // glob
-    const hasSlash = clean.includes('/') || clean.includes('\\');
-    // Require a slash or a known file extension — rejects property access like err.message,
-    // fs.readFileSync, error.stack (whose extensions are not in KNOWN_FILE_EXTENSIONS).
-    if (!hasSlash && !hasKnownFileExtension(clean)) continue;
-    const lineMatch = LINE_REF_RE.exec(clean);
-    if (lineMatch && hasKnownFileExtension(lineMatch[1])) {
-      lineReferenceHints.add(lineMatch[1]);
-      results.add(lineMatch[1]);
-    } else {
-      results.add(clean);
+    const normalized = normalizeExplicitPathCandidate(token.slice(1, -1));
+    if (!normalized) continue;
+    results.add(normalized.path);
+    if (normalized.isLineReference) {
+      lineReferenceHints.add(normalized.path);
     }
   }
 
   for (const word of String(text).split(/\s+/)) {
     if (!word.includes('/')) continue;
-    const token = stripTrailingPathPunctuation(word);
-    if (token.includes('*') || token.includes('?')) continue; // glob
-    const lineMatch = LINE_REF_RE.exec(token);
-    if (lineMatch && hasKnownFileExtension(lineMatch[1])) {
-      if (isLikelyPath(lineMatch[1])) {
-        lineReferenceHints.add(lineMatch[1]);
-        results.add(lineMatch[1]);
-      }
-    } else if (isLikelyPath(token)) {
-      results.add(token);
+    const normalized = normalizeExplicitPathCandidate(word);
+    if (!normalized) continue;
+    results.add(normalized.path);
+    if (normalized.isLineReference) {
+      lineReferenceHints.add(normalized.path);
     }
   }
 
@@ -361,6 +410,14 @@ function extractSymbolHints(text) {
 function isCodeTask(taskText) {
   const normalized = String(taskText).toLowerCase();
   return CODE_HINTS.some((hint) => normalized.includes(hint));
+}
+
+function isHttpExpectationTask(taskText) {
+  const text = String(taskText || '');
+  if (!/(?:->|→)/.test(text) || !/\bHTTP\s+\d{3}\b/i.test(text)) {
+    return false;
+  }
+  return /\b(?:GET|POST|PUT|PATCH|DELETE)\b/i.test(text) || /\/api\//i.test(text);
 }
 
 function isDocTask(taskText) {
@@ -1143,7 +1200,12 @@ function validateTask(task, context, config, plugins) {
     }
   }
 
-  const requiresTest = !task.noTest && context.testFrameworks.length > 0 && isCodeTask(task.text) && !isDocTask(task.text);
+  const requiresTest =
+    !task.noTest &&
+    context.testFrameworks.length > 0 &&
+    isCodeTask(task.text) &&
+    !isDocTask(task.text) &&
+    !isHttpExpectationTask(task.text);
   const configuredRules = Array.isArray(config.validators) ? config.validators : [];
   const pluginRules = collectPluginContributions(plugins || [], 'registerValidators', context);
   let overrideResult = null;
@@ -1181,13 +1243,14 @@ function validateTask(task, context, config, plugins) {
     uniqueReasons = Array.isArray(overrideResult.reasons) ? Array.from(new Set(overrideResult.reasons)) : [];
   }
 
-  const hasConcreteReferenceEvidence = filesFromPurePathHints.length > 0 || filesFromSymbols.length > 0;
-  const attempted = authoritativeEvidence.active
-    || hasRuleGrantedEvidence
-    || evidence.code
-    || evidence.test
-    || evidence.artifact
-    || hasConcreteReferenceEvidence;
+  const hasConcreteReferenceEvidence = filesFromPaths.length > 0 || filesFromSymbols.length > 0;
+  const hasConcreteAttemptEvidence =
+    authoritativeEvidence.active ||
+    hasRuleGrantedEvidence ||
+    filesFromTests.length > 0 ||
+    hasConcreteReferenceEvidence ||
+    (isDocTask(task.text) && filesFromArtifacts.length > 0);
+  const attempted = hasConcreteAttemptEvidence;
   const { categories: strongEvidenceCategories } = countStrongEvidenceCategories(task.text, evidence);
   const strongEvidenceCount = strongEvidenceCategories.length;
   // Only pure path hints (not line-reference hints like file.ts:169) count as direct evidence.

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -529,15 +529,15 @@ test('cli sync preserves existing managed block structure on weak path-only fail
   run(['sync'], projectRoot);
 
   const content = fs.readFileSync(path.join(projectRoot, CANONICAL_ROADMAP), 'utf8');
-  const warningMatches = content.match(/⚠️ attempted but validation failed/g) || [];
+  const warningMatches = content.match(/⚠️ no implementation evidence found yet/g) || [];
 
-  assert.equal(warningMatches.length, 0);
+  assert.equal(warningMatches.length, 1);
   assert.match(content, /## Phase Alfa: Desktop Shell Comercial/);
   assert.match(content, /Contexto de negocio: el shell Electron mantiene Next\.js embebido para demos offline\./);
   assert.match(content, /### Criterio de avance/);
   assert.match(content, /La experiencia de escritorio debe iniciar sin depender de servicios externos\./);
   assert.match(content, /- \[ \] Configurar Electron con Next\.js como servidor embebido/);
-  assert.doesNotMatch(content, /weak path-only evidence lacks content-specific token match/);
+  assert.match(content, /weak path-only evidence lacks content-specific token match/);
   assert.match(content, /- \[ \] Implement app module <!-- rs:task=outside-implement-app-module -->/);
   assert.doesNotMatch(content, /Add SEO metadata/);
   assert.doesNotMatch(content, /Implement responsive/);
@@ -749,7 +749,8 @@ test('doctor --json reports missing integration state', () => {
   const payload = JSON.parse(result.stdout);
 
   assert.notEqual(result.status, 0);
-  assert.equal(payload.cli.ready, false);
+  assert.equal(payload.cli.ready, true);
+  assert.equal(payload.cli.kind, 'current-process');
   assert.equal(payload.vscode.tasks.ready, false);
   assert.equal(payload.hosts.codex.ready, false);
   assert.equal(payload.hosts.claude.ready, false);
@@ -813,6 +814,21 @@ test('doctor --json reports missing task runtime without downgrading Claude read
   assert.equal(payload.hosts.codex.ready, false);
   assert.equal(payload.hosts.claude.ready, true);
   assert.deepEqual(Object.keys(payload.surfaces).sort(), ['claudeCli', 'claudeGui', 'codexCli', 'codexGui']);
+});
+
+test('status --json matches doctor --json payload and exit semantics', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-status-alias-'));
+  run(['init'], projectRoot);
+
+  const doctorResult = runResult(['doctor', '--json', '--project-root', projectRoot], projectRoot, {
+    env: buildNoCliEnv()
+  });
+  const statusResult = runResult(['status', '--json', '--project-root', projectRoot], projectRoot, {
+    env: buildNoCliEnv()
+  });
+
+  assert.equal(statusResult.status, doctorResult.status);
+  assert.deepEqual(JSON.parse(statusResult.stdout), JSON.parse(doctorResult.stdout));
 });
 
 test('launcher accepts /roadmap and prints the same conceptual palette', () => {

--- a/roadmap-skill/test/host.test.js
+++ b/roadmap-skill/test/host.test.js
@@ -192,3 +192,23 @@ test('inspectHostSetup downgrades Codex readiness when task runtime is missing',
   assert.deepEqual(Object.keys(hostStatus.surfaces).sort(), ['claudeCli', 'claudeGui', 'codexCli', 'codexGui']);
   assert.deepEqual(hostStatus.surfaces.claudeGui.expectedCommands, EXPECTED_NATIVE_SLASH_COMMANDS);
 });
+
+test('inspectHostSetup accepts the currently running CLI as valid resolution', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-host-current-cli-'));
+  fs.writeFileSync(path.join(projectRoot, 'ROADMAP.md'), '# roadmap\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, 'AGENTS.md'), '# agents\n', 'utf8');
+
+  const currentCliPath = path.join(projectRoot, 'node_modules', 'roadmapsmith', 'bin', 'cli.js');
+  fs.mkdirSync(path.dirname(currentCliPath), { recursive: true });
+  fs.writeFileSync(currentCliPath, '\'use strict\';\n', 'utf8');
+
+  const hostStatus = inspectHostSetup(projectRoot, {
+    roadmapFile: path.join(projectRoot, 'ROADMAP.md'),
+    agentsFile: path.join(projectRoot, 'AGENTS.md'),
+    currentCliPath
+  });
+
+  assert.equal(hostStatus.cli.ready, true);
+  assert.equal(hostStatus.cli.kind, 'current-process');
+  assert.equal(hostStatus.cli.path, currentCliPath);
+});

--- a/roadmap-skill/test/parser.test.js
+++ b/roadmap-skill/test/parser.test.js
@@ -43,6 +43,24 @@ test('parseRoadmap extracts rs:no-test marker flag', () => {
   assert.equal(parsed.tasks[0].noTest, true);
 });
 
+test('parseRoadmap disambiguates repeated implicit task text while preserving explicit IDs', () => {
+  const content = [
+    '- [ ] Implement billing module',
+    '- [ ] Implement billing module',
+    '- [ ] Implement billing module <!-- rs:task=explicit-billing -->',
+    '- [ ] Implement billing module',
+    ''
+  ].join('\n');
+
+  const parsed = parseRoadmap(content);
+  assert.deepEqual(parsed.tasks.map((task) => task.id), [
+    'implement-billing-module',
+    'implement-billing-module-2',
+    'explicit-billing',
+    'implement-billing-module-3'
+  ]);
+});
+
 test('parseRoadmap reports managed block range', () => {
   const content = [
     '# Notes',

--- a/roadmap-skill/test/slash.test.js
+++ b/roadmap-skill/test/slash.test.js
@@ -49,11 +49,11 @@ test('resolveSlashInvocation keeps unknown direct slash queries in palette mode'
 });
 
 test('renderSlashPalette includes direct, router, and task examples', () => {
-  const output = renderSlashPalette({ source: '/roadmap', suggestions: getSlashSuggestions('sync') });
+  const output = renderSlashPalette({ source: '/roadmap', suggestions: getSlashSuggestions('status') });
   assert.match(output, /RoadmapSmith slash palette/);
   assert.match(output, /Router form:/);
   assert.match(output, /Classic CLI:/);
-  assert.match(output, /\/roadmap-update/);
-  assert.match(output, /\/roadmap-sync/);
+  assert.match(output, /\/roadmap-status/);
+  assert.match(output, /roadmapsmith status --json/);
   assert.match(output, /VS Code task:/);
 });

--- a/roadmap-skill/test/sync.test.js
+++ b/roadmap-skill/test/sync.test.js
@@ -54,9 +54,32 @@ test('sync writes one warning line when validation fails', () => {
   const secondParsed = parseRoadmap(first);
   const second = applySync(first, secondParsed.tasks, results);
 
-  const warningMatches = second.match(/⚠️ attempted but validation failed/g) || [];
+  const warningMatches = second.match(/⚠️ no implementation evidence found yet/g) || [];
   assert.equal(warningMatches.length, 1);
   assert.match(second, /missing test evidence/);
+});
+
+test('sync reaches a fixed point after the first warning write', () => {
+  const projectRoot = setupFixture('node');
+  fs.writeFileSync(path.join(projectRoot, 'src', 'payment.js'), 'function paymentModule() { return true; }\n', 'utf8');
+
+  const config = loadConfig({ projectRoot });
+  const content = [
+    '## Phase P0',
+    '- [ ] Implement payment module <!-- rs:task=implement-payment-module -->',
+    ''
+  ].join('\n');
+
+  const parsed = parseRoadmap(content);
+  const context = buildValidationContext(projectRoot, config, []);
+  const results = validateTasks(parsed.tasks, context, config, []);
+
+  const first = applySync(content, parsed.tasks, results);
+  const secondParsed = parseRoadmap(first);
+  const secondResults = validateTasks(secondParsed.tasks, context, config, []);
+  const second = applySync(first, secondParsed.tasks, secondResults);
+
+  assert.equal(second, first);
 });
 
 test('sync inserts warning after Evidence lines when validation fails', () => {
@@ -78,7 +101,7 @@ test('sync inserts warning after Evidence lines when validation fails', () => {
   assert.match(next, /  - Evidence: src\/lib\/inventory-sync\.ts\n  - ⚠️ attempted but validation failed: evidence file\(s\) not found: src\/lib\/inventory-sync\.ts/);
 });
 
-test('sync leaves weak path-only Mercado Pago Point task unchecked without warning', () => {
+test('sync keeps an honest no-evidence warning when a task has no concrete attempt signal', () => {
   const projectRoot = setupFixture('generic');
   fs.mkdirSync(path.join(projectRoot, 'src', 'app', 'api', 'mercadopago', 'preference'), { recursive: true });
   fs.writeFileSync(
@@ -107,10 +130,10 @@ test('sync leaves weak path-only Mercado Pago Point task unchecked without warni
   const secondParsed = parseRoadmap(first);
   const second = applySync(first, secondParsed.tasks, results);
 
-  const warningMatches = second.match(/⚠️ attempted but validation failed/g) || [];
-  assert.equal(warningMatches.length, 0);
+  const warningMatches = second.match(/⚠️ no implementation evidence found yet/g) || [];
+  assert.equal(warningMatches.length, 1);
   assert.match(second, /- \[ \] Integración Mercado Pago Point/);
-  assert.doesNotMatch(second, /weak path-only evidence lacks content-specific token match/);
+  assert.match(second, /weak path-only evidence lacks content-specific token match/);
 });
 
 test('sync pipeline: low-confidence task stays unchecked when minimumConfidence is medium', () => {
@@ -136,7 +159,7 @@ test('sync pipeline: high-confidence task gets checked when minimumConfidence is
   assert.ok(next.includes('- [x] implement xyzzy module'), 'Task should be checked');
 });
 
-test('sync removes stale warning when the task has no real attempt signal', () => {
+test('sync rewrites stale attempted wording when the task has no real attempt signal', () => {
   const projectRoot = setupFixture('generic');
   fs.mkdirSync(path.join(projectRoot, 'src', 'app', 'api', 'mercadopago', 'preference'), { recursive: true });
   fs.writeFileSync(
@@ -165,6 +188,7 @@ test('sync removes stale warning when the task has no real attempt signal', () =
 
   assert.match(next, /- \[ \] Integración Mercado Pago Point/);
   assert.doesNotMatch(next, /⚠️ attempted but validation failed/);
+  assert.match(next, /⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match/);
 });
 
 test('sync preserves an already checked task with no evidence or path hints', () => {

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -5,7 +5,8 @@ const os = require('os');
 const path = require('path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { buildValidationContext, validateTask, auditValidation, applyMinimumConfidence, CONFIDENCE_RANK, extractTaskNamespace, isAcceptanceCriteria } = require('../src/validator');
+const { parseRoadmap } = require('../src/parser');
+const { buildValidationContext, validateTask, validateTasks, auditValidation, applyMinimumConfidence, CONFIDENCE_RANK, extractTaskNamespace, isAcceptanceCriteria } = require('../src/validator');
 const { loadConfig } = require('../src/config');
 const { walkFiles, detectWorkspaces } = require('../src/io');
 
@@ -57,6 +58,26 @@ test('validator checks explicit file existence hints', () => {
   const fail = validateTask({ id: 'missing-file', text: 'Create parser in `src/missing.js`' }, context, config, []);
   assert.equal(fail.passed, false);
   assert.match(fail.reasons.join('; '), /missing referenced file/);
+});
+
+test('backticked HTTP routes, MIME types, and formulas do not become referenced file paths', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const cases = [
+    { id: 'http-backtick', text: 'Handle `GET /api/backup` gracefully' },
+    { id: 'mime-backtick', text: 'Support `image/png` uploads' },
+    { id: 'formula-backtick', text: 'Explain `margen = (precioVenta - costPrice) / precioVenta * 100` in docs' }
+  ];
+
+  for (const task of cases) {
+    const result = validateTask(task, context, config, []);
+    assert.ok(
+      !result.reasons.some((reason) => reason.includes('missing referenced file')),
+      `"${task.text}" must not produce missing referenced file reasons, got: ${result.reasons.join('; ')}`
+    );
+  }
 });
 
 test('Evidence line with existing test file passes with medium confidence', () => {
@@ -196,6 +217,24 @@ test('Partial implementation helper alone does not complete feature task', () =>
 
   assert.equal(result.evidence.code, true);
   assert.equal(result.passed, false);
+});
+
+test('token-overlap code evidence does not count as a concrete attempt by itself', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'lib', 'billing.js'), 'export function billingModule() { return true; }\n', 'utf8');
+
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+  const result = validateTask(
+    { id: 'future-billing', text: 'Implement billing module' },
+    context,
+    config,
+    []
+  );
+
+  assert.equal(result.evidence.code, true);
+  assert.equal(result.attempted, false);
 });
 
 test('Negative implementation signals block authoritative Evidence completion when code is explicitly not implemented', () => {
@@ -1010,6 +1049,52 @@ test('rs:no-test disables test requirement for task', () => {
   );
   assert.equal(result.requiresTest, false);
   assert.ok(!result.reasons.includes('missing test evidence'));
+});
+
+test('HTTP expectation acceptance lines do not require standalone test evidence', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const cases = [
+    { id: 'http-400', text: 'POST con `stock: -1` -> HTTP 400' },
+    { id: 'http-401', text: 'GET /api/settings/modules sin sesión -> HTTP 401' }
+  ];
+
+  for (const task of cases) {
+    const result = validateTask(task, context, config, []);
+    assert.equal(result.requiresTest, false, `"${task.text}" must not require a standalone test`);
+    assert.ok(
+      !result.reasons.includes('missing test evidence'),
+      `"${task.text}" must not report missing test evidence, got: ${result.reasons.join('; ')}`
+    );
+  }
+});
+
+test('duplicate implicit task text gets independent validation results', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'lib', 'inventory-sync.ts'), 'export function syncInventory() {}\n', 'utf8');
+
+  const content = [
+    '## Phase P1',
+    '- [ ] Implement inventory sync',
+    '  - Evidence: src/lib/inventory-sync.ts',
+    '- [ ] Implement inventory sync',
+    '  - Evidence: src/lib/missing-inventory-sync.ts',
+    ''
+  ].join('\n');
+
+  const parsed = parseRoadmap(content);
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+  const results = validateTasks(parsed.tasks, context, config, []);
+
+  assert.equal(parsed.tasks[0].id, 'implement-inventory-sync');
+  assert.equal(parsed.tasks[1].id, 'implement-inventory-sync-2');
+  assert.equal(results[parsed.tasks[0].id].passed, true);
+  assert.equal(results[parsed.tasks[1].id].passed, false);
+  assert.match(results[parsed.tasks[1].id].reasons.join('; '), /missing-inventory-sync\.ts/);
 });
 
 test('i18n and translation files are excluded from evidence file index', () => {

--- a/skills.json
+++ b/skills.json
@@ -22,7 +22,7 @@
     "command": "npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code",
     "source": "PapiScholz/roadmapsmith",
     "skill": "*",
-    "notes": "Recommended Claude Code install path for native GUI slash commands like /roadmap, /roadmap-zero, /roadmap-maintain, /roadmap-status, /roadmap-init, /roadmap-generate, /roadmap-validate, /roadmap-update, /roadmap-audit, and /roadmap-setup. The legacy /roadmap-sync root remains available for compatibility, especially as /roadmap-sync <action>. Install the roadmapsmith CLI separately for actual command execution, then run /reload-skills and, if applicable, /reload-plugins. Codex native plugin installs use the repo/package .codex-plugin surface instead of this Claude-specific skills CLI path."
+    "notes": "Recommended Claude Code install path for native GUI slash commands like /roadmap, /roadmap-zero, /roadmap-maintain, /roadmap-status, /roadmap-init, /roadmap-generate, /roadmap-validate, /roadmap-update, /roadmap-audit, and /roadmap-setup. The legacy /roadmap-sync root remains available for compatibility, especially as /roadmap-sync <action>. Install the roadmapsmith CLI separately for actual command execution; roadmapsmith status is the visible readiness command and roadmapsmith doctor remains a compatibility alias. Then run /reload-skills and, if applicable, /reload-plugins. Codex native plugin installs use the repo/package .codex-plugin surface instead of this Claude-specific skills CLI path."
   },
   "skills": [
     {
@@ -46,7 +46,7 @@
     {
       "name": "roadmap-status",
       "path": "skills/roadmap-status",
-      "description": "Native slash readiness check grounded in roadmapsmith doctor JSON.",
+      "description": "Native slash readiness check grounded in roadmapsmith status JSON.",
       "version": "0.9.24"
     },
     {

--- a/skills/roadmap-sync/agents/openai.yaml
+++ b/skills/roadmap-sync/agents/openai.yaml
@@ -2,6 +2,6 @@
   "interface": {
     "display_name": "Roadmap Sync",
     "short_description": "Legacy root plus policy for evidence-backed ROADMAP.md slash workflows.",
-    "default_prompt": "Prefer /roadmap for discovery, /roadmap-maintain for existing repos, and /roadmap-update for direct sync."
+    "default_prompt": "Prefer /roadmap, /roadmap-status, /roadmap-maintain, and /roadmap-update."
   }
 }


### PR DESCRIPTION
## Summary
- unify validator path extraction so backticked HTTP routes, MIME types, and formulas no longer become file hints
- tighten sync attempted/no-evidence semantics, deterministic implicit task IDs, and fixed-point coverage
- align status/doctor CLI and slash surfaces, plus docs and bundle metadata

## Test Plan
- C:\Program Files\nodejs\node.exe scripts\pre-push-gate.js qa-regression
- C:\Program Files\nodejs\node.exe scripts\pre-push-gate.js functional-smoke