### PR TITLE
chore(release): v0.9.32

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents, with canonical RoadmapSmith status and maintain surfaces plus advanced sync/generate tools and legacy compatibility aliases.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents, with canonical RoadmapSmith status and maintain surfaces plus advanced sync/generate tools and legacy compatibility aliases.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents, with canonical RoadmapSmith status and maintain surfaces plus advanced sync/generate tools and legacy compatibility aliases.",
   "author": {
     "name": "PapiScholz"

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - None yet.
 
+## v0.9.32 - 2026-06-21
+
+### Changed
+- add HOL AI Plugin Scanner workflow (#57)
+
 ## v0.9.31 - 2026-06-21
 
 ### Fixed

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents, with canonical RoadmapSmith status and maintain surfaces plus advanced sync/generate tools and legacy compatibility aliases.",
   "main": "src/index.js",
   "bin": {

--- a/skills.json
+++ b/skills.json
@@ -28,67 +28,67 @@
       "name": "roadmap",
       "path": "skills/roadmap",
       "description": "Native slash palette for RoadmapSmith commands and recommended entrypoints across supported hosts.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-zero",
       "path": "skills/roadmap-zero",
       "description": "Native slash entrypoint for the one-command Zero Mode CLI workflow.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-maintain",
       "path": "skills/roadmap-maintain",
       "description": "Native slash entrypoint for the preserve-first generate + sync + audit flow.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-status",
       "path": "skills/roadmap-status",
       "description": "Native slash readiness check grounded in roadmapsmith status JSON.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Native slash entrypoint for creating ROADMAP.md and AGENTS.md.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-generate",
       "path": "skills/roadmap-generate",
       "description": "Native slash entrypoint for managed roadmap updates that require --full-regen before destructive replacement.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-validate",
       "path": "skills/roadmap-validate",
       "description": "Native slash entrypoint for evidence-backed roadmap validation.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Native slash entrypoint for evidence-backed sync and verified single-task completion.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-sync",
       "path": "skills/roadmap-sync",
       "description": "DEPRECATED legacy compatibility root; use roadmap-maintain or roadmap-update.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-audit",
       "path": "skills/roadmap-audit",
       "description": "Native slash entrypoint for the advanced sync-plus-audit mutating summary workflow.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     {
       "name": "roadmap-setup",
       "path": "skills/roadmap-setup",
       "description": "Native slash entrypoint for generating RoadmapSmith host integration files.",
-      "version": "0.9.31"
+      "version": "0.9.32"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- automated release PR for v0.9.32
- bumps package metadata and resets the changelog through the protected-branch path
- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode

## Notes
## v0.9.32 - 2026-06-21

### Changed
- add HOL AI Plugin Scanner workflow (#57)