### PR TITLE
ci: pass NODE_AUTH_TOKEN to auto-release step for npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Auto-patch release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node roadmap-skill/scripts/auto-release.js
 
   merge-release-pr:


### PR DESCRIPTION
## Problem

The `Auto-patch release` step in CI calls `npm publish` inside `auto-release.js` but `NODE_AUTH_TOKEN` was never passed to that step's env. The `setup-node` action writes an `.npmrc` that references `${NODE_AUTH_TOKEN}`, so without this env var npm auth fails silently — the GitHub Release gets created but the package never lands on npm.

Evidence: `npm view roadmap-skill dist-tags` shows `{ latest: '0.3.0' }` even after v0.9.36 GitHub Release was created.

## Fix

Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the `Auto-patch release` step env. The `NPM_TOKEN` secret already exists in the repo.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)