### PR TITLE
Potential fix for code scanning alert no. 22: Regular expression injection

### DIFF
--- a/roadmap-skill/src/addTask.js
+++ b/roadmap-skill/src/addTask.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { parseRoadmap, upsertManagedBlock } = require('./parser');
-const { slugify } = require('./utils');
+const { slugify, escapeRegExp } = require('./utils');
 
 const PHASE_LABEL_RE = /\[(P[0-2])\]/i;
 
@@ -37,7 +37,8 @@ function addTask(text, content, options = {}) {
     blockLines = [];
   }
 
-  const phaseHeadingRe = new RegExp(`^###\\s+(?:Phase\\s+)?${phase}\\s*$`, 'i');
+  const safePhase = escapeRegExp(phase);
+  const phaseHeadingRe = new RegExp(`^###\\s+(?:Phase\\s+)?${safePhase}\\s*$`, 'i');
   const headingIdx = blockLines.findIndex((l) => phaseHeadingRe.test(l.trim()));
 
   if (headingIdx >= 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/PapiScholz/roadmapsmith/security/code-scanning/22](https://github.com/PapiScholz/roadmapsmith/security/code-scanning/22)

Use existing `escapeRegExp` utility when embedding `phase` into the dynamic regex pattern.

Best minimal fix (no behavior change):
- In `roadmap-skill/src/addTask.js`, import `escapeRegExp` from `./utils` alongside `slugify`.
- Before constructing `phaseHeadingRe`, compute `safePhase = escapeRegExp(phase)`.
- Use `${safePhase}` in the regex template string.

This preserves matching semantics for normal inputs (`P0`/`P1`/`P2`) while preventing regex metacharacter injection if `phase` ever becomes attacker-controlled through other call paths or future changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
