### PR TITLE
fix: harden roadmap validation and update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 ```
 
 This is the recommended install path if you want native Claude GUI slash commands such as `/roadmap`, `/roadmap-zero`, `/roadmap-maintain`, `/roadmap-status`, `/roadmap-init`, `/roadmap-generate`, `/roadmap-validate`, `/roadmap-update`, `/roadmap-audit`, and `/roadmap-setup`.
-If you install only `--skill roadmap-sync`, Claude GUI will expose only `/roadmap-sync`.
+`roadmap-sync` is deprecated compatibility only; install the full bundle for new workflows and use `/roadmap-maintain` or `/roadmap-update`.
 The skills guide the agent. The CLI executes actions. `roadmapsmith setup` makes those actions visible in VS Code, generates per-platform task wrappers, and can also wire the repo-local Claude hook, but it does not create native Claude GUI slash commands by itself.
 The published RoadmapSmith package/plugin surface now ships the same shared bundle files (`skills.json`, `skills/*`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`) as the GitHub-source install path, but consuming the CLI alone still does not auto-register native Codex or Claude GUI commands.
 
@@ -91,6 +91,7 @@ RoadmapSmith introduces a third path: **validation by evidence**. Before `sync` 
 roadmapsmith setup             # Create visible VS Code tasks + optional Claude hook wiring
 roadmapsmith zero              # Empty repo: terminal interview + init + generate
 roadmapsmith maintain          # Existing repo: generate + sync + audit
+roadmapsmith update --task <id> --evidence "<code-and-test paths>"  # Complete one verified task
 roadmapsmith init              # Advanced/manual: write ROADMAP.md + AGENTS.md governance files
 roadmapsmith generate          # Advanced/manual: preserve-first roadmap update from repository context
 roadmapsmith generate --full-regen # Advanced/manual: explicit full managed-block rebuild
@@ -133,7 +134,11 @@ roadmapsmith /roadmap-sync validate
 
 Claude write-time autoupdate depends on the host environment being able to resolve `node` for the repo-local hook. VS Code tasks use generated wrappers and can also honor `ROADMAPSMITH_NODE` when PATH-based Node resolution is unreliable. That best-effort hook is separate from this repository's git `pre-commit` sync behavior. Native Claude GUI slash commands come from the installed RoadmapSmith skill bundle; native Codex plugin install comes from `.codex-plugin/plugin.json` plus a marketplace entry; CLI slash routing (`roadmapsmith /roadmap`, `roadmapsmith /roadmap maintain`, and deprecated short aliases) is a separate surface that remains available in terminals and launchers. The published package now mirrors that same bundle on disk for downstream host loaders, but each host still has to load its own surface before the GUI changes.
 
-Windows note: prefer `roadmapsmith.cmd`, `npm.cmd`, or explicit `node` paths in shells where PowerShell execution policy or PATH resolution differs from `cmd.exe`.
+Windows note: prefer `roadmapsmith.cmd`, `npm.cmd`, or explicit `node` paths in shells where PowerShell execution policy or PATH resolution differs from `cmd.exe`. If the globally installed shim fails because `node` is absent from that shell PATH, bypass the npm shim:
+
+```powershell
+& "C:\Program Files\nodejs\node.exe" "$env:APPDATA\npm\node_modules\roadmapsmith\bin\cli.js" <command>
+```
 
 ---
 
@@ -204,7 +209,7 @@ Recommended workflow:
 roadmapsmith maintain
 ```
 
-`maintain` runs `generate + sync + audit` in one invocation. Use the lower-level commands only when you want manual inspection or tighter control.
+`maintain` runs `generate + sync + audit` in one invocation. After it succeeds, do not run generate, sync, or audit again in the same cycle unless you need manual inspection or tighter control.
 
 ---
 
@@ -363,6 +368,7 @@ Do not use it if:
 | `roadmapsmith /roadmap-zero` | Native slash alias for Zero Mode |
 | `roadmapsmith /roadmap-maintain` | Native slash alias for the default existing-repo flow |
 | `roadmapsmith /roadmap-update` | Native slash alias for applying evidence-backed sync |
+| `roadmapsmith update --task <id> --evidence <text>` | Complete one task only after supplied evidence validates at high confidence |
 | `roadmapsmith /roadmap-sync validate` | Execute the deprecated legacy namespaced root form through the router |
 | `roadmapsmith init` | Create `ROADMAP.md` and `AGENTS.md` governance files |
 | `roadmapsmith generate --project-root .` | Preserve-first roadmap update from repository context |

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -14,9 +14,10 @@ Use this document for context and command runbook notes only.
 - `roadmapsmith setup` creates the visible VS Code host UX and optional Claude hook wiring.
 - `roadmapsmith zero` is the one-command empty-repo flow.
 - `roadmapsmith maintain` is the one-command existing-repo flow.
+- `roadmapsmith update --task <id> --evidence <text>` is the verified high-confidence single-task completion flow.
 - Native Codex plugin support comes from `.codex-plugin/plugin.json` plus the repo-local marketplace at `.agents/plugins/marketplace.json`.
 - Native Claude GUI slash commands come from the full skill bundle: `/roadmap`, `/roadmap-zero`, `/roadmap-maintain`, `/roadmap-status`, `/roadmap-init`, `/roadmap-generate`, `/roadmap-validate`, `/roadmap-update`, `/roadmap-audit`, and `/roadmap-setup`.
-- `roadmap-sync` remains the legacy/namespaced policy skill; installing only that skill is not full product activation.
+- `roadmap-sync` is a deprecated legacy/namespaced compatibility skill; installing only that skill is not full product activation.
 - Published npm/plugin artifacts must carry the same shared bundle files as the GitHub-source install path: `skills.json`, `skills/*`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and the Codex manifest assets they reference.
 
 Release work is not ready until the docs, host UX, and changelog all reflect that contract consistently.
@@ -58,7 +59,8 @@ Before merging to `main`:
    - `RoadmapSmith: Maintain`
 3. Failure states are actionable:
    - CLI missing
-   - Node runtime missing
+- Node runtime missing
+- global npm CLI shim cannot resolve Node from PATH, with the explicit PowerShell node-and-cli fallback documented
    - skill-only legacy install (`/roadmap-sync` root only)
    - invalid host config
    - `zero` in non-interactive mode

--- a/docs/release-ux-gate.md
+++ b/docs/release-ux-gate.md
@@ -13,6 +13,7 @@ The public entrypoints must stay consistent across CLI help, VS Code tasks, laun
 - `roadmapsmith setup`
 - `roadmapsmith zero`
 - `roadmapsmith maintain`
+- `roadmapsmith update --task <id> --evidence <text>`
 - `roadmapsmith /roadmap`
 - Native Codex plugin install/discovery via `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`
 - Native Claude GUI slash commands: `/roadmap`, `/roadmap-zero`, `/roadmap-maintain`, `/roadmap-status`, `/roadmap-init`, `/roadmap-generate`, `/roadmap-validate`, `/roadmap-update`, `/roadmap-audit`, `/roadmap-setup`
@@ -21,7 +22,7 @@ The skill bundle remains a GUI/policy layer distinct from the CLI:
 
 - from repo root: `codex plugin marketplace add .`
 - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`
-- `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` remains the legacy compatibility path
+- `npx skills add PapiScholz/roadmapsmith --skill roadmap-sync` is a deprecated compatibility path
 
 Skill installation alone must never be described as full activation of the product.
 
@@ -105,6 +106,7 @@ These cases must be tested:
 - `roadmapsmith zero` in non-interactive mode
 - user installed only the skill
 - user installed only the legacy `roadmap-sync` skill
+- global npm CLI shim cannot resolve `node`, with the documented explicit PowerShell fallback
 
 Pass when each case tells the user:
 

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -76,13 +76,13 @@ This exposes the native Claude GUI slash commands:
 
 It still does not install the CLI; the CLI must be installed separately for those commands to execute. That same bundle is now also present in the published package/plugin artifact alongside the Codex plugin manifest for downstream host installers that do not fetch directly from the GitHub working tree.
 
-### Option 3: Install only the legacy compatibility skill
+### Option 3: Legacy compatibility skill (deprecated)
 
 ```bash
 npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ```
 
-This installs only the legacy namespaced slash root `/roadmap-sync` plus the policy instructions. It does not expose the full Claude GUI command list.
+This installs only the deprecated legacy namespaced slash root `/roadmap-sync` plus the policy instructions. It does not expose the full Claude GUI command list; use the full bundle and `/roadmap-maintain` or `/roadmap-update` for new workflows.
 
 ### Option 4: Manual hook setup
 
@@ -120,8 +120,7 @@ roadmapsmith zero
 # 3. For an existing repo, run the maintenance flow in one command
 roadmapsmith maintain
 
-# 4. At the end of the session, verify the state is accurate
-roadmapsmith sync --audit
+# 4. Maintain already generated, synced, and audited the roadmap. Run lower-level commands only for manual inspection.
 
 # 5. Commit — if you use a pre-commit hook, it can run a final sync
 git commit -m "feat: implement task X"
@@ -174,6 +173,8 @@ Use `validate --json` when you want to inspect per-task evidence before taking a
 `roadmapsmith status --json` now separates the native slash surfaces (`claudeGui`, `claudeCli`, `codexGui`, `codexCli`) from the repo-local VS Code task and Claude hook layer. `roadmapsmith doctor --json` remains a compatibility alias. Use that output when you need to distinguish “the bundle exists” from “the host actually loaded it.”
 
 **Hook runs but ROADMAP does not update:** Confirm the Claude hook environment can resolve `node`. Today the repo-local write-time hook is best-effort and depends on that host-level resolution.
+
+**Global CLI says `node` is not recognized:** In PowerShell, bypass the npm shim with `& "C:\Program Files\nodejs\node.exe" "$env:APPDATA\npm\node_modules\roadmapsmith\bin\cli.js" <command>`.
 
 **Sync reverts a task I just completed:** Run `roadmapsmith validate --json` to see what evidence the validator found. The task text or file path in the roadmap may not match what the agent created.
 

--- a/docs/use-cases/sync-audit-mode.md
+++ b/docs/use-cases/sync-audit-mode.md
@@ -39,7 +39,7 @@ A task passes only when accumulated evidence exceeds the configured threshold.
 roadmapsmith maintain
 ```
 
-`maintain` is the default existing-repo flow. It runs `generate + sync + audit` in one invocation.
+`maintain` is the default existing-repo flow. It runs `generate + sync + audit` in one invocation; after it succeeds, do not rerun those lower-level commands in the same cycle unless you need manual control.
 
 Advanced/manual flow:
 
@@ -60,6 +60,7 @@ When `sync` runs:
 - Tasks with passing evidence are marked `[x]`
 - Tasks with concrete attempt evidence emit `⚠️ attempted but validation failed: <reason>` in the roadmap
 - Tasks without concrete attempt evidence emit `⚠️ no implementation evidence found yet: <reason>` in the roadmap
+- A historical warning with fresh code-and-test evidence is classified as `WARN:STALE_EVIDENCE`; sync records the discovered files and completes it only at high confidence
 - `--audit` surfaces tasks that claim completion but have no evidence, and tasks that have evidence but are still unchecked
 
 This means a PR reviewer can run `sync --audit` and see a factual mismatch report — not just the agent's word.
@@ -83,3 +84,11 @@ roadmapsmith sync --audit
 ```
 
 Use `--dry-run` before applying changes. Use `validate --json` when you need a read-only evidence inspection. Use `--audit` when you want the current post-sync summary.
+
+## Completing one task with evidence
+
+```bash
+roadmapsmith update --task p2-customer-history --evidence "src/app/api/customers/route.ts, test/customers.test.js"
+```
+
+`update` verifies the supplied single-line evidence against the repository and writes only if it reaches high confidence. Add `--dry-run` to preview the exact roadmap change.

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-- None yet.
+### Added
+- add verified `roadmapsmith update --task --evidence` completion flow
+- add structured validation diagnostics and stale-evidence convergence
+
+### Changed
+- document Windows global CLI Node fallback and visibly deprecate the legacy roadmap-sync skill
 
 ## v0.9.27 - 2026-06-19
 

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -28,7 +28,7 @@ npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code
 ```
 
 This is the recommended Claude Code install path for native GUI slash commands such as `/roadmap`, `/roadmap-zero`, `/roadmap-maintain`, `/roadmap-status`, `/roadmap-init`, `/roadmap-generate`, `/roadmap-validate`, `/roadmap-update`, `/roadmap-audit`, and `/roadmap-setup`.
-If you install only `--skill roadmap-sync`, Claude GUI will expose only `/roadmap-sync`.
+`roadmap-sync` is deprecated compatibility only; install the full bundle for new workflows and use `/roadmap-maintain` or `/roadmap-update`.
 The skill bundle does not install the CLI and it does not create visible VS Code actions by itself.
 The published `roadmapsmith` package/plugin surface now also ships the shared bundle files for both hosts (`skills.json`, `skills/*`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`) for downstream host installers, but consuming the CLI alone still does not auto-register native Codex or Claude GUI commands.
 
@@ -101,7 +101,11 @@ Use the lower-level commands only when you want manual control over generation, 
 | CI | Use disposable checkouts if you run `sync --audit`, because it still mutates the roadmap today. |
 | Other hosts | Use the skill plus manual CLI commands. |
 
-If Node is installed outside PATH, set `ROADMAPSMITH_NODE` to a working `node` executable before using the generated VS Code tasks.
+If Node is installed outside PATH, set `ROADMAPSMITH_NODE` to a working `node` executable before using the generated VS Code tasks. If the globally installed `roadmapsmith` shim itself cannot resolve Node, bypass it in PowerShell with:
+
+```powershell
+& "C:\Program Files\nodejs\node.exe" "$env:APPDATA\npm\node_modules\roadmapsmith\bin\cli.js" <command>
+```
 
 ---
 
@@ -119,6 +123,7 @@ roadmapsmith maintain [--project-root <path>] [--config <path>] [--roadmap-file 
 roadmapsmith init [--roadmap-file <path>] [--agents-file <path>] [--dry-run]
 roadmapsmith generate [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--dry-run] [--audit] [--full-regen]
 roadmapsmith sync [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run] [--audit]
+roadmapsmith update --task <stable-id> --evidence <text> [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run]
 roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json]
 roadmapsmith status [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]
 roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]   # compatibility alias
@@ -183,6 +188,8 @@ The repo does not remove user-global skills automatically. Use the `doctor` outp
   - `- ⚠️ attempted but validation failed: <reason>` when there is concrete attempt evidence
   - `- ⚠️ no implementation evidence found yet: <reason>` when there is not
 - Preserves unmanaged markdown content by updating only the managed roadmap block.
+- `validate` emits structured diagnostics in human and JSON output (`FAIL:NOT_IMPLEMENTED`, `FAIL:NO_TEST`, `FAIL:MISSING_REFERENCE`, and `WARN:STALE_EVIDENCE`).
+- `update --task <id> --evidence <text>` writes only when the evidence validates at high confidence; otherwise the roadmap is unchanged.
 
 ## Defaults
 

--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -4,7 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const readline = require('node:readline/promises');
-const { parseArgv } = require('../src/utils');
+const { ensureTrailingNewline, parseArgv } = require('../src/utils');
 const { loadConfig, resolveRoadmapFile, resolveAgentsFile, loadPlugins, readUserConfig, resolveConfigPath } = require('../src/config');
 const { readTextIfExists, writeText, printDryRunDiff } = require('../src/io');
 const { buildSetupFiles, applySetupFiles, inspectHostSetup, parseHosts, assertSupportedEditor } = require('../src/host');
@@ -30,6 +30,7 @@ function printHelp() {
     '  roadmapsmith setup [--project-root <path>] [--config <path>] [--editor vscode] [--hosts <codex,claude>] [--dry-run]',
     '  roadmapsmith generate [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--dry-run] [--audit] [--full-regen]',
     '  roadmapsmith sync [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run] [--audit]',
+    '  roadmapsmith update --task <stable-id> --evidence <text> [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run]',
     '  roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json]',
     '  roadmapsmith status [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]',
     '  roadmapsmith doctor [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]   # compatibility alias'
@@ -44,8 +45,13 @@ function isEnabled(value) {
 }
 
 function formatResultLine(task, result) {
-  const status = result.passed ? 'PASS' : 'FAIL';
-  const reason = result.reasons.length > 0 ? ` :: ${result.reasons.join('; ')}` : '';
+  const diagnostics = Array.isArray(result.diagnostics) ? result.diagnostics : [];
+  const primaryError = diagnostics.find((item) => item.severity === 'error');
+  const warnings = diagnostics.filter((item) => item.severity === 'warning');
+  const status = primaryError ? `FAIL:${primaryError.code}` : (result.passed ? 'PASS' : 'FAIL');
+  const parts = [...result.reasons];
+  warnings.forEach((item) => parts.push(`WARN:${item.code} ${item.message}`));
+  const reason = parts.length > 0 ? ` :: ${parts.join('; ')}` : '';
   return `${status} [${task.id}] ${task.text}${reason}`;
 }
 
@@ -215,6 +221,77 @@ function runSyncCommand(projectRoot, config, flags, options = {}) {
   }
 }
 
+function addEvidenceToTask(content, task, evidenceText) {
+  const lines = String(content || '').split(/\r?\n/);
+  const evidenceLine = `${task.indent || ''}  - Evidence: ${evidenceText}`;
+  if (Array.isArray(task.evidenceLines) && task.evidenceLines.length > 0) {
+    lines[task.evidenceLines[0].lineIndex] = evidenceLine;
+    return ensureTrailingNewline(lines.join('\n'));
+  }
+
+  const insertionIndex = task.warningLineIndex != null
+    ? task.warningLineIndex
+    : task.lastChildLineIndex + 1;
+  lines.splice(insertionIndex, 0, evidenceLine);
+  return ensureTrailingNewline(lines.join('\n'));
+}
+
+function runUpdateCommand(projectRoot, config, flags) {
+  const hasTask = flags.task != null;
+  const hasEvidence = flags.evidence != null;
+  if (!hasTask && !hasEvidence) {
+    runSyncCommand(projectRoot, config, flags);
+    return;
+  }
+  if (!hasTask || !hasEvidence || Array.isArray(flags.task) || Array.isArray(flags.evidence)) {
+    throw new Error('update requires exactly one --task <stable-id> and one --evidence <text> value');
+  }
+
+  const taskId = String(flags.task).trim();
+  const evidenceText = String(flags.evidence).trim();
+  if (!taskId || !evidenceText || /[\r\n]/.test(evidenceText)) {
+    throw new Error('update requires a non-empty single-line --task and --evidence value');
+  }
+
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const content = readTextIfExists(roadmapFile);
+  if (content == null) {
+    throw new Error(`Roadmap not found: ${roadmapFile}`);
+  }
+
+  const parsedRoadmap = parseRoadmap(content);
+  const matches = tasksInManagedBlock(parsedRoadmap).filter((task) => task.id === taskId);
+  if (matches.length !== 1) {
+    throw new Error(matches.length === 0
+      ? `Roadmap task not found: ${taskId}`
+      : `Roadmap task ID is ambiguous: ${taskId}`);
+  }
+
+  const draft = addEvidenceToTask(content, matches[0], evidenceText);
+  const draftTask = tasksInManagedBlock(parseRoadmap(draft)).find((task) => task.id === taskId);
+  const validationContext = buildValidationContext(projectRoot, config, loadPlugins(projectRoot, config.plugins));
+  const result = validateTasks([draftTask], validationContext, config, validationContext.plugins)[taskId];
+  const errors = (result.diagnostics || []).filter((item) => item.severity === 'error');
+  const suppliedEvidenceResolved = result.evidence.authoritative && result.evidence.authoritativeFiles.length > 0;
+  if (!suppliedEvidenceResolved || !result.passed || result.confidence !== 'high' || errors.length > 0) {
+    const reasons = result.reasons.length > 0 ? `: ${result.reasons.join('; ')}` : '';
+    throw new Error(`Task ${taskId} was not updated; supplied evidence must resolve in the repository and validate at high confidence${reasons}`);
+  }
+
+  const next = applySync(draft, [draftTask], { [taskId]: result });
+  const dryRun = isEnabled(flags['dry-run']);
+  const writeResult = writeText(roadmapFile, next, { dryRun });
+  if (dryRun) {
+    if (writeResult.changed) {
+      printDryRunDiff(roadmapFile, writeResult.before, writeResult.after);
+    } else {
+      console.log(`No changes for ${roadmapFile}`);
+    }
+  } else {
+    console.log(writeResult.changed ? `Updated ${roadmapFile}` : `No changes for ${roadmapFile}`);
+  }
+}
+
 function printHumanStatus(payload) {
   console.log('RoadmapSmith status\n');
   console.log(`Project root: ${payload.projectRoot}`);
@@ -343,6 +420,8 @@ async function run() {
     if (slashAction.id === 'audit') {
       flags.audit = true;
       effectiveCommand = 'sync';
+    } else if (slashAction.id === 'sync' && String(command).trim().toLowerCase() === '/roadmap-update') {
+      effectiveCommand = 'update';
     } else {
       effectiveCommand = slashAction.id;
     }
@@ -408,6 +487,13 @@ async function run() {
     const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
     const config = loadConfig({ projectRoot, configPath: flags.config });
     runSyncCommand(projectRoot, config, flags);
+    return;
+  }
+
+  if (effectiveCommand === 'update') {
+    const projectRoot = path.resolve(String(flags['project-root'] || process.cwd()));
+    const config = loadConfig({ projectRoot, configPath: flags.config });
+    runUpdateCommand(projectRoot, config, flags);
     return;
   }
 

--- a/roadmap-skill/src/sync/index.js
+++ b/roadmap-skill/src/sync/index.js
@@ -142,6 +142,18 @@ function applySync(content, parsedTasks, results) {
         lines.splice(warningIndex, 1);
         offset -= 1;
       }
+      if (
+        result.staleEvidenceResolved &&
+        (!Array.isArray(task.evidenceLines) || task.evidenceLines.length === 0) &&
+        result.discoveredEvidence
+      ) {
+        const insertionIndex = Math.max(
+          lineIndex + 1,
+          (task.lastChildLineIndex + offset) + 1
+        );
+        lines.splice(insertionIndex, 0, `${task.indent || ''}  - Evidence: ${result.discoveredEvidence}`);
+        offset += 1;
+      }
       continue;
     }
 

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -1290,6 +1290,52 @@ function buildValidationContext(projectRoot, config, plugins) {
   };
 }
 
+function diagnosticCodeForReason(reason) {
+  const normalized = String(reason || '').toLowerCase();
+  if (normalized.includes('missing referenced file') || normalized.includes('evidence file(s) not found')) {
+    return 'MISSING_REFERENCE';
+  }
+  if (normalized.includes('missing test evidence')) {
+    return 'NO_TEST';
+  }
+  if (
+    normalized.includes('no code, test, or artifact evidence found') ||
+    normalized.includes('implementation task requires evidence line') ||
+    normalized.includes('weak path') ||
+    normalized.includes('file reference shows implementation location')
+  ) {
+    return 'NOT_IMPLEMENTED';
+  }
+  return null;
+}
+
+function buildDiagnostics(reasons, options = {}) {
+  const diagnostics = [];
+  const seen = new Set();
+  for (const reason of Array.isArray(reasons) ? reasons : []) {
+    const code = diagnosticCodeForReason(reason);
+    if (!code || seen.has(code)) {
+      continue;
+    }
+    seen.add(code);
+    diagnostics.push({ code, severity: 'error', message: reason });
+  }
+  if (options.staleEvidence) {
+    diagnostics.push({
+      code: 'STALE_EVIDENCE',
+      severity: 'warning',
+      message: 'historical validation warning conflicts with fresh repository evidence'
+    });
+  }
+  return diagnostics;
+}
+
+function buildDiscoveredEvidenceLine(evidence) {
+  const files = unionArrays(evidence.codeFiles, evidence.testFiles)
+    .sort((left, right) => left.localeCompare(right));
+  return files.length > 0 ? files.join(', ') : null;
+}
+
 function validateTask(task, context, config, plugins) {
   const {
     paths: pathHints,
@@ -1467,7 +1513,14 @@ function validateTask(task, context, config, plugins) {
   // evidence, artifact evidence, or strong code+test threshold to pass.
   // Already-checked tasks with found path hints are preserved via shouldPreserveCheckedTask.
   const hasHighConfidenceImplementationEvidence = meetsStrongThreshold && evidence.code && evidence.test;
+  const hasFreshRepositoryEvidence = hasStrongEvidence || hasWeakEvidence;
+  let staleEvidenceDetected = false;
+  let staleEvidenceResolved = false;
   let passed = authoritativeEvidence.passed || hasArtifactTaskPass || hasTrustedRuleEvidencePass || meetsStrongThreshold;
+
+  if (task.warningText && !task.checked && hasFreshRepositoryEvidence && !authoritativeEvidence.passed) {
+    staleEvidenceDetected = true;
+  }
 
   if (!passed && !task.checked && hasDirectReferencePass) {
     const locationReason = 'file reference shows implementation location, not confirmed completion';
@@ -1476,13 +1529,15 @@ function validateTask(task, context, config, plugins) {
     }
   }
 
-  // Unchecked tasks with an existing ⚠️ warning are preserved as failing unless an Evidence line
-  // explicitly confirms implementation. meetsStrongThreshold (token match) cannot override a
-  // human/agent judgment that the feature is incomplete.
+  // Historical warnings are only cleared by independent, high-confidence repository evidence.
   if (task.warningText && !task.checked && passed && !authoritativeEvidence.passed) {
-    passed = false;
-    if (uniqueReasons.length === 0) {
-      uniqueReasons.push('validation failed');
+    if (hasHighConfidenceImplementationEvidence && negativeSignalMatches.length === 0 && uniqueReasons.length === 0) {
+      staleEvidenceResolved = true;
+    } else {
+      passed = false;
+      if (uniqueReasons.length === 0) {
+        uniqueReasons.push('validation failed');
+      }
     }
   }
   if (negativeSignalMatches.length > 0) {
@@ -1533,17 +1588,21 @@ function validateTask(task, context, config, plugins) {
   // Used by auditValidation to flag implementation tasks that pass solely via documentation.
   const evidenceIsDocOnly = !evidence.code && !evidence.test && evidence.artifact && !isDocTask(task.text);
 
+  const finalPassed = overrideResult ? overrideResult.passed !== false : (passed && uniqueReasons.length === 0);
   return {
     taskId: task.id,
-    passed: overrideResult ? overrideResult.passed !== false : (passed && uniqueReasons.length === 0),
+    passed: finalPassed,
     confidence,
     reasons: uniqueReasons,
+    diagnostics: buildDiagnostics(uniqueReasons, { staleEvidence: staleEvidenceDetected }),
     evidence,
     evidenceIsDocOnly,
     requiresTest,
     hasEvidence: hasStrongEvidence || hasWeakEvidence,
     attempted,
-    preservedCheckedState
+    preservedCheckedState,
+    staleEvidenceResolved,
+    discoveredEvidence: staleEvidenceResolved ? buildDiscoveredEvidenceLine(evidence) : null
   };
 }
 

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -327,6 +327,64 @@ test('cli /roadmap-update --dry-run is stable for the RoadmapSmith repo roadmap'
   assert.equal(after, before);
 });
 
+test('cli update completes one task only after its supplied evidence validates at high confidence', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-update-task-'));
+  writePackageJson(projectRoot);
+  fs.mkdirSync(path.join(projectRoot, 'src'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, 'tests'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'customer-history.js'), 'function customerHistory() { return []; }\nmodule.exports = { customerHistory };\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, 'tests', 'customer-history.test.js'), "const { customerHistory } = require('../src/customer-history');\ntest('customer history', () => customerHistory());\n", 'utf8');
+  fs.writeFileSync(
+    path.join(projectRoot, CANONICAL_ROADMAP),
+    [
+      '## Phase P2',
+      '- [ ] Implement customer history <!-- rs:task=p2-customer-history -->',
+      '- [ ] Implement unrelated feature <!-- rs:task=p2-unrelated -->',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  const result = runResult([
+    'update',
+    '--task', 'p2-customer-history',
+    '--evidence', 'src/customer-history.js, tests/customer-history.test.js'
+  ], projectRoot);
+  const content = fs.readFileSync(path.join(projectRoot, CANONICAL_ROADMAP), 'utf8');
+
+  assert.equal(result.status, 0);
+  assert.match(content, /- \[x\] Implement customer history/);
+  assert.match(content, /Evidence: src\/customer-history\.js, tests\/customer-history\.test\.js/);
+  assert.match(content, /- \[ \] Implement unrelated feature/);
+});
+
+test('cli update rejects unresolved evidence without mutating the roadmap, including dry runs', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-update-reject-'));
+  writePackageJson(projectRoot);
+  fs.mkdirSync(path.join(projectRoot, 'src'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, 'tests'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, 'src', 'customer-history.js'), 'function customerHistory() { return []; }\nmodule.exports = { customerHistory };\n', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, 'tests', 'customer-history.test.js'), "const { customerHistory } = require('../src/customer-history');\ntest('customer history', () => customerHistory());\n", 'utf8');
+  const roadmapPath = path.join(projectRoot, CANONICAL_ROADMAP);
+  fs.writeFileSync(
+    roadmapPath,
+    ['## Phase P2', '- [ ] Implement customer history <!-- rs:task=p2-customer-history -->', ''].join('\n'),
+    'utf8'
+  );
+  const before = fs.readFileSync(roadmapPath, 'utf8');
+
+  const result = runResult([
+    '/roadmap-update',
+    '--task', 'p2-customer-history',
+    '--evidence', 'customer history was implemented',
+    '--dry-run'
+  ], projectRoot);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /must resolve in the repository and validate at high confidence/);
+  assert.equal(fs.readFileSync(roadmapPath, 'utf8'), before);
+});
+
 test('cli /roadmap-update and /roadmap-sync update share stable warning output', () => {
   const projectRoot = setupFixture('warning-sync');
   fs.writeFileSync(
@@ -527,6 +585,25 @@ test('cli validate resolves Next.js app-dir route-group aliases without missing 
   assert.doesNotMatch(result.stdout, /missing referenced file\(s\): \/login/);
   assert.doesNotMatch(result.stdout, /missing referenced file\(s\): \/setup/);
   assert.match(result.stdout, /file reference shows implementation location, not confirmed completion/);
+});
+
+test('cli validate prints diagnostic codes and includes them in JSON output', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-diagnostics-'));
+  writePackageJson(projectRoot);
+  fs.writeFileSync(
+    path.join(projectRoot, CANONICAL_ROADMAP),
+    ['## Phase P0', '- [ ] Implement missing module <!-- rs:task=implement-missing-module -->', ''].join('\n'),
+    'utf8'
+  );
+
+  const human = runResult(['validate', '--project-root', projectRoot], projectRoot);
+  const json = runResult(['validate', '--json', '--project-root', projectRoot], projectRoot);
+  const payload = JSON.parse(json.stdout);
+
+  assert.equal(human.status, 1);
+  assert.match(human.stdout, /FAIL:NOT_IMPLEMENTED \[implement-missing-module\]/);
+  assert.equal(json.status, 1);
+  assert.ok(payload[0].result.diagnostics.some((item) => item.code === 'NOT_IMPLEMENTED' && item.severity === 'error'));
 });
 
 test('cli sync rewrites legacy attempted warnings and reaches a fixed point on the second run', () => {

--- a/roadmap-skill/test/skills-manifest.test.js
+++ b/roadmap-skill/test/skills-manifest.test.js
@@ -115,8 +115,8 @@ test('root skills directory contains only the declared namespaced RoadmapSmith b
 test('roadmap-sync Codex metadata parses cleanly and stays short enough for the loader', () => {
   const metadata = JSON.parse(fs.readFileSync(ROADMAP_SYNC_OPENAI_YAML_PATH, 'utf8'));
 
-  assert.equal(metadata.interface.display_name, 'Roadmap Sync');
-  assert.match(metadata.interface.short_description, /legacy root|policy/i);
+  assert.equal(metadata.interface.display_name, 'Roadmap Sync (Deprecated)');
+  assert.match(metadata.interface.short_description, /deprecated/i);
   assert.match(metadata.interface.default_prompt, /\/roadmap-update/);
   assert.ok(metadata.interface.default_prompt.length <= 128);
 });

--- a/roadmap-skill/test/sync.test.js
+++ b/roadmap-skill/test/sync.test.js
@@ -35,6 +35,38 @@ test('sync marks task complete when validation passes', () => {
   assert.doesNotMatch(next, /validation failed/);
 });
 
+test('sync resolves stale warnings with high-confidence evidence and records discovered files', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, 'src', '__tests__'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'lib', 'notification.ts'),
+    'export function sendNotification() {} export function notifySystem() {}\n',
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', '__tests__', 'notification.test.ts'),
+    "import { sendNotification } from '../lib/notification';\ntest('notification system sends delivery', () => sendNotification());\n",
+    'utf8'
+  );
+
+  const config = loadConfig({ projectRoot });
+  const content = [
+    '## Phase P2',
+    '- [ ] Add notification system <!-- rs:task=add-notifications -->',
+    '  - ⚠️ attempted but validation failed: helper exists but no delivery mechanism',
+    ''
+  ].join('\n');
+  const parsed = parseRoadmap(content);
+  const context = buildValidationContext(projectRoot, config, []);
+  const results = validateTasks(parsed.tasks, context, config, []);
+  const next = applySync(content, parsed.tasks, results);
+
+  assert.match(next, /- \[x\] Add notification system/);
+  assert.match(next, /Evidence: src\/__tests__\/notification\.test\.ts, src\/lib\/notification\.ts/);
+  assert.doesNotMatch(next, /⚠️ attempted but validation failed/);
+});
+
 test('sync writes one warning line when validation fails', () => {
   const projectRoot = setupFixture('node');
   fs.writeFileSync(path.join(projectRoot, 'src', 'payment.js'), 'function paymentModule() { return true; }\n', 'utf8');

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -38,6 +38,36 @@ test('validator fails missing tests when framework is detected', () => {
   assert.match(result.reasons.join('; '), /missing test evidence/);
 });
 
+test('validator exposes structured diagnostics for implementation, test, and reference failures', () => {
+  const projectRoot = setupFixture('node');
+  fs.writeFileSync(path.join(projectRoot, 'src', 'billing.js'), 'function billingModule() { return true; }\n', 'utf8');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const missingImplementation = validateTask(
+    { id: 'implement-unrelated-feature', text: 'Implement unrelated feature' },
+    context,
+    config,
+    []
+  );
+  const missingTest = validateTask(
+    { id: 'implement-billing-module', text: 'Implement billing module' },
+    context,
+    config,
+    []
+  );
+  const missingReference = validateTask(
+    { id: 'create-missing-parser', text: 'Create parser in `src/missing.js`' },
+    context,
+    config,
+    []
+  );
+
+  assert.ok(missingImplementation.diagnostics.some((item) => item.code === 'NOT_IMPLEMENTED' && item.severity === 'error'));
+  assert.ok(missingTest.diagnostics.some((item) => item.code === 'NO_TEST' && item.severity === 'error'));
+  assert.ok(missingReference.diagnostics.some((item) => item.code === 'MISSING_REFERENCE' && item.severity === 'error'));
+});
+
 test('validator checks explicit file existence hints', () => {
   const projectRoot = setupFixture('generic');
   const config = loadConfig({ projectRoot });
@@ -1486,14 +1516,18 @@ test('Milestone with Blocked-by in child bullet stays failed when dep is incompl
   assert.ok(results['child-milestone-v1'].reasons.some((r) => r.includes('child-dep-task')), 'reason must name the blocking dep');
 });
 
-// Causa 2: existing ⚠️ warning on unchecked task must survive even when meetsStrongThreshold
-test('Unchecked task with existing warning stays unchecked even when code+feature-surface evidence exists', () => {
+test('Unchecked task with a stale warning passes only when fresh code and test evidence is high confidence', () => {
   const projectRoot = setupFixture('generic');
   fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
-  // Code file with matching tokens so evidence.code = true
   fs.writeFileSync(
     path.join(projectRoot, 'src', 'lib', 'notification.ts'),
     'export function sendNotification() {} export function notifySystem() {}\n',
+    'utf8'
+  );
+  fs.mkdirSync(path.join(projectRoot, 'src', '__tests__'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', '__tests__', 'notification.test.ts'),
+    "import { sendNotification } from '../lib/notification';\ntest('notification system sends delivery', () => sendNotification());\n",
     'utf8'
   );
 
@@ -1511,7 +1545,32 @@ test('Unchecked task with existing warning stays unchecked even when code+featur
   const task = tasks.find((t) => t.id === 'add-notifications');
 
   const result = validateTask(task, context, config, []);
-  assert.equal(result.passed, false, 'existing warning must keep unchecked task failing regardless of token evidence');
+  assert.equal(result.passed, true);
+  assert.equal(result.confidence, 'high');
+  assert.ok(result.diagnostics.some((item) => item.code === 'STALE_EVIDENCE' && item.severity === 'warning'));
+});
+
+test('Unchecked task with a stale warning remains unchecked and reports the warning with code-only evidence', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, 'src', 'lib'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, 'src', 'lib', 'notification.ts'),
+    'export function sendNotification() {} export function notifySystem() {}\n',
+    'utf8'
+  );
+
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+  const { tasks } = parseRoadmap([
+    '## Phase P2',
+    '- [ ] Add notification system <!-- rs:task=add-notifications -->',
+    '  - ⚠️ attempted but validation failed: helper exists but no delivery mechanism',
+    ''
+  ].join('\n'));
+  const result = validateTask(tasks[0], context, config, []);
+
+  assert.equal(result.passed, false);
+  assert.ok(result.diagnostics.some((item) => item.code === 'STALE_EVIDENCE' && item.severity === 'warning'));
 });
 
 // Causa 3a: action-verb task with path hint + code tokens — stays unchecked without Evidence line

--- a/skills.json
+++ b/skills.json
@@ -10,19 +10,18 @@
   ],
   "usageExamples": [
     "npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code",
-    "npx skills add PapiScholz/roadmapsmith --skill roadmap-sync",
     "roadmapsmith setup",
     "roadmapsmith zero",
     "roadmapsmith maintain",
     "roadmapsmith /roadmap",
-    "roadmapsmith /roadmap-update",
+    "roadmapsmith update --task p2-customer-history --evidence \"src/app/api/customers/route.ts, test/customers.test.js\"",
     "roadmapsmith validate --json"
   ],
   "install": {
     "command": "npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code",
     "source": "PapiScholz/roadmapsmith",
     "skill": "*",
-    "notes": "Recommended Claude Code install path for native GUI slash commands like /roadmap, /roadmap-zero, /roadmap-maintain, /roadmap-status, /roadmap-init, /roadmap-generate, /roadmap-validate, /roadmap-update, /roadmap-audit, and /roadmap-setup. The legacy /roadmap-sync root remains available for compatibility, especially as /roadmap-sync <action>. Install the roadmapsmith CLI separately for actual command execution; roadmapsmith status is the visible readiness command and roadmapsmith doctor remains a compatibility alias. Then run /reload-skills and, if applicable, /reload-plugins. Codex native plugin installs use the repo/package .codex-plugin surface instead of this Claude-specific skills CLI path."
+    "notes": "Recommended Claude Code install path for native GUI slash commands like /roadmap, /roadmap-zero, /roadmap-maintain, /roadmap-status, /roadmap-init, /roadmap-generate, /roadmap-validate, /roadmap-update, /roadmap-audit, and /roadmap-setup. DEPRECATED: /roadmap-sync remains only as a compatibility root for existing automation; use /roadmap-maintain or /roadmap-update for new workflows. Install the roadmapsmith CLI separately for actual command execution; roadmapsmith status is the visible readiness command and roadmapsmith doctor remains a compatibility alias. Then run /reload-skills and, if applicable, /reload-plugins. Codex native plugin installs use the repo/package .codex-plugin surface instead of this Claude-specific skills CLI path."
   },
   "skills": [
     {
@@ -70,13 +69,13 @@
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
-      "description": "Native slash entrypoint for applying evidence-backed checklist sync.",
+      "description": "Native slash entrypoint for evidence-backed sync and verified single-task completion.",
       "version": "0.9.27"
     },
     {
       "name": "roadmap-sync",
       "path": "skills/roadmap-sync",
-      "description": "Legacy namespaced root plus policy guidance for RoadmapSmith slash workflows.",
+      "description": "DEPRECATED legacy compatibility root; use roadmap-maintain or roadmap-update.",
       "version": "0.9.27"
     },
     {

--- a/skills/roadmap-maintain/SKILL.md
+++ b/skills/roadmap-maintain/SKILL.md
@@ -12,7 +12,8 @@ Use this command when the repository already has code, tests, docs, or an existi
 1. Prefer the local engine inside this repository:
    - `node roadmap-skill/bin/cli.js maintain --project-root .`
    - on this Windows machine, prefer `C:\Program Files\nodejs\node.exe roadmap-skill/bin/cli.js maintain --project-root .` if `node` is not in PATH
-2. Otherwise prefer `roadmapsmith maintain --project-root .`.
+2. Otherwise prefer `roadmapsmith maintain --project-root .`. If that global shim fails because `node` is not in PATH, run `& "C:\Program Files\nodejs\node.exe" "$env:APPDATA\npm\node_modules\roadmapsmith\bin\cli.js" maintain --project-root .`.
 3. Treat this command as CLI-backed. Do not silently replace it with manual reasoning when the CLI is unavailable.
 4. Mention that maintain runs preserve-first generate, sync, and audit in one invocation.
-5. Mention that `roadmapsmith maintain --full-regen` or `roadmapsmith generate --full-regen` is the explicit destructive rebuild path when the user truly wants a full managed-block replacement.
+5. After a successful maintain cycle, do not propose generate, sync, or audit separately unless the user needs manual control or inspection.
+6. Mention that `roadmapsmith maintain --full-regen` or `roadmapsmith generate --full-regen` is the explicit destructive rebuild path when the user truly wants a full managed-block replacement.

--- a/skills/roadmap-status/SKILL.md
+++ b/skills/roadmap-status/SKILL.md
@@ -12,6 +12,6 @@ Use this command to inspect whether the shared bundle, native host surfaces, CLI
 1. Prefer the local engine inside this repository:
    - `node roadmap-skill/bin/cli.js doctor --json --project-root .`
    - on this Windows machine, prefer `C:\Program Files\nodejs\node.exe roadmap-skill/bin/cli.js doctor --json --project-root .` if `node` is not in PATH
-2. Otherwise prefer `roadmapsmith doctor --json --project-root .`.
+2. Otherwise prefer `roadmapsmith doctor --json --project-root .`. If its global shim cannot resolve `node`, use `& "C:\Program Files\nodejs\node.exe" "$env:APPDATA\npm\node_modules\roadmapsmith\bin\cli.js" doctor --json --project-root .`.
 3. Parse and summarize the JSON output in plain language.
 4. Explicitly call out missing commands or duplicate `/roadmap-sync` registration when doctor reports them.

--- a/skills/roadmap-sync/SKILL.md
+++ b/skills/roadmap-sync/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: roadmap-sync
-description: Legacy namespaced root and policy guidance for RoadmapSmith slash workflows.
+description: DEPRECATED legacy root for RoadmapSmith slash workflows; use roadmap-maintain or roadmap-update.
 ---
 
-# RoadmapSmith Legacy Root
+# RoadmapSmith Legacy Root (Deprecated)
 
-Use this skill when the host exposes or the user invokes `/roadmap-sync`, or when the agent needs the RoadmapSmith operating rules for roadmap maintenance.
+Use this skill only when the host exposes or the user explicitly invokes `/roadmap-sync`. For new work, use `/roadmap-maintain` for the daily flow or `/roadmap-update` for evidence-backed completion.
 
 ## Required behavior
 

--- a/skills/roadmap-sync/agents/openai.yaml
+++ b/skills/roadmap-sync/agents/openai.yaml
@@ -1,7 +1,7 @@
 {
   "interface": {
-    "display_name": "Roadmap Sync",
-    "short_description": "Legacy root plus policy for evidence-backed ROADMAP.md slash workflows.",
+    "display_name": "Roadmap Sync (Deprecated)",
+    "short_description": "DEPRECATED legacy root; use /roadmap-maintain or /roadmap-update.",
     "default_prompt": "Prefer /roadmap, /roadmap-status, /roadmap-maintain, and /roadmap-update."
   }
 }

--- a/skills/roadmap-update/SKILL.md
+++ b/skills/roadmap-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-update
-description: Apply evidence-backed checklist sync through the RoadmapSmith CLI.
+description: Apply evidence-backed checklist sync or complete one task with verified evidence through the RoadmapSmith CLI.
 ---
 
 # RoadmapSmith Update
@@ -10,8 +10,9 @@ Use this command when the user wants the direct sync surface without routing thr
 ## Required behavior
 
 1. Prefer the local engine inside this repository:
-   - `node roadmap-skill/bin/cli.js sync --project-root .`
-   - on this Windows machine, prefer `C:\Program Files\nodejs\node.exe roadmap-skill/bin/cli.js sync --project-root .` if `node` is not in PATH
-2. Otherwise prefer `roadmapsmith sync --project-root .`.
+   - `node roadmap-skill/bin/cli.js update --project-root .`
+   - on this Windows machine, prefer `C:\Program Files\nodejs\node.exe roadmap-skill/bin/cli.js update --project-root .` if `node` is not in PATH
+2. Otherwise prefer `roadmapsmith update --project-root .`. If that global shim fails because `node` is not in PATH, run `& "C:\Program Files\nodejs\node.exe" "$env:APPDATA\npm\node_modules\roadmapsmith\bin\cli.js" update --project-root .`.
 3. Explain that `/roadmap-update` is the visible namespaced sync command, while `/roadmap-sync <action>` remains legacy compatibility.
-4. Keep the evidence-backed sync semantics unchanged: sync updates checklist state from repository evidence; it is not a full regeneration path.
+4. Keep the evidence-backed sync semantics unchanged: no-argument update syncs the roadmap from repository evidence; it is not a full regeneration path.
+5. To complete one task, run `roadmapsmith update --task <stable-id> --evidence "<single-line evidence>"`. It writes only after the supplied evidence validates at high confidence; use `--dry-run` to preview it.

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -13,7 +13,7 @@ Use this command as the native discovery entrypoint for the shared RoadmapSmith 
 2. When working inside the RoadmapSmith repository itself and `roadmap-skill/bin/cli.js` exists, prefer the local engine:
    - `node roadmap-skill/bin/cli.js /roadmap`
    - on this Windows machine, prefer `C:\Program Files\nodejs\node.exe roadmap-skill/bin/cli.js /roadmap` if `node` is not in PATH
-3. Otherwise, if the `roadmapsmith` CLI is available, you may run `roadmapsmith /roadmap` from the project root and use that output directly.
+3. Otherwise, if the `roadmapsmith` CLI is available, you may run `roadmapsmith /roadmap` from the project root and use that output directly. If its global shim cannot resolve `node`, use `& "C:\Program Files\nodejs\node.exe" "$env:APPDATA\npm\node_modules\roadmapsmith\bin\cli.js" /roadmap`.
 4. If the CLI is missing, provide the palette manually and explain the install path:
    - `npm install -g roadmapsmith`
    - `npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code`


### PR DESCRIPTION
## Summary
- Add structured validation diagnostics and safe stale-evidence convergence.
- Add verified single-task update workflow and Windows global CLI fallback guidance.
- Deprecate the legacy roadmap-sync skill in favor of maintain/update.

## Verification
- npm test
- npm run validate:qa-regression
- npm run validate:functional-smoke