### PR TITLE
Harden roadmap maintain and zero UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `roadmapsmith doctor --json` now separates native slash surfaces (`claudeGui`, `claudeCli`, `codexGui`, `codexCli`) from the VS Code task plus Claude hook setup layer.
 - `roadmapsmith status` is now the visible classic readiness command, with `roadmapsmith doctor` kept as a compatibility alias to the same inspection payload.
 - `maintain` and `generate` are now documented as preserve-first updates for existing substantive managed blocks, while `/roadmap-update` replaces direct `/roadmap-sync` usage as the visible sync slash entrypoint.
+- `maintain` is now documented as conservative on non-empty authored roadmaps without managed markers, `update` is documented as the inline-annotation path for those files, and `zero` now documents config-plus-flag discovery in non-interactive environments.
 - The public slash namespace now prefers `/roadmap*` commands, uses `/roadmap-update` as the visible direct sync command, keeps `/roadmap-sync <action>` as the legacy root, and requires `--full-regen` before destructive regeneration.
 - Release and maintainer docs now require independent subagent-owned validation passes before push, and CI reuses the same gate commands.
 - Canonical, advanced, and compatibility command surfaces are now documented separately across code, skills, manifests, and docs.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,27 @@ Empty or low-context repository:
 roadmapsmith zero
 ```
 
+`roadmapsmith zero` can also run without a TTY when the brief is complete in `roadmap-skill.config.json` or provided with flags such as `--primary-user`, `--problem-statement`, `--target-outcome`, and `--done-criterion`.
+
 Existing repository:
 
 ```bash
+roadmapsmith maintain --dry-run
 roadmapsmith maintain
+```
+
+`maintain` owns only the managed `<!-- rs:managed:* -->` section. If an authored `ROADMAP.md` has task markers but no managed block, use:
+
+```bash
+roadmapsmith update --dry-run
+roadmapsmith update
+```
+
+To intentionally seed a managed section into an authored roadmap, use:
+
+```bash
+roadmapsmith generate --dry-run
+roadmapsmith generate
 ```
 
 Readiness and host setup:
@@ -53,8 +70,9 @@ roadmapsmith update --task <stable-id> --evidence "src/file.ts, test/file.test.t
 
 1. Run `roadmapsmith setup` when you want the VS Code task layer and optional Claude hook template.
 2. Use `roadmapsmith zero` for empty repos.
-3. Use `roadmapsmith maintain` for existing repos.
-4. Use `roadmapsmith status` as the public readiness command.
+3. Use `roadmapsmith maintain --dry-run` before applying changes to an existing managed roadmap.
+4. Use `roadmapsmith update` when you only want inline task annotations on an authored roadmap without managed markers.
+5. Use `roadmapsmith status` as the public readiness command.
 
 ## Command Surfaces
 
@@ -68,6 +86,8 @@ Canonical public surfaces:
 - `update`
 
 `update` is the public family for both evidence-backed checklist refresh and verified single-task completion. Advanced surfaces such as `init`, `generate`, `generate --full-regen`, `sync`, and `sync --audit` remain available, but they are documented separately in [docs/command-surfaces.md](docs/command-surfaces.md).
+
+`maintain` is conservative by default: it will not seed a new managed block into a non-empty authored roadmap. `update` is the conservative annotation path for existing task lines, while `generate` is the explicit managed-section creation path.
 
 Compatibility-only surfaces such as `doctor`, `regenerate`, `/road <action>`, and `/roadmap-sync <action>` remain executable for existing automation but are no longer part of the primary UX.
 
@@ -99,3 +119,4 @@ roadmapsmith validate --strict --json
 - [docs/use-cases/codex-plugin.md](docs/use-cases/codex-plugin.md): Codex plugin install and duplicate-surface troubleshooting
 - [docs/use-cases/sync-audit-mode.md](docs/use-cases/sync-audit-mode.md): maintain, sync, audit, and strict validation semantics
 - [docs/release-readiness.md](docs/release-readiness.md): maintainer and release workflow
+- [docs/audit-remediation.md](docs/audit-remediation.md): post-0.9.33 audit findings and staged remediation roadmap

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,11 +22,17 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 ### Scaffold / Partial
 
 - [ ] Module "classifier" partially implemented — coverage unknown <!-- rs:task=prof-state-scaffold-module-classifier-partially-implemented-coverage-unknown -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] Module "config" partially implemented — coverage unknown <!-- rs:task=prof-state-scaffold-module-config-partially-implemented-coverage-unknown -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] Module "generator" partially implemented — coverage unknown <!-- rs:task=prof-state-scaffold-module-generator-partially-implemented-coverage-unknown -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] Module "host" partially implemented — coverage unknown <!-- rs:task=prof-state-scaffold-module-host-partially-implemented-coverage-unknown -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] Module "io" partially implemented — coverage unknown <!-- rs:task=prof-state-scaffold-module-io-partially-implemented-coverage-unknown -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] Module "match" partially implemented — coverage unknown <!-- rs:task=prof-state-scaffold-module-match-partially-implemented-coverage-unknown -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 ### Known Limitations
 
@@ -50,14 +56,18 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Tasks:**
 
 - [ ] `[P0]` Preserve compact backward compatibility <!-- rs:task=prof-task-preserve-compact-backward-compatibility -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Extract compact renderer to renderer/compact.js <!-- rs:task=prof-task-extract-compact-renderer -->
-  - ⚠️ attempted but validation failed: missing referenced file(s): renderer/compact.js; no code, test, or artifact evidence found
+  - ⚠️ no implementation evidence found yet: missing referenced file(s): renderer/compact.js; no code, test, or artifact evidence found
 - [ ] `[P2]` Add renderer dispatcher (renderBody) <!-- rs:task=prof-task-add-renderer-dispatcher -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 **Exit Criteria:**
 
 - [ ] `[P0]` Compact output remains byte-stable where expected <!-- rs:task=prof-ph1-st1-exit-compact-output-remains-byte-stable-where-expected -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Professional profile renders all 12 sections <!-- rs:task=prof-ph1-st1-exit-professional-profile-renders-all-12-sections -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 #### Step 1.2: Model Improvements
 
@@ -69,15 +79,18 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Tasks:**
 
 - [ ] `[P0]` Add phasesDetailed model field <!-- rs:task=prof-task-add-phasesdetailed-model-field -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Filter code vs doc TODOs in Known Limitations inference <!-- rs:task=prof-task-filter-code-vs-doc-todos -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Add task-level priority rendering with [P0]/[P1] labels <!-- rs:task=prof-task-add-task-priority-rendering -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 **Exit Criteria:**
 
 - [ ] `[P0]` A P0 task inside a P2 step renders with [P0] label in correct step position <!-- rs:task=prof-ph1-st2-exit-a-p0-task-inside-a-p2-step-renders-with-p0-label-in-correct-step-position -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Known Limitations no longer includes doc-only TODO mentions <!-- rs:task=prof-ph1-st2-exit-known-limitations-no-longer-includes-doc-only-todo-mentions -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 
 ### Phase 2: Validation Quality
 
@@ -95,13 +108,18 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Tasks:**
 
 - [ ] `[P0]` Fix false-positive task similarity matching on overlapping text <!-- rs:task=prof-task-fix-false-positive-task-matching -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add fixture for doc-only TODO filtering test <!-- rs:task=prof-task-add-doc-only-todo-fixture -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Improve evidence scoring for test file coverage <!-- rs:task=prof-task-improve-evidence-scoring -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 **Exit Criteria:**
 
 - [ ] `[P0]` All validation tests pass on node, python, go, rust fixtures <!-- rs:task=prof-ph2-st1-exit-all-validation-tests-pass-on-node-python-go-rust-fixtures -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` No false-positive task merges on similar-text tasks <!-- rs:task=prof-ph2-st1-exit-no-false-positive-task-merges-on-similar-text-tasks -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### Phase 3: Showcase and Distribution
 
@@ -137,16 +155,18 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Tasks:**
 
 - [ ] `[P0]` Publish stable semver to npm <!-- rs:task=prof-task-publish-stable-semver-to-npm -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Tag git release aligned with npm publish <!-- rs:task=prof-task-tag-git-release-aligned-with-npm -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Document npm global and npx install instructions <!-- rs:task=prof-task-document-npx-install-instructions -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 
 **Exit Criteria:**
 
 - [ ] `[P0]` npm publish succeeds and package is installable via npx roadmapsmith <!-- rs:task=prof-ph3-st2-exit-npm-publish-succeeds-and-package-is-installable-via-npx-roadmapsmith -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Git tag matches npm version <!-- rs:task=prof-ph3-st2-exit-git-tag-matches-npm-version -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ## 5. Versioned Milestones
 
@@ -157,15 +177,18 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **What Must Exist:**
 
 - [ ] `[P0]` CLI binary with init, generate, sync, validate commands <!-- rs:task=prof-ms-v0-1-exist-cli-binary-with-init-generate-sync-validate-commands -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match; missing test evidence
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match; missing test evidence
 - [ ] `[P0]` Parser correctly extracts rs:task IDs and checked state <!-- rs:task=prof-ms-v0-1-exist-parser-correctly-extracts-rs-task-ids-and-checked-state -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Managed block preserved across regeneration <!-- rs:task=prof-ms-v0-1-exist-managed-block-preserved-across-regeneration -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 **What Must Be Stable:**
 
 - [ ] `[P1]` rs:task ID slugification algorithm — _Stable as of v0.5.1 — locked by test/utils.test.js. Meta-declaration: not evidence-scannable by sync._ <!-- rs:task=prof-ms-v0-1-stable-rs-task-id-slugification-algorithm -->
-  - ⚠️ attempted but validation failed: missing referenced file(s): test/utils.test.js; no code, test, or artifact evidence found
+  - ⚠️ no implementation evidence found yet: missing referenced file(s): test/utils.test.js; no code, test, or artifact evidence found
 - [ ] `[P1]` managed block start/end marker format <!-- rs:task=prof-ms-v0-1-stable-managed-block-start-end-marker-format -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 **Intentionally Out of Scope:**
 
@@ -180,14 +203,18 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **What Must Exist:**
 
 - [ ] `[P0]` Evidence-based validation (code, test, artifact) <!-- rs:task=prof-ms-v0-2-exist-evidence-based-validation-code-test-artifact -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Plugin hook system (registerTaskDetectors, registerValidators) <!-- rs:task=prof-ms-v0-2-exist-plugin-hook-system-registertaskdetectors-registervalidators -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P0]` Multi-language fixture test suite (Node, Python, Go, Rust) <!-- rs:task=prof-ms-v0-2-exist-multi-language-fixture-test-suite-node-python-go-rust -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 **What Must Be Stable:**
 
 - [ ] `[P1]` Validation evidence scoring algorithm <!-- rs:task=prof-ms-v0-2-stable-validation-evidence-scoring-algorithm -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Task similarity matching threshold <!-- rs:task=prof-ms-v0-2-stable-task-similarity-matching-threshold -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 **Intentionally Out of Scope:**
 
@@ -201,16 +228,24 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **What Must Exist:**
 
 - [ ] `[P0]` Renderer architecture with compact and professional profiles <!-- rs:task=prof-ms-v0-3-exist-renderer-architecture-with-compact-and-professional-profiles -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` 12-section professional roadmap output <!-- rs:task=prof-ms-v0-3-exist-12-section-professional-roadmap-output -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` roadmapProfile field in roadmap-skill.config.json <!-- rs:task=prof-ms-v0-3-exist-roadmapprofile-field-in-roadmap-skill-config-json -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` product metadata block in config <!-- rs:task=prof-ms-v0-3-exist-product-metadata-block-in-config -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Sequential step model for Section 4 <!-- rs:task=prof-ms-v0-3-exist-sequential-step-model-for-section-4 -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 **What Must Be Stable:**
 
 - [ ] `[P1]` compact profile output (backward compatible) <!-- rs:task=prof-ms-v0-3-stable-compact-profile-output-backward-compatible -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` professional profile section structure <!-- rs:task=prof-ms-v0-3-stable-professional-profile-section-structure -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` prof-step-N- task ID namespace — _Stable as of v0.5.1 — locked by exit criteria ID format and checked-state roundtrip tests in generator.test.js. Meta-declaration: not evidence-scannable by sync._ <!-- rs:task=prof-ms-v0-3-stable-prof-step-n-task-id-namespace -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 **Intentionally Out of Scope:**
 
@@ -224,16 +259,21 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **What Must Exist:**
 
 - [ ] `[P0]` All test fixtures green across Node, Python, Go, Rust, generic <!-- rs:task=prof-ms-v1-0-exist-all-test-fixtures-green-across-node-python-go-rust-generic -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [x] `[P0]` README.md showcases professional output with excerpt <!-- rs:task=prof-ms-v1-0-exist-readme-md-showcases-professional-output-with-excerpt -->
 - [ ] `[P0]` SKILL.md documents profile selection <!-- rs:task=prof-ms-v1-0-exist-skill-md-documents-profile-selection -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Published to npm with stable semver <!-- rs:task=prof-ms-v1-0-exist-published-to-npm-with-stable-semver -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 **What Must Be Stable:**
 
 - [ ] `[P1]` All CLI commands <!-- rs:task=prof-ms-v1-0-stable-all-cli-commands -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Config schema (roadmapProfile, product, milestones, phaseTemplates) <!-- rs:task=prof-ms-v1-0-stable-config-schema-roadmapprofile-product-milestones-phasetemplates -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Plugin hook signatures <!-- rs:task=prof-ms-v1-0-stable-plugin-hook-signatures -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 
 **Intentionally Out of Scope:**
 
@@ -247,151 +287,200 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Current state:** module detected in scan.
 
 - [ ] `[P1]` Define maturity criteria and testability gates for classifier <!-- rs:task=prof-mat-classifier-define-maturity-criteria -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### config
 
 **Current state:** Supports roadmapProfile, product block, milestones, phaseTemplates, plugins.
 
 - [ ] `[P1]` Add JSON schema validation for roadmap-skill.config.json <!-- rs:task=prof-mat-config-json-schema-validation -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` Add init --professional or init --with-config bootstrap flow <!-- rs:task=prof-mat-config-add-init-with-config-bootstrap-flow -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Honor versioned roadmap config instead of regenerating from defaults <!-- rs:task=prof-mat-config-honor-versioned-config-before-defaults -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Define manual-to-managed migration flow and drift warnings between skill and CLI guidance <!-- rs:task=prof-mat-config-define-manual-to-managed-migration-and-drift-warnings -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### generator
 
 **Current state:** Compact and professional profiles supported; Phase→Step→Task model implemented.
 
 - [ ] `[P0]` Improve Phase→Step→Task model inference quality <!-- rs:task=prof-mat-generator-improve-phase-step-task-inference -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Add scan-driven task suggestions per detected module <!-- rs:task=prof-mat-generator-scan-driven-task-suggestions -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 ### host
 
 **Current state:** module detected in scan.
 
 - [ ] `[P1]` Define maturity criteria and testability gates for host <!-- rs:task=prof-mat-host-define-maturity-criteria -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### io
 
 **Current state:** Scans files, detects languages, test frameworks, commands, modules.
 
 - [ ] `[P2]` Improve module detection for monorepo workspace layouts <!-- rs:task=prof-mat-io-monorepo-workspace-detection -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 ### match
 
 **Current state:** Task similarity matching with edit-distance threshold.
 
 - [ ] `[P0]` Tune similarity threshold to reduce false-positive merges <!-- rs:task=prof-mat-match-tune-similarity-threshold -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### parser
 
 **Current state:** Parses managed blocks, rs:task IDs, and checked state.
 
 - [ ] `[P1]` Add parser validation for Phase→Step hierarchy markers <!-- rs:task=prof-mat-parser-phase-hierarchy-validation -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Improve section boundary detection for professional format <!-- rs:task=prof-mat-parser-professional-section-detection -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### renderer
 
 **Current state:** Dispatcher supports compact, professional, and enterprise (error) profiles.
 
 - [ ] `[P0]` Add snapshot regression fixtures for compact and professional <!-- rs:task=prof-mat-renderer-snapshot-regression-fixtures -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Harden priority label rendering for edge cases <!-- rs:task=prof-mat-renderer-priority-label-edge-cases -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ## 7. Output Contract Roadmap
 
 ### Output Format
 
 - [ ] `[P0]` Define stable public output format (stdout, files, exit codes) <!-- rs:task=prof-out-define-stable-public-output-format-stdout-files-exit-codes -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Version output format alongside package version <!-- rs:task=prof-out-version-output-format-alongside-package-version -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Define explicit contract for sync, sync --audit, and future promote-only flows <!-- rs:task=prof-out-define-explicit-contract-for-sync-sync-audit-and-future-promote-only-flows -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Document current gap: sync --audit is not yet a dedicated read-only audit command <!-- rs:task=prof-out-document-current-gap-sync-audit-is-not-yet-a-dedicated-read-only-audit-command -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add machine-readable audit output (JSON) <!-- rs:task=prof-out-add-machine-readable-audit-output-json -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add audit summary-only output mode <!-- rs:task=prof-out-add-audit-summary-only-output-mode -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` Define explicit exit-code semantics for sync and audit commands <!-- rs:task=prof-out-define-explicit-exit-code-semantics-for-sync-and-audit-commands -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 ### Breaking Changes
 
 - [ ] `[P1]` Document breaking vs. non-breaking output changes <!-- rs:task=prof-out-document-breaking-vs-non-breaking-output-changes -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Add output schema validation to CI <!-- rs:task=prof-out-add-output-schema-validation-to-ci -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` Separate mutating sync behavior from future read-only audit mode <!-- rs:task=prof-out-separate-mutating-sync-behavior-from-future-read-only-audit-mode -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Expose weak-evidence, documentation-only, and structural-mismatch findings in audit output <!-- rs:task=prof-out-expose-weak-evidence-documentation-only-and-structural-mismatch-findings-in-audit-output -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ## 8. Testing and Quality-Gate Roadmap
 
 ### Test Coverage
 
 - [ ] `[P0]` Unit test coverage for all core modules <!-- rs:task=prof-test-unit-test-coverage-for-all-core-modules -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` Integration tests covering the full generate → sync → validate pipeline <!-- rs:task=prof-test-integration-tests-covering-the-full-generate-sync-validate-pipeline -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Regression fixtures for compact and professional profile output <!-- rs:task=prof-test-regression-fixtures-for-compact-and-professional-profile-output -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Edge case coverage: empty repo, no config, large monorepo scan <!-- rs:task=prof-test-edge-case-coverage-empty-repo-no-config-large-monorepo-scan -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Add direct tests for .claude/hooks/roadmap-sync.js payload parsing <!-- rs:task=prof-test-add-direct-tests-for-claude-hooks-roadmap-sync-js-payload-parsing -->
-  - ⚠️ attempted but validation failed: missing referenced file(s): .claude/hooks/roadmap-sync.js; no code, test, or artifact evidence found; missing test evidence
+  - ⚠️ no implementation evidence found yet: missing referenced file(s): .claude/hooks/roadmap-sync.js; no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add direct tests for ROADMAP.md self-edit skip behavior <!-- rs:task=prof-test-add-direct-tests-for-roadmap-md-self-edit-skip-behavior -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add direct tests for lock-file reentry guard <!-- rs:task=prof-test-add-direct-tests-for-lock-file-reentry-guard -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` Add direct tests for sync failure surfacing when the child process cannot be spawned <!-- rs:task=prof-test-add-direct-tests-for-sync-failure-surfacing-when-the-child-process-cannot-be-spawned -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` Add regression coverage for environments where node is not available on PATH <!-- rs:task=prof-test-add-regression-coverage-for-environments-where-node-is-not-available-on-path -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add integration coverage for pre-commit sync using the absolute Node path <!-- rs:task=prof-test-add-integration-coverage-for-pre-commit-sync-using-the-absolute-node-path -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 ### Quality Gates
 
 - [ ] `[P0]` CI quality gate: tests must pass before merge <!-- rs:task=prof-test-ci-quality-gate-tests-must-pass-before-merge -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Block merge when generated roadmap loses checked state <!-- rs:task=prof-test-block-merge-when-generated-roadmap-loses-checked-state -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Add professional renderer snapshot tests <!-- rs:task=prof-test-add-professional-renderer-snapshot-tests -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 ## 9. Distribution Roadmap
 
 ### npm Registry
 
 - [ ] `[P0]` Publish to npm registry with stable semver <!-- rs:task=prof-dist-publish-to-npm-registry-with-stable-semver -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Ensure CLI binary is correctly linked in package.json `bin` <!-- rs:task=prof-dist-ensure-cli-binary-is-correctly-linked-in-package-json-bin -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### Release Process
 
 - [ ] `[P1]` Tag git releases aligned with npm publish <!-- rs:task=prof-dist-tag-git-releases-aligned-with-npm-publish -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Document install instructions for npm global and npx usage <!-- rs:task=prof-dist-document-install-instructions-for-npm-global-and-npx-usage -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 
 ## 10. Documentation Roadmap
 
 ### Core Docs
 
 - [ ] `[P0]` README.md covers install, commands, and profile selection <!-- rs:task=prof-doc-readme-md-covers-install-commands-and-profile-selection -->
-  - ⚠️ attempted but validation failed: missing test evidence
+  - ⚠️ no implementation evidence found yet: missing test evidence
 - [ ] `[P0]` SKILL.md reflects current feature set and guardrails <!-- rs:task=prof-doc-skill-md-reflects-current-feature-set-and-guardrails -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [x] `[P1]` CHANGELOG.md maintained for each release <!-- rs:task=prof-doc-changelog-md-maintained-for-each-release -->
 - [ ] `[P0]` README.md documents current sync --audit semantics without claiming read-only behavior <!-- rs:task=prof-doc-readme-md-documents-current-sync-audit-semantics-without-claiming-read-only-behavior -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` README.md includes host matrix for Claude Code, Codex/Codex CLI, CI, and manual workflows <!-- rs:task=prof-doc-readme-md-includes-host-matrix-for-claude-code-codex-codex-cli-ci-and-manual-workflows -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Document distinction between supported Claude hooks and manual workflows on other hosts <!-- rs:task=prof-doc-document-distinction-between-supported-claude-hooks-and-manual-workflows-on-other-hosts -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Document Codex/Codex CLI manual fallback workflow <!-- rs:task=prof-doc-document-codex-codex-cli-manual-fallback-workflow -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Document Windows shell caveats: roadmapsmith.cmd, npm.cmd, and PowerShell policy differences <!-- rs:task=prof-doc-document-windows-shell-caveats-roadmapsmith-cmd-npm-cmd-and-powershell-policy-differences -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Skill instructions require extending existing phases before adding new ones <!-- rs:task=prof-doc-skill-instructions-require-extending-existing-phases-before-adding-new-ones -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match; missing test evidence
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match; missing test evidence
 - [ ] `[P1]` Document that Claude write-time autoupdate currently depends on Node resolution in the hook environment <!-- rs:task=prof-doc-document-that-claude-write-time-autoupdate-currently-depends-on-node-resolution-in-the-hook-environment -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Document the difference between the Claude PostToolUse hook and the git pre-commit hook <!-- rs:task=prof-doc-document-the-difference-between-the-claude-posttooluse-hook-and-the-git-pre-commit-hook -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Document current autoupdate reliability boundaries: write-time hook is best-effort, pre-commit is stricter <!-- rs:task=prof-doc-document-current-autoupdate-reliability-boundaries-write-time-hook-is-best-effort-pre-commit-is-stricter -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Document troubleshooting for hook failure when node is missing from PATH <!-- rs:task=prof-doc-document-troubleshooting-for-hook-failure-when-node-is-missing-from-path -->
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Document that Codex/Codex CLI remains manual and does not share the Claude repo-local hook path <!-- rs:task=prof-doc-document-that-codex-codex-cli-remains-manual-and-does-not-share-the-claude-repo-local-hook-path -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 
 ### Showcase
 
 - [ ] `[P1]` docs/ use-cases cover compact and professional profiles <!-- rs:task=prof-doc-docs-use-cases-cover-compact-and-professional-profiles -->
-  - ⚠️ attempted but validation failed: missing referenced file(s): docs/; weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: missing referenced file(s): docs/; weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Generated ROADMAP.md showcases professional Phase→Step→Task output <!-- rs:task=prof-doc-generated-roadmap-md-showcases-professional-phase-step-task-output -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ## 11. Risks, Constraints, and Anti-Goals
 
 ### Risks
 
 - [ ] `[P0]` Inference quality degrades on very large monorepos (scan cap at 120 files) <!-- rs:task=prof-risk-inference-quality-degrades-on-very-large-monorepos-scan-cap-at-120-files -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Professional profile sections may feel over-structured for small hobby projects <!-- rs:task=prof-risk-professional-profile-sections-may-feel-over-structured-for-small-hobby-projects -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Task similarity matching may mis-merge tasks with overlapping language <!-- rs:task=prof-risk-task-similarity-matching-may-mis-merge-tasks-with-overlapping-language -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Roadmap drift if users edit the managed block directly instead of using the CLI <!-- rs:task=prof-risk-roadmap-drift-if-users-edit-the-managed-block-directly-instead-of-using-the-cli -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ### Anti-Goals
 
@@ -403,11 +492,15 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 ## 12. 1.0 Measurable Success Criteria
 
 - [ ] `[P0]` compact mode generates idempotent output on all fixture projects <!-- rs:task=prof-sc-compact-mode-generates-idempotent-output-on-all-fixture-projects -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` professional mode renders all 12 required sections without errors <!-- rs:task=prof-sc-professional-mode-renders-all-12-required-sections-without-errors -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` checked task state survives regeneration across both profiles <!-- rs:task=prof-sc-checked-task-state-survives-regeneration-across-both-profiles -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` RoadmapSmith's own ROADMAP.md is generated entirely by RoadmapSmith itself <!-- rs:task=prof-sc-roadmapsmith-s-own-roadmap-md-is-generated-entirely-by-roadmapsmith-itself -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P0]` npm test passes with no failures on all fixture languages <!-- rs:task=prof-sc-npm-test-passes-with-no-failures-on-all-fixture-languages -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 
 ## 13. Extended Phases
 
@@ -426,22 +519,25 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Tasks:**
 
 - [ ] `[P0]` Align versions across package.json, skills.json, plugin.json <!-- rs:task=mkt-p0-align-versions-package-skills-plugin -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` Improve package.json keywords and description for discoverability <!-- rs:task=mkt-p0-improve-package-json-keywords-description -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [x] `[P1]` Add demo.gif or placeholder to README <!-- rs:task=mkt-p0-add-demo-gif-placeholder -->
 - [ ] `[P1]` Move Quick Start section to top of README <!-- rs:task=mkt-p0-move-quick-start-to-top-readme -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [x] `[P1]` Add badges (npm version, CI status, license) to README <!-- rs:task=mkt-p0-add-badges-npm-ci-license -->
 - [x] `[P1]` Add comparison table (vs TODO.md, GitHub Issues, etc.) to README <!-- rs:task=mkt-p0-add-comparison-table -->
 - [ ] `[P2]` Add GitHub Actions audit template example <!-- rs:task=mkt-p0-add-github-actions-audit-template -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match; missing test evidence
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match; missing test evidence
 - [ ] `[P2]` Add SECURITY.md <!-- rs:task=mkt-p0-add-security-md -->
-  - ⚠️ attempted but validation failed: missing test evidence
+  - ⚠️ no implementation evidence found yet: missing test evidence
 
 **Exit Criteria:**
 
 - [ ] `[P0]` All version strings match across package.json, skills.json, plugin.json <!-- rs:task=mkt-ph4-st1-exit-version-strings-aligned -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` README Quick Start is the first user-facing section <!-- rs:task=mkt-ph4-st1-exit-quick-start-at-top -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 
 ### Phase 5: Reliability Hardening
 
@@ -458,11 +554,13 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Tasks:**
 
 - [ ] `[P0]` Add validation confidence levels (design or scaffold if not implemented) <!-- rs:task=mkt-p1-add-validation-confidence-levels -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P0]` Add config option: validation.minimumConfidence <!-- rs:task=mkt-p1-add-config-validation-minimum-confidence -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add `roadmapsmith doctor` command (scaffold or planned) <!-- rs:task=mkt-p1-add-roadmapsmith-doctor-command -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match; missing test evidence
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match; missing test evidence
 - [ ] `[P1]` Add docs/use-cases/ci-audit.md <!-- rs:task=mkt-p1-add-docs-use-cases-ci-audit -->
-  - ⚠️ attempted but validation failed: file reference shows implementation location, not confirmed completion
+  - ⚠️ no implementation evidence found yet: missing referenced file(s): docs/use-cases/ci-audit.md; no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P1]` Add docs/use-cases/claude-code.md <!-- rs:task=mkt-p1-add-docs-use-cases-claude-code -->
   - ⚠️ attempted but validation failed: file reference shows implementation location, not confirmed completion
 - [ ] `[P2]` Add docs/limitations.md (consolidate existing known limitations) <!-- rs:task=mkt-p1-add-docs-limitations -->
@@ -471,8 +569,9 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Exit Criteria:**
 
 - [ ] `[P0]` validation.minimumConfidence config field accepted without errors <!-- rs:task=mkt-ph5-st1-exit-minimum-confidence-config-accepted -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` roadmapsmith doctor exits 0 on a healthy repo <!-- rs:task=mkt-ph5-st1-exit-doctor-exits-zero-healthy-repo -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 
 ### Phase 6: Distribution
 
@@ -489,27 +588,70 @@ RoadmapSmith is a CLI tool and agent skill that auto-generates, validates, and s
 **Tasks:**
 
 - [ ] `[P0]` Prepare and cut GitHub release v0.6.0 <!-- rs:task=mkt-p2-github-release-v060 -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P0]` Publish npm release v0.6.0 <!-- rs:task=mkt-p2-npm-release-v060 -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Update GitHub Actions workflow actions for Node 24 runner compatibility <!-- rs:task=mkt-p2-update-github-actions-node24-compat -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` Publish or update skills.sh entry <!-- rs:task=mkt-p2-publish-skills-sh-entry -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P1]` Evaluate MCP Market and skill.fish publishing <!-- rs:task=mkt-p2-evaluate-mcp-market-skill-fish -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P2]` Create launch post (LinkedIn) <!-- rs:task=mkt-p2-create-launch-post-linkedin -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found; missing test evidence
 - [ ] `[P2]` Add GitHub issue templates (bug, feature, false-positive) <!-- rs:task=mkt-p2-add-issue-templates -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match; missing test evidence
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match; missing test evidence
 
 **Exit Criteria:**
 
 - [ ] `[P0]` npm install -g roadmapsmith@0.6.0 succeeds <!-- rs:task=mkt-ph6-st1-exit-npm-install-v060-succeeds -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 - [ ] `[P0]` GitHub release v0.6.0 published with release notes <!-- rs:task=mkt-ph6-st1-exit-github-release-v060-published -->
-  - ⚠️ attempted but validation failed: weak path-only evidence lacks content-specific token match
+  - ⚠️ no implementation evidence found yet: weak path-only evidence lacks content-specific token match
 - [ ] `[P1]` skills.sh entry updated or submitted <!-- rs:task=mkt-ph6-st1-exit-skills-sh-entry-updated -->
+  - ⚠️ no implementation evidence found yet: no code, test, or artifact evidence found
 
 ## Detected Project Profile
 - **Type:** landing-site
 - **Confidence:** medium
 - **Evidence:** directory: assets, config: next.config.js, config: tailwind.config.js, CSS files present, landing/service routes: 4
+
+### Phase 7: Post-0.9.33 Audit Remediation
+
+**Phase Priority:** `[P0]`
+
+**Objective:** Address the six findings from the production audit of 0.9.33. Full diagnosis and fix specifications in [docs/audit-remediation.md](docs/audit-remediation.md).
+
+#### Step 7.1: Breaking change and documentation
+
+**Step Priority:** `[P0]`
+**Depends on:** None
+
+**Tasks:**
+
+- [ ] `[P0]` Add `[fix]` remediation hint to `doctor`/`status` when canonical VS Code tasks are missing after upgrade <!-- rs:task=audit-p0-doctor-status-setup-hint -->
+- [ ] `[P1]` Document `WARN:STALE_EVIDENCE` resolution paths in roadmap-validate skill <!-- rs:task=audit-p1a-stale-evidence-docs -->
+- [ ] `[P1]` Document `validate --json` Windows pipe limitation and add `--out <file>` flag <!-- rs:task=audit-p1b-validate-json-windows -->
+
+#### Step 7.2: Artifact contamination fix
+
+**Step Priority:** `[P0]`
+**Depends on:** None
+
+**Tasks:**
+
+- [ ] `[P0]` Centralize generated-output filtering into `stripNonEvidencePaths()` applied after evidence assembly <!-- rs:task=audit-p2-artifact-filter-centralize -->
+
+#### Step 7.3: Validate independence — content verification layer
+
+**Step Priority:** `[P1]`
+**Depends on:** Step 7.2
+
+**Tasks:**
+
+- [ ] `[P1]` Spec and meta-tests for `contentVerifier.js` contract using real false-positive fixtures from audit <!-- rs:task=audit-p3a-content-verifier-spec -->
+- [ ] `[P1]` Implement `src/validator/contentVerifier.js` behind `--strict-content` flag, report-only mode <!-- rs:task=audit-p3b-content-verifier-impl -->
+- [ ] `[P1]` Wire content verifier to exit-code and `WARN:UNVERIFIED_EVIDENCE` diagnostic under `--strict` <!-- rs:task=audit-p3c-content-verifier-gating -->
+- [ ] `[P2]` Integrate content verifier into `maintain` self-audit once `validate --strict-content` is stable <!-- rs:task=audit-p3d-content-verifier-maintain -->
+
 <!-- rs:managed:end -->

--- a/docs/audit-remediation.md
+++ b/docs/audit-remediation.md
@@ -1,0 +1,241 @@
+# Audit Remediation Roadmap — post-0.9.33
+
+This document tracks the staged remediation plan derived from a production audit of RoadmapSmith
+0.9.33 against a real repository (Electron + Next.js + Prisma, ~80 tasks in ROADMAP.md). It lives
+here so progress can be tracked across releases without losing the technical analysis.
+
+---
+
+## Audit summary
+
+### What works well in 0.9.33
+
+- **`maintain`** — conservative contract is solid. Zero false positives observed. Pending tasks
+  receive `⚠️` annotations with traceable file references rather than invented checkmarks.
+- **`validate` WARN:STALE_EVIDENCE** — correctly fires when a historical annotation contradicts
+  what the inferencer sees today. A concrete improvement over 0.9.28 where validate silently
+  confirmed false positives without resistance.
+- **`update` validation gate** — the most important addition in this version. Rejects supplied
+  evidence that cannot be verified at high confidence in the repository. The tool refuses to write
+  blindly what a human asserts.
+- **`generate --dry-run`** — correctly rejects without `--full-regen` when a managed block exists.
+- **`sync --dry-run`** — returns "No changes" when appropriate.
+
+### Six findings
+
+| # | Finding | Severity | Status |
+|---|---------|----------|--------|
+| F0 | `doctor`/`status` exit 1 with no remediation hint after 0.9.33 upgrade | Breaking/Urgent | [ ] Fase 0 |
+| F1a | `WARN:STALE_EVIDENCE` resolution path undocumented | Doc gap | [ ] Fase 1 |
+| F1b | `validate --json \| command` fails on Windows | Platform gap | [ ] Fase 1 |
+| F2 | Build artifacts (`dist-electron/` etc.) still appear in evidence lists | Evidence noise | [ ] Fase 2 |
+| F3 | `validate` shares the same inferencer as `maintain` — not an independent second opinion | Structural gap | [ ] Fase 3 |
+
+---
+
+## Phase 0 — Breaking change in `doctor`/`status` (URGENT)
+
+**Status:** `[ ]` pending
+
+### Root cause
+
+0.9.33 added `RoadmapSmith: Update` to `ROADMAPSMITH_CANONICAL_TASK_LABELS`
+([host.js:28](../roadmap-skill/src/host.js)). Any installation that did not run `setup` after
+upgrading is missing that task in `.vscode/tasks.json`. The consequence: `doctor` and `status`
+return exit 1 with:
+
+```
+[fail] VS Code tasks incomplete: missing RoadmapSmith: Update
+```
+
+([cli.js:636](../roadmap-skill/bin/cli.js)) with no indication of what to do. The user sees FAIL on
+a perfectly valid installation that simply has not been updated yet.
+
+The hint text already exists for the Codex surface at
+[host.js:1330](../roadmap-skill/src/host.js):
+`'Run roadmapsmith setup to regenerate the VS Code task surface'`.
+
+### Planned fix
+
+In `cli.js:636`, after the `logError(...)` for the missing labels, emit a second line:
+
+```
+[fix] Run `roadmapsmith setup` to apply the latest task configuration (new task added in 0.9.33).
+```
+
+Keep `ok = false` and exit 1 — the installation genuinely needs an action — but the message is now
+actionable. Do not degrade to a warning: a missing canonical task is an incomplete state.
+
+### Planned tests
+
+In `test/cli.test.js`: extend the `status`/`doctor` test case with a `.vscode/tasks.json` missing
+the Update label, and assert that stdout includes `roadmapsmith setup`.
+
+---
+
+## Phase 1 — Documentation: WARN:STALE_EVIDENCE and Windows pipe (cheap)
+
+**Status:** `[ ]` pending
+
+### 1a. WARN:STALE_EVIDENCE resolution path
+
+The warning is emitted in
+[validator/index.js:1834](../roadmap-skill/src/validator/index.js)
+when a historical `⚠️` annotation contradicts fresh repository evidence. No resolution path is
+documented anywhere.
+
+**How the warning resolves (analysis):**
+
+The flag `staleEvidenceResolved` ([validator/index.js:2080](../roadmap-skill/src/validator/index.js))
+is set to `true` when: the task is not checked AND it passes AND it was NOT confirmed by authoritative
+evidence AND deterministic verification passed OR high-confidence code+test evidence exists AND no
+negative signals or unique reasons remain. When `staleEvidenceResolved` is `true`, sync writes a
+`Evidence:` discovery line and removes the stale annotation.
+
+**Resolution paths for the user:**
+
+1. Run `roadmapsmith maintain`. If the fresh evidence is strong enough (deterministic verifier or
+   high-confidence code+test match with no negative signals), maintain clears the annotation and
+   writes a confirmed `Evidence:` line.
+2. If maintain does not clear it, the evidence is not strong enough to auto-resolve. Add an explicit
+   `Evidence:` line manually pointing to the files that implement the task, then run `maintain`
+   again.
+3. If the annotation is known to be a historical artifact with no resolution needed, delete the
+   `⚠️` line manually from ROADMAP.md.
+
+**Planned deliverable:** Add a "Resolving WARN:STALE_EVIDENCE" section to
+`skills/roadmap-validate/SKILL.md` and its mirror in
+`plugins/roadmapsmith/skills/roadmap-validate/SKILL.md` describing the three paths above.
+
+### 1b. `validate --json | command` fails on Windows
+
+`validate --json` writes JSON to stdout ([cli.js:551](../roadmap-skill/bin/cli.js)). The audit
+failure was from a consumer that reads `/dev/stdin`, which on Windows resolves to
+`C:\dev\stdin` (nonexistent). This is not a bug in RoadmapSmith, but it should be documented and a
+Windows-friendly escape should exist.
+
+**Workaround (now):** Redirect to a file: `roadmapsmith validate --json > out.json`.
+
+**Planned fix:** Add a `--out <file>` flag to `validate` that writes JSON to a file instead of
+stdout, sidestepping the pipe issue entirely. Implement alongside the output block at
+`cli.js:549-551`. Add a note to the skill and `--help` output documenting the limitation.
+
+---
+
+## Phase 2 — Artifact contamination in evidence lists
+
+**Status:** `[ ]` pending
+
+### Root cause (confirmed)
+
+`dist-electron/` and other build outputs are declared in `GENERATED_OUTPUT_PREFIXES`
+([validator/index.js:16](../roadmap-skill/src/validator/index.js)) and each matching pass contains
+`if (file.generatedOutput) continue;`. However, the guard is re-implemented per-pass and **not all
+passes apply it**. The `evidence` object assembled at
+[validator/index.js:1889](../roadmap-skill/src/validator/index.js)
+holds ~8 file arrays:
+
+| Array | Guard applied? |
+|-------|---------------|
+| `codeFiles` (via `findCodeEvidence`) | Yes |
+| `testFiles` (via `findTestEvidence`) | Yes |
+| `weakPathFiles` | Yes |
+| `files` (via `findFilesByPathHints` / pathHintResolver) | **No** |
+| `authoritativeFiles` (via `applyAuthoritativeEvidence` matchedPaths) | **No** |
+| `structuralFiles` (via `checkNamespaceStructuralEvidence`) | **Not verified** |
+
+Additionally, `artifactPatterns` ([validator/index.js:997](../roadmap-skill/src/validator/index.js))
+lists `dist/` and `build/` but **not** `dist-electron/`, `.next/`, or `coverage/`, making it
+inconsistent with `GENERATED_OUTPUT_PREFIXES`.
+
+The result: build artifact paths leak into evidence display (the `⚠️` annotation and
+`discoveredEvidence` lines), adding noise and potentially contributing to false proximity scores.
+
+### Planned fix
+
+1. Add a helper `stripNonEvidencePaths(paths, fileIndex)` that drops any path whose indexed file has
+   `generatedOutput === true`.
+2. Apply it to **all** arrays in the `evidence` object immediately after construction at
+   ~[validator/index.js:1908](../roadmap-skill/src/validator/index.js), so no future pass can
+   reintroduce generated paths. Recalculate the boolean flags `code`/`test`/`artifact` from the
+   cleaned arrays so they cannot be `true` with an empty file list.
+3. Complete `artifactPatterns` to match `GENERATED_OUTPUT_PREFIXES` for consistency
+   (already gated by the `generatedOutput` flag in the main index scan, but the pattern list is a
+   second read path).
+
+### Planned tests
+
+A fixture with a `dist-electron/main.js` whose filename matches tokens of a task; assert that after
+`validateTask`, none of the `evidence` keys (including `files`, `authoritativeFiles`,
+`structuralFiles`) contain generated paths, and that `buildDiscoveredEvidenceLine` returns `null` or
+a path that does not include `dist-electron/`. The existing `test/fixtures/electron-pos/` is the
+right base.
+
+---
+
+## Phase 3 — `validate` independence: content verification layer
+
+**Status:** `[ ]` pending (multi-sub-step; each shippable)
+
+### Root cause (structural gap)
+
+`validate` and `maintain` run the same proximity inferencer
+([validator/index.js](../roadmap-skill/src/validator/index.js)): it scores semantic closeness of
+file names to the task domain, not file content or test behavior. As a result, the two commands
+agree on their evaluations — including false positives. The audit manually reviewed 13 items that
+`validate` reported as PASS in prior sessions; 10 were confirmed false positives after reading the
+actual test files. The inferencer is evaluating semantic proximity of file names, not behavioral
+evidence.
+
+`WARN:STALE_EVIDENCE` helps when a prior incorrect annotation exists to contradict, but does not
+help on a first pass where the inferencer produces a fresh (incorrect) evaluation with no historical
+annotation to challenge it.
+
+Real independence requires a content-verification layer that reads the files the inferencer cited and
+confirms the claimed evidence actually exists inside them.
+
+### Design
+
+New module `src/validator/contentVerifier.js` — a separate layer that does **not** touch the
+proximity inferencer:
+
+- **Input:** a task + the file paths the inferencer cited as evidence.
+- **Verification:** for each cited file, confirm that the symbols/tokens from the task text appear
+  in the file body (reuse `tokenize` from `src/utils.js` and `extractSymbolHints` already in the
+  validator); for test files, confirm that an import reference to the unit under test exists (the
+  import-matching machinery is already in `referencedPathMatches` / `findTestEvidence`).
+- **Output:** an independent verdict `{ verified: bool, checkedFiles, unverifiedFiles, reason }`,
+  reported **alongside** the proximity result, not replacing it.
+- **Flag-gated:** new CLI flag `--strict-content` (or `validation.contentVerification: true` in
+  config). Without the flag, behavior is identical to today — zero regression. With the flag, a task
+  that the inferencer marks PASS but whose evidence files do not confirm the token/symbol content
+  emits `WARN:UNVERIFIED_EVIDENCE` and does not count as `passed` under `--strict`.
+
+### Precedence (from design history)
+
+`validate --strict` with content-verification must stabilize before integrating it into the
+self-audit of `maintain`. The order is: independent `validate` first, then `maintain` can consume
+the layer. Do not skip this gate.
+
+### Sub-steps (each independently mergeable)
+
+| Step | Deliverable | Depends on |
+|------|-------------|-----------|
+| 3a | Spec + meta-tests for the content-verifier contract; fixtures from real audit false positives | — |
+| 3b | `contentVerifier.js` implementation behind `--strict-content`, reporting only (no gating) | 3a |
+| 3c | Wire verifier verdict to exit-code under `--strict`; emit `WARN:UNVERIFIED_EVIDENCE` diagnostic | 3b |
+| 3d | Optional: integrate content-verifier into `maintain` self-audit once 3c is stable | 3c |
+
+### Success criterion
+
+The set of false-positive fixtures from the audit (tasks that the inferencer marks PASS but whose
+cited files do not contain the relevant symbols/behavior) must emit `WARN:UNVERIFIED_EVIDENCE` with
+`--strict-content`. Without the flag, they must still emit PASS (backward-compatibility).
+
+---
+
+## Cross-reference
+
+- Known limitations: [docs/limitations.md](limitations.md)
+- Command surfaces: [docs/command-surfaces.md](command-surfaces.md)
+- Release readiness: [docs/release-readiness.md](release-readiness.md)

--- a/docs/command-surfaces.md
+++ b/docs/command-surfaces.md
@@ -13,6 +13,12 @@ Public default path:
 - `validate`
 - `update`
 
+Behavioral contract:
+
+- `zero`: interactive discovery when TTY is available; config-plus-flags discovery when non-interactive
+- `maintain`: conservative managed-block maintenance; does not seed a managed block into a non-empty authored roadmap
+- `update`: conservative inline annotation path for existing task lines, with or without a managed block
+
 Native slash surfaces:
 
 - `/roadmap`
@@ -34,6 +40,8 @@ Available, but not the default path:
 - `generate --full-regen`
 - `sync` as the advanced alias for `update`
 - `sync --audit`
+
+`generate` is the explicit managed-section creation path. Prefer `generate --dry-run` before applying it to an authored roadmap.
 
 `update --task --evidence` remains part of the same canonical public `update` family.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -8,6 +8,14 @@ RoadmapSmith is an evidence-based tool, not a mind-reader. This document is hone
 
 **No semantic understanding.** The validator cannot distinguish between a real implementation, a stub that returns `null`, or a comment that mentions the feature name.
 
+**`validate` is not yet an independent second opinion.** `validate` and `maintain` share the same
+proximity inferencer, so they agree on their evaluations — including false positives. A production
+audit of 0.9.33 found that 10 of 13 tasks reported as PASS by `validate` were false positives when
+the cited files were read directly. A content-verification layer that checks file bodies (not just
+file names) is planned as an independent module gated by `--strict-content`. See
+[Phase 3](audit-remediation.md#phase-3----validate-independence-content-verification-layer)
+in the remediation roadmap.
+
 **Heuristic test matching is not behavioral proof.** A related test can help locate a candidate implementation, but UI/runtime behavior only auto-completes when its `Verify: kind=behavior` metadata matches the source, test, case, trigger, assertion, and a fresh configured test result.
 
 ## Confidence Levels
@@ -22,7 +30,9 @@ RoadmapSmith is an evidence-based tool, not a mind-reader. This document is hone
 
 ## File Coverage
 
-**Generated outputs are not implementation evidence.** `dist-electron/`, `dist/`, `build/`, `out/`, `.next/`, and `coverage/` are excluded from heuristic code/test matching. A configured test report is read directly by its explicit path, not discovered as source evidence.
+**Generated outputs are not implementation evidence.** `dist-electron/`, `dist/`, `build/`, `out/`, `.next/`, and `coverage/` are flagged as generated output and excluded from most heuristic code/test matching passes. However, a production audit of 0.9.33 found that generated paths can still surface in evidence lists through path-hint resolution, authoritative evidence, and structural evidence passes that do not apply the same guard. Centralizing the filter into a single post-assembly step is planned in
+[Phase 2](audit-remediation.md#phase-2----artifact-contamination-in-evidence-lists)
+of the remediation roadmap. A configured test report is read directly by its explicit path, not discovered as source evidence.
 
 **Binary files are skipped.** Images, compiled assets, and other binaries are not inspected.
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -23,6 +23,13 @@ Required taxonomy:
 - advanced: `init`, `generate`, `generate --full-regen`, `sync`, `sync --audit`
 - compatibility: `doctor`, `regenerate`, `/road <action>`, `/roadmap-sync <action>`, deprecated direct aliases
 
+Required behavior notes:
+
+- `maintain --dry-run` is documented and `maintain` refuses to seed a managed block into a non-empty authored roadmap
+- `update` is documented as the conservative inline-annotation path, including roadmaps without managed markers
+- `generate` is documented as the explicit managed-section creation path
+- `zero` documents config-plus-flag inputs for non-interactive environments
+
 ## Validator And Audit Checks
 
 Release only when all of the following are true:

--- a/docs/use-cases/claude-code.md
+++ b/docs/use-cases/claude-code.md
@@ -38,6 +38,11 @@ Compatibility only:
 
 Installing only `--skill roadmap-sync` exposes only the deprecated legacy compatibility root. It is not the recommended activation path for new workflows.
 
+Behavioral notes:
+
+- `/roadmap-maintain` is for repositories with an existing managed `ROADMAP.md` block. If the roadmap is authored and non-empty without `<!-- rs:managed:* -->`, use `/roadmap-update` for conservative inline annotations.
+- `/roadmap-zero` can run in non-interactive hosts when the discovery brief is already complete in config or provided via CLI flags.
+
 ## Repo-Local Hook
 
 `roadmapsmith setup` can generate repo-local Claude hook wiring.

--- a/docs/use-cases/codex-plugin.md
+++ b/docs/use-cases/codex-plugin.md
@@ -30,6 +30,12 @@ Advanced native slash surfaces:
 - `/roadmap-generate`
 - `/roadmap-audit`
 
+Behavioral notes:
+
+- `/roadmap-maintain` only maintains an existing managed roadmap block; it will not seed managed content into a non-empty authored roadmap.
+- `/roadmap-update` is the conservative inline-annotation path for existing task lines, including authored roadmaps without managed markers.
+- `/roadmap-zero` can rely on config plus CLI flags when the host is non-interactive.
+
 ## Duplicate legacy surface
 
 If a legacy `~/.agents/skills/roadmap-sync` install is still present, Codex may show a duplicate `/roadmap-sync`.

--- a/docs/use-cases/sync-audit-mode.md
+++ b/docs/use-cases/sync-audit-mode.md
@@ -7,7 +7,22 @@ Use this mode when the repository already contains code, tests, docs, TODOs, or 
 Daily maintenance:
 
 ```bash
+roadmapsmith maintain --dry-run
 roadmapsmith maintain
+```
+
+Authored roadmap with task markers but no managed block:
+
+```bash
+roadmapsmith update --dry-run
+roadmapsmith update
+```
+
+Intentional managed-section creation in an authored roadmap:
+
+```bash
+roadmapsmith generate --dry-run
+roadmapsmith generate
 ```
 
 Independent audit:
@@ -19,11 +34,13 @@ roadmapsmith validate --strict --json
 
 ## Semantics
 
-- `maintain`: preserve-first flow that runs generation, sync, and audit output together
+- `maintain`: preserve-first flow that runs generation, sync, and audit output together, but only for an existing managed block
 - `sync`: advanced mutating checklist refresh
 - `sync --audit`: advanced mutating summary after sync
 - `validate`: default validation view with compatibility-preserving semantics
 - `validate --strict`: first independent audit path
+
+If `ROADMAP.md` is non-empty and lacks `<!-- rs:managed:start -->`, `maintain` fails fast instead of appending generated boilerplate. Use `update` for conservative inline annotations or `generate` to seed the managed section explicitly.
 
 `validate --strict` may still use the inferencer to discover candidates, but PASS is limited to explicit `Evidence:` or passing typed `Verify:`.
 

--- a/docs/use-cases/zero-mode-discovery.md
+++ b/docs/use-cases/zero-mode-discovery.md
@@ -20,7 +20,7 @@ Do not use Zero Mode for a repository that already has code, tests, or a partial
 
 ## How it works
 
-`roadmapsmith zero` is the public entrypoint. It does not expect the user to invent a free-form prompt. The CLI detects that Zero Mode applies, runs a terminal-native discovery interview, persists the brief into config, creates governance files when needed, and generates the first roadmap in one invocation.
+`roadmapsmith zero` is the public entrypoint. It does not expect the user to invent a free-form prompt. The CLI detects that Zero Mode applies, runs a terminal-native discovery interview when TTY is available, or consumes a complete brief from config plus flags in non-interactive environments. It then persists the brief into config, creates governance files when needed, and generates the first roadmap in one invocation.
 
 The `roadmap-sync` skill remains the policy layer for agent hosts that use skills, but it is no longer the only way to access Zero Mode.
 
@@ -57,6 +57,29 @@ A well-formed Zero Mode roadmap includes:
 roadmapsmith zero
 ```
 
+Non-interactive workflow:
+
+```bash
+roadmapsmith zero \
+  --product-name "Launchpad" \
+  --primary-user "Solo founders" \
+  --problem-statement "They lose roadmap continuity between agent sessions" \
+  --target-outcome "ship the first usable planning workflow" \
+  --done-criterion "One founder can generate a roadmap" \
+  --done-criterion "One founder can sync it after code changes"
+```
+
+Supported non-interactive inputs:
+
+- `--product-name`
+- `--primary-user`
+- `--problem-statement`
+- `--target-outcome`
+- `--anti-goal` (repeatable)
+- `--preferred-stack`
+- `--constraint` (repeatable)
+- `--done-criterion` (repeatable)
+
 Optional policy layer for skill-based hosts:
 
 ```bash
@@ -74,5 +97,5 @@ npx skills add PapiScholz/roadmapsmith --skill roadmap-sync
 ## Guardrails
 
 - Zero Mode must not generate a generic roadmap (for example: "Set up repo", "Add tests", "Deploy") without first completing discovery.
-- In non-interactive environments, `roadmapsmith zero` must fail clearly instead of guessing the missing brief.
+- In non-interactive environments, `roadmapsmith zero` must either receive a complete brief from config/flags or fail clearly while naming the missing fields.
 - Skill installation alone must not be presented as if it already enabled the CLI or VS Code task surface.

--- a/plugins/roadmapsmith/skills/roadmap-maintain/SKILL.md
+++ b/plugins/roadmapsmith/skills/roadmap-maintain/SKILL.md
@@ -9,7 +9,8 @@ Use this command when the repository already has code, tests, docs, or an existi
 
 ## Required behavior
 
-1. Run `roadmapsmith maintain --project-root .`.
+1. Run `roadmapsmith maintain --project-root .`. Prefer `--dry-run` first when previewing impact.
 2. Treat this command as CLI-backed. Do not silently replace it with manual reasoning when the CLI is unavailable.
-3. Mention that maintain runs preserve-first generate, sync, and audit in one invocation.
-4. After a successful maintain cycle, do not propose generate, sync, or audit separately unless the user needs manual control or inspection.
+3. Mention that maintain runs preserve-first generate, sync, and audit in one invocation, but only for an existing managed roadmap block.
+4. If the roadmap is non-empty and lacks `<!-- rs:managed:* -->`, direct the user to `roadmapsmith update` for conservative inline annotations or `roadmapsmith generate` for explicit managed-section creation.
+5. After a successful maintain cycle, do not propose generate, sync, or audit separately unless the user needs manual control or inspection.

--- a/plugins/roadmapsmith/skills/roadmap-sync/agents/openai.yaml
+++ b/plugins/roadmapsmith/skills/roadmap-sync/agents/openai.yaml
@@ -2,6 +2,6 @@
   "interface": {
     "display_name": "Roadmap Sync (Deprecated)",
     "short_description": "DEPRECATED legacy root; use /roadmap-maintain or /roadmap-update.",
-    "default_prompt": "Prefer /roadmap, /roadmap-status, /roadmap-maintain, and /roadmap-update."
+    "default_prompt": "Prefer /roadmap, /roadmap-status, /roadmap-maintain, and /roadmap-update; use /roadmap-update when markers are missing."
   }
 }

--- a/plugins/roadmapsmith/skills/roadmap-zero/SKILL.md
+++ b/plugins/roadmapsmith/skills/roadmap-zero/SKILL.md
@@ -10,4 +10,5 @@ Use this command when the repository is empty or low-context and the user needs 
 ## Required behavior
 
 1. Run `roadmapsmith zero --project-root .`.
-2. If the CLI is missing, explain the install path instead of improvising the workflow manually.
+2. In non-interactive environments, provide or reuse a complete brief from config plus flags such as `--primary-user`, `--problem-statement`, `--target-outcome`, and repeatable `--done-criterion`.
+3. If the CLI is missing, explain the install path instead of improvising the workflow manually.

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- None yet.
+### Changed
+- make `maintain` fail fast on non-empty authored roadmaps that lack `<!-- rs:managed:* -->`, steering users to `update` for conservative annotations and `generate` for explicit managed-section creation
+- add pre-write `--dry-run` guidance to mutating roadmap commands and document managed-block ownership across CLI/docs/host surfaces
+- let `roadmapsmith zero` run without TTY when config plus CLI flags provide a complete discovery brief
 
 ## v0.9.33 - 2026-06-22
 

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -8,7 +8,7 @@ This package owns the RoadmapSmith CLI, validator, sync engine, host setup files
 
 - `roadmapsmith setup`
 - `roadmapsmith zero`
-- `roadmapsmith maintain`
+- `roadmapsmith maintain [--dry-run]`
 - `roadmapsmith status [--json]`
 - `roadmapsmith validate [--json] [--strict]`
 - `roadmapsmith update [--task <stable-id> --evidence "<single-line evidence>"]`
@@ -40,11 +40,39 @@ This package owns the RoadmapSmith CLI, validator, sync engine, host setup files
 
 ### Zero Mode
 
-Use for empty or low-context repositories. `roadmapsmith zero` runs the terminal interview, updates config, and generates the first roadmap.
+Use for empty or low-context repositories. `roadmapsmith zero` runs the terminal interview when TTY is available, or consumes a complete brief from config plus flags in non-interactive environments.
+
+Non-interactive inputs:
+
+- `--product-name`
+- `--primary-user`
+- `--problem-statement`
+- `--target-outcome`
+- `--anti-goal` (repeatable)
+- `--preferred-stack`
+- `--constraint` (repeatable)
+- `--done-criterion` (repeatable)
+
+Without TTY, Zero Mode requires a complete brief from config/flags and fails clearly when required fields are missing.
 
 ### Sync/Audit Mode
 
-Use for repositories that already contain code, tests, docs, TODOs, or an existing roadmap. `roadmapsmith maintain` is the preserve-first one-command flow.
+Use for repositories that already contain code, tests, docs, TODOs, or an existing roadmap. `roadmapsmith maintain` is the preserve-first one-command flow for an existing managed roadmap block.
+
+If `ROADMAP.md` is authored and non-empty but has no `<!-- rs:managed:* -->` block:
+
+- `maintain` refuses to seed managed content implicitly
+- `update` is the conservative inline-annotation path
+- `generate` is the explicit managed-section creation path
+
+For write-capable surfaces (`maintain`, `generate`, `sync`, `update`), prefer `--dry-run` first.
+
+## Managed Block Ownership
+
+- `maintain` owns the managed roadmap block only.
+- `update` can annotate existing task lines even when no managed block exists.
+- `generate` is the explicit path that creates or replaces managed roadmap content.
+- Manually inserting empty `<!-- rs:managed:start -->` markers is no longer required as a workaround.
 
 ## Verification Model
 

--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -14,14 +14,21 @@ const { generateRoadmapDocument } = require('../src/generator');
 const { parseRoadmap, tasksInManagedBlock } = require('../src/parser');
 const { buildValidationContext, validateTasks, auditValidation, CONFIDENCE_RANK, applyMinimumConfidence } = require('../src/validator');
 const { applySync } = require('../src/sync');
-const { buildZeroModeConfigPatch, buildZeroModeDefaults, collectZeroModeAnswers, isInteractiveTerminal } = require('../src/zero');
+const {
+  buildZeroModeConfigPatch,
+  collectZeroModeAnswers,
+  formatMissingZeroModeFields,
+  getMissingZeroModeFields,
+  isInteractiveTerminal,
+  resolveZeroModeAnswers
+} = require('../src/zero');
 
 function printHelp() {
   console.log([
     'Usage:',
     '  Canonical commands:',
-    '  roadmapsmith zero [--project-root <path>] [--config <path>]',
-    '  roadmapsmith maintain [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--full-regen] [--refresh-annotations]',
+    '  roadmapsmith zero [--project-root <path>] [--config <path>] [--product-name <text>] [--primary-user <text>] [--problem-statement <text>] [--target-outcome <text>] [--anti-goal <text> ...] [--preferred-stack <text>] [--constraint <text> ...] [--done-criterion <text> ...]',
+    '  roadmapsmith maintain [--project-root <path>] [--config <path>] [--roadmap-file <path>] [--dry-run] [--full-regen] [--refresh-annotations]',
     '  roadmapsmith status [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--json]',
     '  roadmapsmith validate [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--task <id|text>] [--json] [--strict]',
     '  roadmapsmith update [--task <stable-id> --evidence <text>] [--roadmap-file <path>] [--project-root <path>] [--config <path>] [--dry-run]',
@@ -140,6 +147,42 @@ function formatSetupVerb(result, dryRun) {
   return result.before == null ? 'Created' : 'Updated';
 }
 
+function emitPreWriteWarning(roadmapFile, options = {}) {
+  if (options.dryRun || options.suppressWarning) {
+    return;
+  }
+  if (options.warningState && options.warningState.emitted) {
+    return;
+  }
+
+  const commandName = options.commandName || 'roadmapsmith';
+  console.log(`Warning: ${commandName} will modify ${roadmapFile}. Review the preview first with --dry-run.`);
+  if (options.managedSectionNote) {
+    console.log(options.managedSectionNote);
+  }
+
+  if (options.warningState) {
+    options.warningState.emitted = true;
+  }
+}
+
+function assertMaintainCanWrite(roadmapFile, content) {
+  if (content == null || String(content).trim().length === 0) {
+    return;
+  }
+
+  const parsed = parseRoadmap(content);
+  if (parsed.hasManagedBlock) {
+    return;
+  }
+
+  throw new Error(
+    `Refusing to let roadmapsmith maintain seed a managed section into an authored roadmap without <!-- rs:managed:start --> markers: ${roadmapFile}\n` +
+    'For conservative inline annotations, run `roadmapsmith update --dry-run` then `roadmapsmith update`.\n' +
+    'To intentionally create a managed section, run `roadmapsmith generate --dry-run` then `roadmapsmith generate`.'
+  );
+}
+
 function runInitCommand(projectRoot, config, flags) {
   const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
   const agentsFile = resolveAgentsFile(projectRoot, config, flags['agents-file']);
@@ -187,6 +230,13 @@ function runGenerateCommand(projectRoot, config, flags, options = {}) {
     forceFullRegenerate: options.forceFullRegenerate === true || isEnabled(flags['full-regen'])
   });
 
+  emitPreWriteWarning(roadmapFile, {
+    commandName: options.commandName || 'roadmapsmith generate',
+    dryRun,
+    suppressWarning: options.suppressPreWriteWarning,
+    warningState: options.warningState,
+    managedSectionNote: 'This command may create or replace a managed roadmap section depending on the current file state and flags.'
+  });
   const writeResult = writeText(roadmapFile, document, { dryRun });
   if (dryRun) {
     if (writeResult.changed) {
@@ -229,6 +279,12 @@ function runSyncCommand(projectRoot, config, flags, options = {}) {
   const forceRefresh = isEnabled(flags['refresh-annotations']);
   const next = applySync(content, syncTasks, results, { forceRefresh });
   const dryRun = isEnabled(flags['dry-run']);
+  emitPreWriteWarning(roadmapFile, {
+    commandName: options.commandName || 'roadmapsmith sync',
+    dryRun,
+    suppressWarning: options.suppressPreWriteWarning,
+    warningState: options.warningState
+  });
   const writeResult = writeText(roadmapFile, next, { dryRun });
 
   if (dryRun) {
@@ -266,7 +322,7 @@ function runUpdateCommand(projectRoot, config, flags) {
   const hasTask = flags.task != null;
   const hasEvidence = flags.evidence != null;
   if (!hasTask && !hasEvidence) {
-    runSyncCommand(projectRoot, config, flags);
+    runSyncCommand(projectRoot, config, flags, { commandName: 'roadmapsmith update' });
     return;
   }
   if (!hasTask || !hasEvidence || Array.isArray(flags.task) || Array.isArray(flags.evidence)) {
@@ -306,6 +362,10 @@ function runUpdateCommand(projectRoot, config, flags) {
 
   const next = applySync(draft, [draftTask], { [taskId]: result });
   const dryRun = isEnabled(flags['dry-run']);
+  emitPreWriteWarning(roadmapFile, {
+    commandName: 'roadmapsmith update',
+    dryRun
+  });
   const writeResult = writeText(roadmapFile, next, { dryRun });
   if (dryRun) {
     if (writeResult.changed) {
@@ -371,40 +431,69 @@ function runStatusCommand(projectRoot, config, flags, options = {}) {
 async function runZeroCommand(projectRoot, flags) {
   const configPath = resolveConfigPath({ projectRoot, configPath: flags.config });
   const config = loadConfig({ projectRoot, configPath: flags.config });
-  if (!isInteractiveTerminal(process.stdin, process.stdout)) {
-    throw new Error('Zero Mode requires an interactive terminal. Run roadmapsmith zero from a terminal session, or add a config/brief workflow before retrying in non-interactive mode.');
-  }
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const roadmapExistedBeforeInit = fs.existsSync(roadmapFile);
+  const defaults = resolveZeroModeAnswers(projectRoot, config, flags);
+  const interactive = isInteractiveTerminal(process.stdin, process.stdout);
+  let answers = defaults;
 
-  const defaults = buildZeroModeDefaults(projectRoot, config);
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-  });
-
-  try {
+  if (!interactive) {
+    const missingFields = getMissingZeroModeFields(defaults);
+    if (missingFields.length > 0) {
+      throw new Error(
+        'Zero Mode requires a complete brief in non-interactive environments. Missing: ' +
+        `${formatMissingZeroModeFields(missingFields).join(', ')}. ` +
+        'Provide the missing values with CLI flags or in roadmap-skill.config.json before retrying.'
+      );
+    }
     console.log('RoadmapSmith Zero Mode');
-    console.log('Answer the discovery interview to generate the first roadmap.\n');
-    const answers = await collectZeroModeAnswers((prompt) => rl.question(prompt), defaults);
-    const existingUserConfig = readUserConfig({ projectRoot, configPath: flags.config });
-    const nextUserConfig = buildZeroModeConfigPatch(projectRoot, existingUserConfig, answers);
-    writeText(configPath, JSON.stringify(nextUserConfig, null, 2));
-    console.log(`Updated ${configPath}`);
-    const nextConfig = loadConfig({ projectRoot, configPath: flags.config });
-    runInitCommand(projectRoot, nextConfig, flags);
-    runGenerateCommand(projectRoot, nextConfig, flags);
-  } finally {
-    rl.close();
+    console.log('Using config/flag discovery inputs in non-interactive mode.\n');
+  } else {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+
+    try {
+      console.log('RoadmapSmith Zero Mode');
+      console.log('Answer the discovery interview to generate the first roadmap.\n');
+      answers = await collectZeroModeAnswers((prompt) => rl.question(prompt), defaults);
+    } finally {
+      rl.close();
+    }
   }
+
+  const existingUserConfig = readUserConfig({ projectRoot, configPath: flags.config });
+  const nextUserConfig = buildZeroModeConfigPatch(projectRoot, existingUserConfig, answers);
+  writeText(configPath, JSON.stringify(nextUserConfig, null, 2));
+  console.log(`Updated ${configPath}`);
+  const nextConfig = loadConfig({ projectRoot, configPath: flags.config });
+  runInitCommand(projectRoot, nextConfig, flags);
+  runGenerateCommand(projectRoot, nextConfig, flags, {
+    commandName: 'roadmapsmith zero',
+    suppressPreWriteWarning: true,
+    forceFullRegenerate: !roadmapExistedBeforeInit
+  });
 }
 
 function runMaintainCommand(projectRoot, flags) {
   const config = loadConfig({ projectRoot, configPath: flags.config });
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const existingContent = readTextIfExists(roadmapFile);
+  assertMaintainCanWrite(roadmapFile, existingContent);
   const fullRegen = isEnabled(flags['full-regen']);
+  const warningState = { emitted: false };
   runGenerateCommand(projectRoot, config, flags, {
+    commandName: 'roadmapsmith maintain',
     preserveManagedBlock: !fullRegen,
-    forceFullRegenerate: fullRegen
+    forceFullRegenerate: fullRegen,
+    warningState
   });
-  runSyncCommand(projectRoot, config, { ...flags, audit: true }, { audit: true });
+  runSyncCommand(projectRoot, config, { ...flags, audit: true }, {
+    audit: true,
+    commandName: 'roadmapsmith maintain',
+    warningState
+  });
 }
 
 async function run() {

--- a/roadmap-skill/src/zero.js
+++ b/roadmap-skill/src/zero.js
@@ -2,6 +2,17 @@
 
 const path = require('path');
 
+const ZERO_MODE_FLAG_SPECS = {
+  productName: { flag: '--product-name', configPath: 'product.name', type: 'scalar' },
+  primaryUser: { flag: '--primary-user', configPath: 'product.primaryUser', type: 'scalar', required: true },
+  problemStatement: { flag: '--problem-statement', configPath: 'zeroMode.problemStatement', type: 'scalar', required: true },
+  targetOutcome: { flag: '--target-outcome', configPath: 'product.targetOutcome', type: 'scalar', required: true },
+  antiGoals: { flag: '--anti-goal', configPath: 'product.antiGoals', type: 'list' },
+  preferredStack: { flag: '--preferred-stack', configPath: 'zeroMode.preferredStack', type: 'scalar' },
+  constraints: { flag: '--constraint', configPath: 'zeroMode.constraints', type: 'list' },
+  doneCriteria: { flag: '--done-criterion', configPath: 'zeroMode.doneCriteria', type: 'list', required: true }
+};
+
 const ZERO_MODE_QUESTIONS = [
   { id: 'productName', prompt: '1. What product are we building?' },
   { id: 'primaryUser', prompt: '2. Who is the target user?' },
@@ -52,6 +63,80 @@ function buildZeroModeDefaults(projectRoot, config) {
         : (config.product && config.product.successCriteria)
     )
   };
+}
+
+function getSingleFlagValue(value) {
+  if (Array.isArray(value)) {
+    return value[value.length - 1];
+  }
+  return value;
+}
+
+function getListFlagValues(value) {
+  const rawValues = Array.isArray(value) ? value : [value];
+  return rawValues.flatMap((item) => splitListAnswer(item));
+}
+
+function resolveZeroModeAnswers(projectRoot, config, flags = {}) {
+  const defaults = buildZeroModeDefaults(projectRoot, config);
+  const answers = { ...defaults };
+
+  for (const [field, spec] of Object.entries(ZERO_MODE_FLAG_SPECS)) {
+    const flagKey = spec.flag.slice(2);
+    if (!Object.prototype.hasOwnProperty.call(flags, flagKey)) {
+      continue;
+    }
+
+    if (spec.type === 'list') {
+      answers[field] = getListFlagValues(flags[flagKey]).join('; ');
+      continue;
+    }
+
+    const raw = getSingleFlagValue(flags[flagKey]);
+    answers[field] = String(raw == null ? '' : raw).trim();
+  }
+
+  if (!String(answers.productName || '').trim()) {
+    answers.productName = path.basename(projectRoot);
+  }
+
+  return answers;
+}
+
+function getMissingZeroModeFields(answers = {}) {
+  const missing = [];
+  for (const [field, spec] of Object.entries(ZERO_MODE_FLAG_SPECS)) {
+    if (!spec.required) {
+      continue;
+    }
+
+    if (spec.type === 'list') {
+      if (splitListAnswer(answers[field]).length === 0) {
+        missing.push({
+          field,
+          flag: spec.flag,
+          configPath: spec.configPath
+        });
+      }
+      continue;
+    }
+
+    if (!String(answers[field] || '').trim()) {
+      missing.push({
+        field,
+        flag: spec.flag,
+        configPath: spec.configPath
+      });
+    }
+  }
+  return missing;
+}
+
+function formatMissingZeroModeFields(missingFields) {
+  return missingFields.map((item) => {
+    const label = item.field.replace(/([A-Z])/g, ' $1').toLowerCase();
+    return `${label} (${item.flag} or config ${item.configPath})`;
+  });
 }
 
 async function collectZeroModeAnswers(ask, defaults = {}) {
@@ -124,6 +209,9 @@ module.exports = {
   buildZeroModeConfigPatch,
   buildZeroModeDefaults,
   collectZeroModeAnswers,
+  formatMissingZeroModeFields,
+  getMissingZeroModeFields,
   isInteractiveTerminal,
+  resolveZeroModeAnswers,
   splitListAnswer
 };

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -258,9 +258,34 @@ test('cli maintain runs generate, sync, and audit in one invocation', () => {
   const roadmapPath = path.join(projectRoot, CANONICAL_ROADMAP);
   const content = fs.readFileSync(roadmapPath, 'utf8');
 
+  assert.match(out, /Warning: roadmapsmith maintain will modify/);
   assert.match(out, /Updated .*ROADMAP\.md|No changes for .*ROADMAP\.md/);
   assert.match(out, /Audit summary:/);
   assert.match(content, /<!-- rs:managed:start -->/);
+});
+
+test('cli maintain refuses to seed a managed block into an authored roadmap without managed markers', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-maintain-authored-'));
+  writePackageJson(projectRoot);
+  const roadmapPath = path.join(projectRoot, CANONICAL_ROADMAP);
+  const before = [
+    '# Mi roadmap editorial',
+    '',
+    '## Prioridades',
+    '- [ ] Integrar facturacion AFIP <!-- rs:task=afip -->',
+    '- [ ] Cerrar caja diario <!-- rs:task=cierre-caja -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(roadmapPath, before, 'utf8');
+
+  const result = runResult(['maintain'], projectRoot);
+  const after = fs.readFileSync(roadmapPath, 'utf8');
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Refusing to let roadmapsmith maintain seed a managed section/i);
+  assert.match(result.stderr, /roadmapsmith update --dry-run/);
+  assert.match(result.stderr, /roadmapsmith generate --dry-run/);
+  assert.equal(after, before);
 });
 
 test('cli maintain preserves a substantive custom managed block for Electron desktop repos', () => {
@@ -326,6 +351,31 @@ test('cli /roadmap-update --dry-run is stable for the RoadmapSmith repo roadmap'
   assert.match(result.stdout, /No changes for .*ROADMAP\.md|Dry run: .*ROADMAP\.md/i);
   assert.doesNotMatch(result.stdout, /Add SEO metadata|Lighthouse performance score|responsive and mobile-first layout|accessibility baseline/i);
   assert.equal(after, before);
+});
+
+test('cli update refreshes inline annotations without adding a managed block to authored roadmaps', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-update-authored-'));
+  writePackageJson(projectRoot);
+  const roadmapPath = path.join(projectRoot, CANONICAL_ROADMAP);
+  fs.writeFileSync(
+    roadmapPath,
+    [
+      '# Mi roadmap editorial',
+      '',
+      '## Prioridades',
+      '- [ ] Integrar facturacion AFIP <!-- rs:task=afip -->',
+      '- [ ] Cerrar caja diario <!-- rs:task=cierre-caja -->',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  const out = run(['update'], projectRoot);
+  const content = fs.readFileSync(roadmapPath, 'utf8');
+
+  assert.match(out, /Warning: roadmapsmith update will modify/);
+  assert.match(content, /⚠️ no implementation evidence found yet/);
+  assert.doesNotMatch(content, /<!-- rs:managed:start -->/);
 });
 
 test('cli update completes one task only after its supplied evidence validates at high confidence', () => {
@@ -834,6 +884,15 @@ test('no args prints usage', () => {
   assert.match(out, /Usage:/);
   assert.match(out, /roadmapsmith zero/);
   assert.match(out, /roadmapsmith maintain/);
+  assert.match(out, /maintain .*--dry-run/);
+  assert.match(out, /--product-name/);
+  assert.match(out, /--primary-user/);
+  assert.match(out, /--problem-statement/);
+  assert.match(out, /--target-outcome/);
+  assert.match(out, /--anti-goal/);
+  assert.match(out, /--preferred-stack/);
+  assert.match(out, /--constraint/);
+  assert.match(out, /--done-criterion/);
   assert.match(out, /--full-regen/);
   assert.match(out, /\/roadmap-update/);
   assert.doesNotMatch(out, /\/roadmap-regenerate/);
@@ -857,6 +916,26 @@ test('cli /roadmap-maintain executes the one-command existing-repo flow', () => 
 
   assert.match(out, /Audit summary:/);
   assert.equal(fs.existsSync(path.join(projectRoot, CANONICAL_ROADMAP)), true);
+});
+
+test('cli /roadmap-maintain refuses to seed a managed block into an authored roadmap without markers', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-maintain-authored-'));
+  writePackageJson(projectRoot);
+  const roadmapPath = path.join(projectRoot, CANONICAL_ROADMAP);
+  const before = [
+    '# Mi roadmap editorial',
+    '',
+    '## Prioridades',
+    '- [ ] Integrar facturacion AFIP <!-- rs:task=afip -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(roadmapPath, before, 'utf8');
+
+  const result = runResult(['/roadmap-maintain'], projectRoot);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /roadmapsmith update --dry-run/);
+  assert.equal(fs.readFileSync(roadmapPath, 'utf8'), before);
 });
 
 test('cli /roadmap sync resolves to the canonical update family without changing dry-run behavior', () => {
@@ -926,12 +1005,94 @@ test('cli unknown direct slash input shows related help safely', () => {
   assert.match(result.stdout, /\/roadmap-update/);
 });
 
-test('cli zero fails clearly in non-interactive mode', () => {
+test('cli zero succeeds in non-interactive mode when config provides a complete brief', () => {
   const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-zero-noninteractive-'));
+  fs.writeFileSync(
+    path.join(projectRoot, 'roadmap-skill.config.json'),
+    JSON.stringify({
+      product: {
+        name: 'Launchpad',
+        primaryUser: 'Solo founders',
+        targetOutcome: 'ship the first usable planning workflow',
+        successCriteria: ['One founder can sync the roadmap after coding']
+      },
+      zeroMode: {
+        problemStatement: 'They lose roadmap continuity between agent sessions'
+      }
+    }, null, 2),
+    'utf8'
+  );
   const result = runResult(['zero'], projectRoot);
 
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Using config\/flag discovery inputs in non-interactive mode/);
+  assert.equal(fs.existsSync(path.join(projectRoot, CANONICAL_ROADMAP)), true);
+});
+
+test('cli zero succeeds in non-interactive mode when flags provide a complete brief', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-zero-flags-'));
+  const result = runResult([
+    'zero',
+    '--product-name', 'Launchpad',
+    '--primary-user', 'Solo founders',
+    '--problem-statement', 'They lose roadmap continuity between agent sessions',
+    '--target-outcome', 'ship the first usable planning workflow',
+    '--anti-goal', 'No billing',
+    '--constraint', 'Bootstrap in 2 weeks',
+    '--done-criterion', 'One founder can generate a roadmap',
+    '--done-criterion', 'One founder can sync it after code changes'
+  ], projectRoot);
+  const savedConfig = JSON.parse(fs.readFileSync(path.join(projectRoot, 'roadmap-skill.config.json'), 'utf8'));
+
+  assert.equal(result.status, 0);
+  assert.equal(fs.existsSync(path.join(projectRoot, CANONICAL_ROADMAP)), true);
+  assert.equal(savedConfig.product.primaryUser, 'Solo founders');
+  assert.deepEqual(savedConfig.product.antiGoals, ['No billing']);
+  assert.deepEqual(savedConfig.zeroMode.constraints, ['Bootstrap in 2 weeks']);
+  assert.deepEqual(savedConfig.zeroMode.doneCriteria, [
+    'One founder can generate a roadmap',
+    'One founder can sync it after code changes'
+  ]);
+});
+
+test('cli /roadmap-zero inherits non-interactive config-plus-brief behavior', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-slash-zero-'));
+  fs.writeFileSync(
+    path.join(projectRoot, 'roadmap-skill.config.json'),
+    JSON.stringify({
+      product: {
+        name: 'Launchpad',
+        primaryUser: 'Solo founders',
+        targetOutcome: 'ship the first usable planning workflow',
+        successCriteria: ['One founder can sync the roadmap after coding']
+      },
+      zeroMode: {
+        problemStatement: 'They lose roadmap continuity between agent sessions'
+      }
+    }, null, 2),
+    'utf8'
+  );
+
+  const result = runResult(['/roadmap-zero'], projectRoot);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Using config\/flag discovery inputs in non-interactive mode/);
+  assert.equal(fs.existsSync(path.join(projectRoot, CANONICAL_ROADMAP)), true);
+});
+
+test('cli zero fails clearly in non-interactive mode when the merged brief is incomplete', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roadmap-skill-cli-zero-incomplete-'));
+  const result = runResult([
+    'zero',
+    '--problem-statement', 'They lose roadmap continuity between agent sessions'
+  ], projectRoot);
+
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /interactive terminal/i);
+  assert.match(result.stderr, /complete brief in non-interactive environments/i);
+  assert.match(result.stderr, /--primary-user/);
+  assert.match(result.stderr, /--target-outcome/);
+  assert.match(result.stderr, /--done-criterion/);
+  assert.equal(fs.existsSync(path.join(projectRoot, 'roadmap-skill.config.json')), false);
 });
 
 test('doctor --json reports missing integration state', () => {

--- a/roadmap-skill/test/docs-contract.test.js
+++ b/roadmap-skill/test/docs-contract.test.js
@@ -10,6 +10,7 @@ const ROOT_README_PATH = path.join(REPO_ROOT, 'README.md');
 const PACKAGE_README_PATH = path.join(REPO_ROOT, 'roadmap-skill', 'README.md');
 const COMMAND_SURFACES_DOC_PATH = path.join(REPO_ROOT, 'docs', 'command-surfaces.md');
 const SYNC_AUDIT_DOC_PATH = path.join(REPO_ROOT, 'docs', 'use-cases', 'sync-audit-mode.md');
+const ZERO_MODE_DOC_PATH = path.join(REPO_ROOT, 'docs', 'use-cases', 'zero-mode-discovery.md');
 const RELEASE_READINESS_DOC_PATH = path.join(REPO_ROOT, 'docs', 'release-readiness.md');
 const RELEASE_UX_GATE_DOC_PATH = path.join(REPO_ROOT, 'docs', 'release-ux-gate.md');
 const CI_AUDIT_DOC_PATH = path.join(REPO_ROOT, 'docs', 'use-cases', 'ci-audit.md');
@@ -47,6 +48,23 @@ test('docs present update as the public family and sync as the advanced alias', 
 
   assert.match(combined, /update`? is the public .*family|public .*`update` family/i);
   assert.match(combined, /sync`? .*advanced alias|advanced alias for `?roadmapsmith update`?/i);
+});
+
+test('docs describe maintain as conservative, update as the inline annotation path, and generate as explicit managed-section creation', () => {
+  const combined = [read(ROOT_README_PATH), read(PACKAGE_README_PATH), read(SYNC_AUDIT_DOC_PATH), read(COMMAND_SURFACES_DOC_PATH)].join('\n');
+
+  assert.match(combined, /maintain[\s\S]*does not seed a managed block|authored roadmap without managed markers/i);
+  assert.match(combined, /update[\s\S]*annotat(e|es)[\s\S]*without a managed block/i);
+  assert.match(combined, /generate[\s\S]*explicit[\s\S]*managed section/i);
+});
+
+test('docs describe zero as supporting config and flags in non-interactive environments', () => {
+  const combined = [read(ROOT_README_PATH), read(PACKAGE_README_PATH), read(ZERO_MODE_DOC_PATH)].join('\n');
+
+  assert.match(combined, /non-interactive/i);
+  assert.match(combined, /--primary-user/);
+  assert.match(combined, /--done-criterion/);
+  assert.match(combined, /config.*flags|flags.*config/i);
 });
 
 test('docs do not describe dist as heuristic implementation evidence', () => {

--- a/roadmap-skill/test/zero.test.js
+++ b/roadmap-skill/test/zero.test.js
@@ -7,6 +7,9 @@ const {
   buildZeroModeConfigPatch,
   buildZeroModeDefaults,
   collectZeroModeAnswers,
+  formatMissingZeroModeFields,
+  getMissingZeroModeFields,
+  resolveZeroModeAnswers,
   splitListAnswer
 } = require('../src/zero');
 
@@ -82,4 +85,54 @@ test('buildZeroModeConfigPatch persists interview answers into product and zeroM
   ]);
   assert.equal(next.zeroMode.preferredStack, 'Next.js + Node');
   assert.deepEqual(next.zeroMode.constraints, ['2 weeks', 'low budget']);
+});
+
+test('resolveZeroModeAnswers merges config defaults with scalar and repeated CLI flags', () => {
+  const answers = resolveZeroModeAnswers(path.join(process.cwd(), 'demo-repo'), {
+    product: {
+      name: 'Configured Product',
+      primaryUser: 'Configured user',
+      targetOutcome: 'configured outcome',
+      antiGoals: ['Configured anti-goal'],
+      successCriteria: ['Configured done']
+    },
+    zeroMode: {
+      problemStatement: 'Configured problem',
+      preferredStack: 'Configured stack',
+      constraints: ['Configured constraint'],
+      doneCriteria: ['Configured done']
+    }
+  }, {
+    'primary-user': 'Flag user',
+    'anti-goal': ['No billing', 'No marketplace'],
+    'constraint': 'Ship in 2 weeks; low budget',
+    'done-criterion': ['One user completes onboarding', 'One user syncs the roadmap'],
+    'preferred-stack': 'Node + React'
+  });
+
+  assert.equal(answers.productName, 'Configured Product');
+  assert.equal(answers.primaryUser, 'Flag user');
+  assert.equal(answers.problemStatement, 'Configured problem');
+  assert.equal(answers.targetOutcome, 'configured outcome');
+  assert.equal(answers.preferredStack, 'Node + React');
+  assert.equal(answers.antiGoals, 'No billing; No marketplace');
+  assert.equal(answers.constraints, 'Ship in 2 weeks; low budget');
+  assert.equal(answers.doneCriteria, 'One user completes onboarding; One user syncs the roadmap');
+});
+
+test('getMissingZeroModeFields reports required non-interactive brief gaps with flag/config hints', () => {
+  const missing = getMissingZeroModeFields({
+    productName: 'Demo Product',
+    primaryUser: '',
+    problemStatement: '',
+    targetOutcome: 'Launch the beta',
+    doneCriteria: ''
+  });
+
+  assert.deepEqual(missing.map((item) => item.field), ['primaryUser', 'problemStatement', 'doneCriteria']);
+  assert.deepEqual(formatMissingZeroModeFields(missing), [
+    'primary user (--primary-user or config product.primaryUser)',
+    'problem statement (--problem-statement or config zeroMode.problemStatement)',
+    'done criteria (--done-criterion or config zeroMode.doneCriteria)'
+  ]);
 });

--- a/skills.json
+++ b/skills.json
@@ -12,7 +12,7 @@
     "npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code",
     "roadmapsmith setup",
     "roadmapsmith zero",
-    "roadmapsmith maintain",
+    "roadmapsmith maintain --dry-run",
     "roadmapsmith /roadmap",
     "roadmapsmith update --task p2-customer-history --evidence \"src/app/api/customers/route.ts, test/customers.test.js\"",
     "roadmapsmith validate --json"
@@ -21,7 +21,7 @@
     "command": "npx skills add PapiScholz/roadmapsmith --skill '*' -a claude-code",
     "source": "PapiScholz/roadmapsmith",
     "skill": "*",
-    "notes": "Recommended Claude Code install path for native GUI slash commands. Canonical surfaces: /roadmap, /roadmap-zero, /roadmap-maintain, /roadmap-status, /roadmap-validate, /roadmap-update, /roadmap-setup. The public CLI update family covers both checklist refresh and verified single-task completion; sync remains the advanced alias for the mutating refresh path. Advanced surfaces: /roadmap-init, /roadmap-generate, /roadmap-audit. DEPRECATED: /roadmap-sync remains only as a compatibility root for existing automation; use /roadmap-maintain or /roadmap-update for new workflows. Install the roadmapsmith CLI separately for actual command execution; roadmapsmith status is the public readiness command and roadmapsmith doctor remains a compatibility alias. Then run /reload-skills and, if applicable, /reload-plugins. Codex native plugin installs use the repo/package .codex-plugin surface instead of this Claude-specific skills CLI path."
+    "notes": "Recommended Claude Code install path for native GUI slash commands. Canonical surfaces: /roadmap, /roadmap-zero, /roadmap-maintain, /roadmap-status, /roadmap-validate, /roadmap-update, /roadmap-setup. The public CLI update family covers both checklist refresh and verified single-task completion; sync remains the advanced alias for the mutating refresh path. /roadmap-maintain now owns only existing managed roadmap blocks, while /roadmap-update is the conservative annotation path for authored roadmaps without markers. /roadmap-zero can consume a complete discovery brief from config plus CLI flags in non-interactive environments. Advanced surfaces: /roadmap-init, /roadmap-generate, /roadmap-audit. DEPRECATED: /roadmap-sync remains only as a compatibility root for existing automation; use /roadmap-maintain or /roadmap-update for new workflows. Install the roadmapsmith CLI separately for actual command execution; roadmapsmith status is the public readiness command and roadmapsmith doctor remains a compatibility alias. Then run /reload-skills and, if applicable, /reload-plugins. Codex native plugin installs use the repo/package .codex-plugin surface instead of this Claude-specific skills CLI path."
   },
   "skills": [
     {
@@ -33,13 +33,13 @@
     {
       "name": "roadmap-zero",
       "path": "skills/roadmap-zero",
-      "description": "Native slash entrypoint for the one-command Zero Mode CLI workflow.",
+      "description": "Native slash entrypoint for Zero Mode, including non-interactive config-plus-flag discovery.",
       "version": "0.9.33"
     },
     {
       "name": "roadmap-maintain",
       "path": "skills/roadmap-maintain",
-      "description": "Native slash entrypoint for the preserve-first generate + sync + audit flow.",
+      "description": "Native slash entrypoint for conservative managed-block maintenance plus sync and audit output.",
       "version": "0.9.33"
     },
     {
@@ -69,7 +69,7 @@
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
-      "description": "Native slash entrypoint for evidence-backed sync and verified single-task completion.",
+      "description": "Native slash entrypoint for evidence-backed inline annotation refresh and verified single-task completion.",
       "version": "0.9.33"
     },
     {

--- a/skills/roadmap-maintain/SKILL.md
+++ b/skills/roadmap-maintain/SKILL.md
@@ -9,7 +9,8 @@ Use this command when the repository already has code, tests, docs, or an existi
 
 ## Required behavior
 
-1. Run `roadmapsmith maintain --project-root .`.
+1. Run `roadmapsmith maintain --project-root .`. Prefer `--dry-run` first when previewing impact.
 2. Treat this command as CLI-backed. Do not silently replace it with manual reasoning when the CLI is unavailable.
-3. Mention that maintain runs preserve-first generate, sync, and audit in one invocation.
-4. After a successful maintain cycle, do not propose generate, sync, or audit separately unless the user needs manual control or inspection.
+3. Mention that maintain runs preserve-first generate, sync, and audit in one invocation, but only for an existing managed roadmap block.
+4. If the roadmap is non-empty and lacks `<!-- rs:managed:* -->`, direct the user to `roadmapsmith update` for conservative inline annotations or `roadmapsmith generate` for explicit managed-section creation.
+5. After a successful maintain cycle, do not propose generate, sync, or audit separately unless the user needs manual control or inspection.

--- a/skills/roadmap-sync/agents/openai.yaml
+++ b/skills/roadmap-sync/agents/openai.yaml
@@ -2,6 +2,6 @@
   "interface": {
     "display_name": "Roadmap Sync (Deprecated)",
     "short_description": "DEPRECATED legacy root; use /roadmap-maintain or /roadmap-update.",
-    "default_prompt": "Prefer /roadmap, /roadmap-status, /roadmap-maintain, and /roadmap-update."
+    "default_prompt": "Prefer /roadmap, /roadmap-status, /roadmap-maintain, and /roadmap-update; use /roadmap-update when markers are missing."
   }
 }

--- a/skills/roadmap-zero/SKILL.md
+++ b/skills/roadmap-zero/SKILL.md
@@ -10,4 +10,5 @@ Use this command when the repository is empty or low-context and the user needs 
 ## Required behavior
 
 1. Run `roadmapsmith zero --project-root .`.
-2. If the CLI is missing, explain the install path instead of improvising the workflow manually.
+2. In non-interactive environments, provide or reuse a complete brief from config plus flags such as `--primary-user`, `--problem-statement`, `--target-outcome`, and repeatable `--done-criterion`.
+3. If the CLI is missing, explain the install path instead of improvising the workflow manually.


### PR DESCRIPTION
## Summary
- harden `maintain` so it refuses to seed a managed block into a non-empty authored roadmap
- add non-interactive `zero` config/flag inputs plus clearer missing-field errors
- align CLI docs, skill surfaces, manifests, and regression coverage with the new contract

## Validation
- `functional-smoke`: PASS
- `qa-regression`: PASS
- `C:\Program Files\nodejs\node.exe scripts/run-tests.js`: PASS