### PR TITLE
chore(release): v0.9.28

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "author": {
     "name": "PapiScholz"

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Unreleased
 
-### Added
-- add verified `roadmapsmith update --task --evidence` completion flow
-- add structured validation diagnostics and stale-evidence convergence
+- None yet.
 
-### Changed
-- document Windows global CLI Node fallback and visibly deprecate the legacy roadmap-sync skill
+## v0.9.28 - 2026-06-20
+
+### Fixed
+- harden roadmap validation and update workflow (#49)
 
 ## v0.9.27 - 2026-06-19
 

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "One-command evidence-backed ROADMAP.md generator and sync tool for AI coding agents, with shared RoadmapSmith plugin skills for Codex and Claude plus the roadmapsmith status readiness surface.",
   "main": "src/index.js",
   "bin": {

--- a/skills.json
+++ b/skills.json
@@ -28,67 +28,67 @@
       "name": "roadmap",
       "path": "skills/roadmap",
       "description": "Native slash palette for RoadmapSmith commands and recommended entrypoints across supported hosts.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-zero",
       "path": "skills/roadmap-zero",
       "description": "Native slash entrypoint for the one-command Zero Mode CLI workflow.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-maintain",
       "path": "skills/roadmap-maintain",
       "description": "Native slash entrypoint for the preserve-first generate + sync + audit flow.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-status",
       "path": "skills/roadmap-status",
       "description": "Native slash readiness check grounded in roadmapsmith status JSON.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Native slash entrypoint for creating ROADMAP.md and AGENTS.md.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-generate",
       "path": "skills/roadmap-generate",
       "description": "Native slash entrypoint for managed roadmap updates that require --full-regen before destructive replacement.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-validate",
       "path": "skills/roadmap-validate",
       "description": "Native slash entrypoint for evidence-backed roadmap validation.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Native slash entrypoint for evidence-backed sync and verified single-task completion.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-sync",
       "path": "skills/roadmap-sync",
       "description": "DEPRECATED legacy compatibility root; use roadmap-maintain or roadmap-update.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-audit",
       "path": "skills/roadmap-audit",
       "description": "Native slash entrypoint for the current sync-plus-audit workflow.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     {
       "name": "roadmap-setup",
       "path": "skills/roadmap-setup",
       "description": "Native slash entrypoint for generating RoadmapSmith host integration files.",
-      "version": "0.9.27"
+      "version": "0.9.28"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- automated release PR for v0.9.28
- bumps package metadata and resets the changelog through the protected-branch path
- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode

## Notes
## v0.9.28 - 2026-06-20

### Fixed
- harden roadmap validation and update workflow (#49)