### PR TITLE
ci: add HOL AI Plugin Scanner workflow

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,27 @@
+name: HOL Plugin Scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan plugin bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: HOL AI Plugin Scanner
+        uses: hashgraph-online/ai-plugin-scanner-action@bedc0169303b4918d45560ea9064132d35428f85 # v1.2.259
+        with:
+          plugin_dir: "."
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: text


### PR DESCRIPTION
Adds the mandatory HOL AI Plugin Scanner CI gate required for listing in [hashgraph-online/awesome-codex-plugins#227](https://github.com/hashgraph-online/awesome-codex-plugins/pull/227).

**What this adds:**
- \.github/workflows/hol-plugin-scanner.yml\ — runs on every push and PR against \main\
- Fails if score < 80/130 or any \high\/\critical\ finding is present
- Actions pinned to commit SHAs (\ctions/checkout@11bd71...\ v4.2.2, \i-plugin-scanner-action@bedc01...\ v1.2.259)
- Minimal permissions: \contents: read\ only