### PR TITLE
fix: restore package-lock.json and remove it from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ assets/palette.png
 
 # backups raros
 *.mp4~
-
-# npm lockfile — contains high-entropy SHA512 integrity hashes
-roadmap-skill/package-lock.json

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "roadmapsmith",
+  "version": "0.9.32",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "roadmapsmith",
+      "version": "0.9.32",
+      "license": "MIT",
+      "bin": {
+        "roadmapsmith": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
auto-release.js includes package-lock.json in its release commit. Having it gitignored caused the CI Release job to fail with exit 1 on every push to main.