### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/docs/command-surfaces.md
+++ b/docs/command-surfaces.md
@@ -40,6 +40,8 @@ Available, but not the default path:
 - `generate --full-regen`
 - `sync` as the advanced alias for `update`
 - `sync --audit`
+- `update --concise` / `update --no-warnings`
+- `verify --task <id> [--run]`
 
 `generate` is the explicit managed-section creation path. Prefer `generate --dry-run` before applying it to an authored roadmap.
 

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/skills/roadmap-update/SKILL.md
+++ b/plugins/roadmapsmith/skills/roadmap-update/SKILL.md
@@ -50,11 +50,36 @@ Available update flags:
 - `--evidence <text>` — evidence to attach to `--task`
 - `--audit` — show validation audit after refresh (grouped by cause: `path-mismatch`, `no-evidence`, `deletion-task`, `namespace-gate`, `strict-mode`)
 - `--evidence-only` — write ⚠️/✅ sub-bullets but never flip `[ ]`/`[x]` (safe review pass)
+- `--concise` / `--no-warnings` — suppress ⚠️ warning lines in the emitted markdown (safe for READMEs / PR embeds)
 - `--check-drift` — compare northStar to repo state
 - `--strict` — strict validation mode (preservedCheckedState does not count as pass)
 - `--dry-run` — preview without writing
 - `--json` — output in JSON format
 - `--project-root <path>` — project root (default: cwd)
+
+## Task marker attributes
+
+Tasks use a stable-id comment: `<!-- rs:task=slug -->`. The same comment can carry extra attributes that change how the validator treats the task:
+
+- `rs:planned` — "intentionally not implemented yet". Validator skips evidence hunt. Sync emits **no** ⚠️ warning and does not flip the checkbox. Use for future scope you want on the roadmap without polluting every refresh with warnings. Example: `- [ ] Ship v0.2 feature X <!-- rs:task=ship-x rs:planned -->`.
+- `rs:kind=rollup` — "milestone/aggregator; children carry the evidence". Passes validation without a file-existence hunt. Use for phase exits, milestone rollups, "Finalize module implementation" style parent tasks. Example: `- [x] Milestone v0.2 shipped <!-- rs:task=milestone-v0-2 rs:kind=rollup -->`.
+- `rs:kind=command` + `rs:verified-by=<command>` — "evidence = a command exits 0". Passes validation on the marker alone during `update` (no shell execution). To actually run the command and flip the checkbox, use `roadmapsmith verify --task <id> --run`. Example: `- [ ] TypeScript compila sin errores <!-- rs:task=tsc-clean rs:kind=command rs:verified-by=tsc-noemit -->`. Note: `rs:verified-by` captures a single non-whitespace token — use a script path or an npm-script name if the command needs arguments.
+- `rs:evidence=manual` — human-attested completion. Trust the checked state, no evidence hunt.
+- `rs:no-test` — the task legitimately has no test.
+
+## Command-verified tasks (`verify`)
+
+For tasks marked `rs:kind=command`, `roadmapsmith update --audit` prints a **"Command-verified tasks pending run"** block listing the exact ready-to-run invocation for each unchecked command task:
+
+```
+Command-verified tasks pending run (2):
+- [tsc-clean] roadmapsmith verify --task tsc-clean --run   # (would run: tsc-noemit)
+- [test-suite] roadmapsmith verify --task test-suite --run # (would run: npm-test)
+```
+
+When you (agent) see that block, invoke each `verify --task <id> --run` yourself — the human user should not have to type them. `verify --run` executes the `rs:verified-by` command in the repo root, prints stdout/stderr, and flips `[x]` on exit 0. Non-zero exit leaves the checkbox unchecked and CLI exits with code 2.
+
+`verify --task <id>` without `--run` is a dry-preview that just prints `Would run: <command>`.
 
 ## Known limitations
 

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 - None yet.
 
+## v0.12.0 - 2026-07-11
+
+### Added
+- `rs:kind=rollup` marker attribute: milestone/aggregator tasks pass validation without file-evidence lookup. Their children carry the truth.
+- `rs:kind=command` marker attribute + `rs:verified-by=<command>`: command-verified tasks (e.g. `tsc --noEmit`, `pytest`) pass on the marker alone during `update`; the checkbox stays under human/agent control.
+- `roadmapsmith verify --task <id> [--run]` subcommand: executes the `rs:verified-by` command for a `rs:kind=command` task and flips `[x]` on exit 0. Without `--run` it prints the command it *would* execute.
+- `roadmapsmith update --concise` (alias `--no-warnings`): suppresses ⚠️ warning lines in the emitted markdown. Useful for embedding the roadmap in READMEs or PR descriptions.
+- `printAudit` now surfaces a "Command-verified tasks pending run" section listing the exact `verify --task <id> --run` invocation for each unchecked `rs:kind=command` task. Designed so an AI agent (not the human) picks them up and runs them.
+- `printAudit` now includes a `checkedWithWeakEvidence` count in the default text summary (previously visible only via `--json`).
+
+### Fixed
+- **Bug 1 — File-reference validator now strips `:line[-range][:col]` suffix.** Evidence like `.github/workflows/release.yml:99-144 (Playwright install)` resolves to the file on disk instead of falsely reporting `missing referenced file(s)`. The leading path token is extracted before any trailing prose.
+- **Bug 2 — `rs:planned` tasks no longer emit `no implementation evidence found yet` warnings on every refresh.** Sync short-circuits on the parser's `planned` flag and drops any pre-existing warning line.
+- **Bug 3 — Two consecutive `update` runs on an unchanged repo now produce a byte-identical diff.** Warning reasons are sorted deterministically inside `normalizeWarningReasons`, and `shouldPreserveExistingWarning` was deleted outright so the warning line is always regenerated from the fresh validator reasons.
+- **Bug 4 — Rollups and command-verified tasks no longer pollute the `checkedWithWeakEvidence` audit bucket.** `auditValidation` skips results whose `kind` is `rollup` or `command`.
+
+### Changed
+- `shouldPreserveExistingWarning` and its call site in `src/sync/index.js` are removed. Existing warning text is now always overwritten by the fresh validator reason. The three unit tests that guarded the old preservation behavior were flipped into regression guards for the new "always overwrite" contract.
+- Unused `isLowSpecificityReason` import dropped from `src/sync/index.js`.
+
+### Verification
+- 249 / 249 tests pass.
+- Determinism: two consecutive `roadmapsmith update --dry-run` runs on this monorepo produce byte-identical output.
+- `roadmapsmith update --concise --dry-run` on this monorepo produces zero `⚠️` lines.
+
 ## v0.11.3 - 2026-07-09
 
 ### Changed

--- a/roadmap-skill/README.md
+++ b/roadmap-skill/README.md
@@ -21,6 +21,8 @@ This package owns the RoadmapSmith CLI, validator, sync engine, host setup files
 - `roadmapsmith sync`
 - `roadmapsmith sync --audit`
 - `roadmapsmith sync` as the advanced alias for `roadmapsmith update`
+- `roadmapsmith update --concise` — suppress ⚠️ warning lines in the emitted markdown
+- `roadmapsmith verify --task <id> [--run]` — execute the `rs:verified-by` command of an `rs:kind=command` task; with `--run`, flip the checkbox on exit 0
 
 ### Compatibility only
 

--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -50,10 +50,17 @@ update flags:
   --evidence <text>             Evidence to add to --task
   --audit                       Show validation audit after refresh
   --evidence-only               Add ⚠️/✅ sub-bullets, do NOT flip [ ]/[x] checkboxes
+  --concise, --no-warnings      Suppress ⚠️ warning lines in the output
   --check-drift                 Check alignment of northStar vs repo state
   --strict                      Use strict validation mode
   --dry-run                     Preview without writing
   --json                        Output in JSON format
+  --project-root <path>         Project root (default: cwd)
+
+verify flags (roadmapsmith verify --task <id>):
+  --task <id>                   Task ID to verify (must have rs:kind=command marker)
+  --run                         Actually execute rs:verified-by command; flip [x] on exit 0
+  --dry-run                     Preview only
   --project-root <path>         Project root (default: cwd)`.trim();
 
 // ─── runInit ──────────────────────────────────────────────────────────────────
@@ -118,8 +125,27 @@ function runInit(projectRoot, config, flags) {
 
 // ─── printAudit ───────────────────────────────────────────────────────────────
 
-function printAudit(audit) {
+function printAudit(audit, context) {
   console.log(`Audit summary: ${audit.checkedWithoutEvidence.length} checked-without-evidence, ${audit.readyButUnchecked.length} ready-but-unchecked.`);
+  if (Array.isArray(audit.checkedWithWeakEvidence) && audit.checkedWithWeakEvidence.length > 0) {
+    console.log(`  checkedWithWeakEvidence: ${audit.checkedWithWeakEvidence.length}`);
+  }
+  if (context && Array.isArray(context.tasks) && context.resultMap) {
+    const pending = [];
+    for (const task of context.tasks) {
+      const r = context.resultMap[task.id];
+      if (r && r.kind === 'command' && !task.checked) {
+        pending.push({ id: task.id, verifiedBy: r.verifiedBy || task.verifiedBy || null });
+      }
+    }
+    if (pending.length > 0) {
+      console.log(`Command-verified tasks pending run (${pending.length}):`);
+      for (const p of pending) {
+        const suffix = p.verifiedBy ? `   # (would run: ${p.verifiedBy})` : '';
+        console.log(`- [${p.id}] roadmapsmith verify --task ${p.id} --run${suffix}`);
+      }
+    }
+  }
   if (audit.checkedWithoutEvidence.length > 0) {
     const byCause = {};
     for (const item of audit.checkedWithoutEvidence) {
@@ -224,7 +250,8 @@ function runUpdate(projectRoot, config, flags) {
   }
   const resultMap = validateTasks(tasks, context, config, plugins);
   const evidenceOnly = isEnabled(flags['evidence-only']);
-  const { content: synced, changes } = applySync(existingContent, tasks, resultMap, { forceRefresh: true, evidenceOnly });
+  const concise = isEnabled(flags.concise) || isEnabled(flags['no-warnings']);
+  const { content: synced, changes } = applySync(existingContent, tasks, resultMap, { forceRefresh: true, evidenceOnly, concise });
 
   writeText(roadmapFile, synced, { dryRun });
   console.log(`${dryRun ? 'Would update' : 'Updated'} ${roadmapFile}${evidenceOnly ? ' (evidence-only: no checkboxes flipped)' : ''}`);
@@ -234,7 +261,7 @@ function runUpdate(projectRoot, config, flags) {
     if (useJson) {
       console.log(JSON.stringify(audit, null, 2));
     } else {
-      printAudit(audit);
+      printAudit(audit, { tasks, resultMap });
     }
     if (audit.checkedWithoutEvidence.length > 0 || audit.readyButUnchecked.length > 0) {
       process.exitCode = 2;
@@ -265,7 +292,88 @@ function runMaintain(projectRoot, config, flags) {
   }
 
   const audit = auditValidation(tasks, resultMap, changes);
-  printAudit(audit);
+  printAudit(audit, { tasks, resultMap });
+}
+
+// ─── runVerify ────────────────────────────────────────────────────────────────
+
+function runVerify(projectRoot, config, flags) {
+  const dryRun = isEnabled(flags['dry-run']);
+  const shouldRun = isEnabled(flags.run);
+  const useJson = isEnabled(flags.json);
+  const roadmapFile = resolveRoadmapFile(projectRoot, config, flags['roadmap-file']);
+  const targetId = flags.task ? String(flags.task) : null;
+
+  if (!targetId) {
+    console.error('verify requires --task <id>');
+    process.exitCode = 1;
+    return;
+  }
+
+  const existingContent = readTextIfExists(roadmapFile) || '';
+  const parsed = parseRoadmap(existingContent);
+  const target = parsed.tasks.find((t) => t.markerId === targetId || t.id === targetId);
+  if (!target) {
+    console.error(`Task not found: ${targetId}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (target.kind !== 'command') {
+    console.error(`Task ${targetId} is not rs:kind=command (kind=${target.kind || 'none'})`);
+    process.exitCode = 1;
+    return;
+  }
+  const cmd = target.verifiedBy || null;
+  if (!cmd) {
+    console.error(`Task ${targetId} has no rs:verified-by command`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!shouldRun) {
+    console.log(`Would run: ${cmd}`);
+    console.log(`(pass --run to execute and flip the checkbox on exit 0)`);
+    return;
+  }
+
+  const { spawnSync } = require('child_process');
+  const isWin = process.platform === 'win32';
+  const spawned = spawnSync(cmd, {
+    cwd: projectRoot,
+    shell: isWin ? true : '/bin/sh',
+    encoding: 'utf8',
+    timeout: 5 * 60 * 1000
+  });
+
+  const passed = spawned.status === 0 && !spawned.error;
+  const summary = {
+    task: targetId,
+    command: cmd,
+    exit: spawned.status,
+    signal: spawned.signal || null,
+    passed
+  };
+
+  if (useJson) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    if (spawned.stdout) process.stdout.write(spawned.stdout);
+    if (spawned.stderr) process.stderr.write(spawned.stderr);
+    console.log(`verify ${targetId}: exit=${spawned.status}${spawned.signal ? ` signal=${spawned.signal}` : ''} → ${passed ? 'PASS' : 'FAIL'}`);
+  }
+
+  if (!passed) {
+    process.exitCode = 2;
+    return;
+  }
+
+  // Flip [x] on the target task line in place.
+  const lines = existingContent.split('\n');
+  if (target.lineIndex != null && target.lineIndex >= 0 && target.lineIndex < lines.length) {
+    lines[target.lineIndex] = lines[target.lineIndex].replace(/- \[( |x|X)\]/, '- [x]');
+  }
+  writeText(roadmapFile, lines.join('\n'), { dryRun });
+  console.log(`${dryRun ? 'Would mark' : 'Marked'} [${targetId}] as complete in ${roadmapFile}`);
 }
 
 // ─── runDoctor ────────────────────────────────────────────────────────────────
@@ -368,6 +476,8 @@ function main() {
     runDoctor(projectRoot, config, flags);
   } else if (cmd === 'generate') {
     runGenerate(projectRoot, config, flags);
+  } else if (cmd === 'verify') {
+    runVerify(projectRoot, config, flags);
   } else if (cmd === '/roadmap-sync') {
     runLegacySlashSync(projectRoot, config, flags, args);
   } else {

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.11.3",
+      "version": "0.12.0",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "main": "src/index.js",
   "bin": {

--- a/roadmap-skill/src/sync/index.js
+++ b/roadmap-skill/src/sync/index.js
@@ -2,7 +2,6 @@
 
 const { parseRoadmap } = require('../parser');
 const { ensureTrailingNewline } = require('../utils');
-const { isLowSpecificityReason } = require('../reasons');
 
 const ATTEMPTED_WARNING_REASON_PREFIX = 'attempted but validation failed:';
 const NO_EVIDENCE_WARNING_REASON_PREFIX = 'no implementation evidence found yet:';
@@ -125,17 +124,9 @@ function normalizeWarningReasons(reasons) {
       normalized.push(clean);
     }
   }
+  // Sort so back-to-back runs on unchanged repo state produce byte-identical warnings.
+  normalized.sort((left, right) => left.localeCompare(right));
   return normalized;
-}
-
-function shouldPreserveExistingWarning(existingReason, newReason, options) {
-  if (options && options.forceRefresh) return false;
-  const cleanExisting = normalizeWarningReason(existingReason);
-  const cleanNew = normalizeWarningReason(newReason) || 'validation failed';
-  // Preserve when the freshly computed reason is a low-specificity policy message (no
-  // file- or symbol-specific information) and the existing annotation carries more
-  // diagnostic value (is not itself a low-specificity message).
-  return isLowSpecificityReason(cleanNew) && Boolean(cleanExisting) && !isLowSpecificityReason(cleanExisting);
 }
 
 function formatVerificationRecipe(indent, recipe) {
@@ -195,6 +186,17 @@ function applySync(content, parsedTasks, results, options) {
     const hasWarning = task.warningLineIndex != null;
     const warningIndex = hasWarning ? task.warningLineIndex + offset : null;
     const lastChildLineIndex = (task.lastChildLineIndex != null ? task.lastChildLineIndex : task.lineIndex) + offset;
+    const concise = !!(options && options.concise);
+
+    // rs:planned or --concise: no warning line ever, and drop any pre-existing warning.
+    if (result.planned || concise) {
+      if (warningIndex != null && warningIndex >= 0 && warningIndex < lines.length) {
+        lines.splice(warningIndex, 1);
+        offset -= 1;
+        changes.warningsRemoved.push(task.id);
+      }
+      continue;
+    }
 
     if (result.passed) {
       if (warningIndex != null && warningIndex >= 0 && warningIndex < lines.length) {
@@ -245,11 +247,8 @@ function applySync(content, parsedTasks, results, options) {
         }
       }
     } else if (warningIndex != null && warningIndex >= 0 && warningIndex < lines.length) {
-      const existingReason = normalizeWarningReason(lines[warningIndex]);
-      const newReason = reason || 'validation failed';
-      if (!shouldPreserveExistingWarning(existingReason, newReason, options)) {
-        lines[warningIndex] = warningText;
-      }
+      // Always regenerate from the fresh validator reasons — no preservation of prior text.
+      lines[warningIndex] = warningText;
     } else {
       lines.splice(lastChildLineIndex + 1, 0, warningText);
       offset += 1;

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -1886,6 +1886,27 @@ function validateTask(task, context, config, plugins) {
     };
   }
 
+  // rs:kind=rollup — milestone/aggregator tasks; children carry the evidence.
+  if (task.kind === 'rollup') {
+    return {
+      taskId, passed: true, kind: 'rollup', confidence: 'medium', reasons: [], diagnostics: [],
+      evidence: { code: false, test: false, artifact: false, files: [], codeFiles: [], testFiles: [], symbols: [], structuralEvidence: null },
+      attempted: false, preservedCheckedState: true, requiresTest: false,
+      staleEvidenceDetected: false, staleEvidenceResolved: false, discoveredEvidence: null, verificationRecipe: null, generatedTestEvidence: null
+    };
+  }
+
+  // rs:kind=command — command-verified; roadmapsmith verify --task <id> --run executes it.
+  if (task.kind === 'command') {
+    return {
+      taskId, passed: true, kind: 'command', verifiedBy: task.verifiedBy || null,
+      confidence: 'medium', reasons: [], diagnostics: [],
+      evidence: { code: false, test: false, artifact: false, files: [], codeFiles: [], testFiles: [], symbols: [], structuralEvidence: null },
+      attempted: false, preservedCheckedState: true, requiresTest: false,
+      staleEvidenceDetected: false, staleEvidenceResolved: false, discoveredEvidence: null, verificationRecipe: null, generatedTestEvidence: null
+    };
+  }
+
   // Human-attested bypass: `rs:evidence=manual` (delete/cleanup done = absence, or any manually-verified completion)
   // or strikethrough `~~text~~` in body (N/A / declined scope). Trust the checked state; don't hunt for evidence.
   if (task.declined || task.evidenceMode === 'manual') {
@@ -1936,11 +1957,15 @@ function validateTask(task, context, config, plugins) {
   for (const eLine of evidenceLines) {
     if (!eLine || !eLine.text) continue;
     for (const eText of eLine.text.split(',').map((s) => s.trim()).filter(Boolean)) {
-      const eFound = findFilesByPathHints([eText], pathHintResolver);
+      // Take the leading path token (up to first space/paren), then strip trailing :line[-range][:col].
+      // Handles IDE-style refs like `.github/workflows/x.yml:99-144 (Playwright install)`.
+      const eTextHead = eText.split(/[\s(]/)[0];
+      const eTextClean = eTextHead.replace(/:\d+(?:-\d+)?(?::\d+)?$/, '');
+      const eFound = findFilesByPathHints([eTextClean], pathHintResolver);
       if (eFound.length > 0) {
         evidenceLinePass = true;
-      } else if (eText.includes('/') || /\.\w+$/.test(eText)) {
-        reasons.push('missing referenced file(s): ' + eText + ' → if this is a monorepo, add pathAliases in roadmap-skill.config.json');
+      } else if (eTextClean.includes('/') || /\.\w+$/.test(eTextClean)) {
+        reasons.push('missing referenced file(s): ' + eTextClean + ' → if this is a monorepo, add pathAliases in roadmap-skill.config.json');
       }
     }
   }
@@ -1949,10 +1974,12 @@ function validateTask(task, context, config, plugins) {
   const pass1Files = findFilesByPathHints(purePathHints, pathHintResolver);
   const pass1Found = pass1Files.length > 0;
 
-  // Missing referenced file check (for text-based path hints)
-  const allResolvedPaths = findFilesByPathHints(pathHints, pathHintResolver);
-  if (pathHints.length > 0 && allResolvedPaths.length === 0) {
-    const internalHints = pathHints.filter((h) => !(externalPaths || []).includes(h));
+  // Missing referenced file check (for text-based path hints).
+  // Strip trailing :line[-range][:col] before resolution — file existence checks must not fail on IDE-style refs.
+  const cleanedPathHints = pathHints.map((h) => String(h || '').replace(/:\d+(?:-\d+)?(?::\d+)?$/, ''));
+  const allResolvedPaths = findFilesByPathHints(cleanedPathHints, pathHintResolver);
+  if (cleanedPathHints.length > 0 && allResolvedPaths.length === 0) {
+    const internalHints = cleanedPathHints.filter((h) => !(externalPaths || []).includes(h));
     if (internalHints.length > 0) {
       reasons.push('missing referenced file(s): ' + internalHints.join(', ') + ' → if this is a monorepo, add pathAliases in roadmap-skill.config.json');
     }
@@ -2140,7 +2167,7 @@ function auditValidation(tasks, results, changes) {
       readyButUnchecked.push({ task, result });
     }
 
-    if (task.checked && result.passed && result.confidence === 'low') {
+    if (task.checked && result.passed && result.confidence === 'low' && result.kind !== 'rollup' && result.kind !== 'command') {
       checkedWithWeakEvidence.push({ task, result });
     }
 

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -150,3 +150,97 @@ test('update --task with unknown id exits 1', () => {
   const result = runResult(['update', '--task', 'nonexistent', '--evidence', 'x', '--project-root', dir], dir);
   assert.equal(result.status, 1);
 });
+
+// ─── --concise / --no-warnings ────────────────────────────────────────────────
+
+test('update --concise strips ⚠️ lines from output', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '# Roadmap',
+    '',
+    '- [ ] Do the thing <!-- rs:task=do-thing -->',
+    '  - Evidence: src/nonexistent.ts',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'test' }));
+  run(['update', '--concise', '--project-root', dir], dir);
+  const content = fs.readFileSync(path.join(dir, 'ROADMAP.md'), 'utf8');
+  assert.doesNotMatch(content, /⚠️/);
+});
+
+// ─── verify ───────────────────────────────────────────────────────────────────
+
+test('verify without --task exits 1', () => {
+  const dir = tmpdir();
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), '');
+  const result = runResult(['verify', '--project-root', dir], dir);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--task/);
+});
+
+test('verify --task without --run prints "Would run"', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '# Roadmap',
+    '',
+    '- [ ] TSC clean <!-- rs:task=tsc-clean rs:kind=command rs:verified-by=echo-hi -->',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  const out = run(['verify', '--task', 'tsc-clean', '--project-root', dir], dir);
+  assert.match(out, /Would run: echo-hi/);
+});
+
+test('verify --task on non-command task exits 1', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '# Roadmap',
+    '',
+    '- [ ] Regular task <!-- rs:task=regular -->',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  const result = runResult(['verify', '--task', 'regular', '--project-root', dir], dir);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /not rs:kind=command/);
+});
+
+test('verify --task --run flips checkbox on exit-0 command', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '# Roadmap',
+    '',
+    '- [ ] Trivial pass <!-- rs:task=trivial-pass rs:kind=command rs:verified-by=hostname -->',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  run(['verify', '--task', 'trivial-pass', '--run', '--project-root', dir], dir);
+  const content = fs.readFileSync(path.join(dir, 'ROADMAP.md'), 'utf8');
+  assert.match(content, /- \[x\] Trivial pass/);
+});
+
+test('verify --task --run on failing command exits 2 and leaves checkbox', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '# Roadmap',
+    '',
+    '- [ ] Fails <!-- rs:task=fails rs:kind=command rs:verified-by=zzz-not-a-real-cmd-x9k -->',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  const result = runResult(['verify', '--task', 'fails', '--run', '--project-root', dir], dir);
+  assert.equal(result.status, 2);
+  const content = fs.readFileSync(path.join(dir, 'ROADMAP.md'), 'utf8');
+  assert.match(content, /- \[ \] Fails/);
+});

--- a/roadmap-skill/test/sync.test.js
+++ b/roadmap-skill/test/sync.test.js
@@ -17,6 +17,66 @@ function setupFixture(name) {
   return target;
 }
 
+test('sync emits no warning line for rs:planned tasks', () => {
+  const projectRoot = setupFixture('node');
+  const config = loadConfig({ projectRoot });
+  const content = [
+    '## Phase P2',
+    '- [ ] Ship feature X <!-- rs:task=ship-x rs:planned -->',
+    ''
+  ].join('\n');
+  const parsed = parseRoadmap(content);
+  const context = buildValidationContext(projectRoot, config, []);
+  const results = validateTasks(parsed.tasks, context, config, []);
+  const { content: first } = applySync(content, parsed.tasks, results, { forceRefresh: true });
+
+  assert.doesNotMatch(first, /⚠️/);
+  assert.doesNotMatch(first, /no implementation evidence found/);
+  assert.match(first, /- \[ \] Ship feature X/);
+
+  const secondParsed = parseRoadmap(first);
+  const secondResults = validateTasks(secondParsed.tasks, context, config, []);
+  const { content: second } = applySync(first, secondParsed.tasks, secondResults, { forceRefresh: true });
+  assert.equal(second, first);
+});
+
+test('sync produces byte-identical output on consecutive runs (Bug 3 determinism)', () => {
+  const projectRoot = setupFixture('node');
+  const config = loadConfig({ projectRoot });
+  const content = [
+    '## Phase P1',
+    '- [ ] Ship the widget <!-- rs:task=ship-widget -->',
+    '  - Evidence: src/nonexistent-a.ts, src/nonexistent-b.ts',
+    ''
+  ].join('\n');
+  const parsed = parseRoadmap(content);
+  const context = buildValidationContext(projectRoot, config, []);
+  const results = validateTasks(parsed.tasks, context, config, []);
+  const { content: first } = applySync(content, parsed.tasks, results, { forceRefresh: true });
+
+  const secondParsed = parseRoadmap(first);
+  const secondResults = validateTasks(secondParsed.tasks, context, config, []);
+  const { content: second } = applySync(first, secondParsed.tasks, secondResults, { forceRefresh: true });
+
+  assert.equal(second, first);
+});
+
+test('sync --concise suppresses ⚠️ warning lines', () => {
+  const projectRoot = setupFixture('node');
+  const config = loadConfig({ projectRoot });
+  const content = [
+    '## Phase P1',
+    '- [ ] Do the thing <!-- rs:task=do-thing -->',
+    '  - Evidence: src/nonexistent.ts',
+    ''
+  ].join('\n');
+  const parsed = parseRoadmap(content);
+  const context = buildValidationContext(projectRoot, config, []);
+  const results = validateTasks(parsed.tasks, context, config, []);
+  const { content: out } = applySync(content, parsed.tasks, results, { forceRefresh: true, concise: true });
+  assert.doesNotMatch(out, /⚠️/);
+});
+
 test('sync marks task complete when validation passes', () => {
   const projectRoot = setupFixture('node');
   const config = loadConfig({ projectRoot });
@@ -304,7 +364,7 @@ test('sync preserves checked task when minimumConfidence is medium and state was
   assert.match(next, /- \[x\] Foundation baseline complete milestone/);
 });
 
-test('applySync preserves more specific existing warning over generic new message', () => {
+test('applySync always overwrites existing warning with fresh validator reason (no preservation)', () => {
   const content = [
     '- [ ] Fix timeout in fetch handler <!-- rs:task=fix-timeout -->',
     '  - ⚠️ attempted but validation failed: missing referenced file(s): src/pos/page.tsx, missing test evidence'
@@ -321,11 +381,8 @@ test('applySync preserves more specific existing warning over generic new messag
 
   const { content: next } = applySync(content, parsed.tasks, results);
 
-  assert.match(
-    next,
-    /missing referenced file\(s\): src\/pos\/page\.tsx/,
-    'specific existing warning must be preserved when new message is more generic'
-  );
+  assert.doesNotMatch(next, /missing referenced file\(s\): src\/pos\/page\.tsx/, 'old specific warning must be overwritten');
+  assert.match(next, /validation failed/, 'fresh reason must replace the old warning');
 });
 
 test('applySync deduplicates warning reasons from a prior /api route sync run', () => {
@@ -395,9 +452,7 @@ test('sync generates and replaces a single verification recipe for pending behav
   assert.equal((second.match(/Verification recipe:/g) || []).length, 1);
 });
 
-test('applySync preserves specific existing warning when new reason is generic policy message (Gap 1a)', () => {
-  // 'implementation task requires deterministic Verify metadata...' is a low-specificity
-  // policy message; it must not clobber a more informative existing annotation.
+test('applySync overwrites existing specific warning with generic policy reason (no preservation)', () => {
   const specific = 'no content match in src/lib/stock.ts: expected getLowStockProducts';
   const content = [
     '- [ ] Add getLowStockProducts helper <!-- rs:task=low-stock -->',
@@ -414,11 +469,11 @@ test('applySync preserves specific existing warning when new reason is generic p
 
   const { content: next } = applySync(content, parsed.tasks, results);
 
-  assert.match(next, /no content match in src\/lib\/stock\.ts/, 'specific existing message must survive generic policy overwrite');
-  assert.doesNotMatch(next, /deterministic Verify metadata/);
+  assert.doesNotMatch(next, /no content match in src\/lib\/stock\.ts/, 'old specific message must be overwritten');
+  assert.match(next, /deterministic Verify metadata/, 'fresh reason must appear');
 });
 
-test('applySync preserves external prose when new reason is generic policy message (Gap 1b)', () => {
+test('applySync overwrites external prose annotation with fresh validator reason (no preservation)', () => {
   const prose = 'getLowStockProducts() in src/lib/stock.ts exists but no in-app notification delivery';
   const content = [
     '- [ ] Wire notification delivery <!-- rs:task=notify-delivery -->',
@@ -435,8 +490,8 @@ test('applySync preserves external prose when new reason is generic policy messa
 
   const { content: next } = applySync(content, parsed.tasks, results);
 
-  assert.match(next, /no in-app notification delivery/, 'external prose must survive generic policy overwrite');
-  assert.doesNotMatch(next, /high-confidence evidence/);
+  assert.doesNotMatch(next, /no in-app notification delivery/, 'external prose must be overwritten');
+  assert.match(next, /high-confidence evidence/, 'fresh reason must appear');
 });
 
 test('applySync with forceRefresh replaces external prose annotation (Gap 2 escape hatch)', () => {

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -59,6 +59,65 @@ test('backticked HTTP routes, MIME types, and formulas do not become referenced 
   }
 });
 
+test('evidence with :line-range suffix resolves to the file on disk', () => {
+  const projectRoot = setupFixture('generic');
+  fs.mkdirSync(path.join(projectRoot, '.github', 'workflows'), { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, '.github', 'workflows', 'release.yml'), 'name: release\n', 'utf8');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask({
+    id: 'ci-release',
+    text: 'Wire Playwright smoke into release workflow',
+    checked: true,
+    evidenceLines: [{ text: '.github/workflows/release.yml:99-144 (Playwright install + smoke run)' }]
+  }, context, config, []);
+
+  assert.ok(
+    !result.reasons.some((r) => /missing referenced file/.test(String(r))),
+    `line-range suffix must be stripped before existence check, got: ${result.reasons.join('; ')}`
+  );
+});
+
+test('rs:kind=rollup tasks pass with no evidence hunt', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const result = validateTask({
+    id: 'milestone-x',
+    text: 'Ship v0.2 milestone',
+    checked: true,
+    kind: 'rollup'
+  }, context, config, []);
+
+  assert.equal(result.passed, true);
+  assert.equal(result.kind, 'rollup');
+  assert.deepEqual(result.reasons, []);
+});
+
+test('rs:kind=command tasks pass on marker; audit surfaces verifiedBy', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+
+  const tasks = [{
+    id: 'tsc-clean',
+    text: 'TypeScript compila sin errores',
+    checked: false,
+    kind: 'command',
+    verifiedBy: 'tsc -p tsconfig.json --noEmit'
+  }];
+  const results = validateTasks(tasks, context, config, []);
+  const r = results['tsc-clean'];
+  assert.equal(r.passed, true);
+  assert.equal(r.kind, 'command');
+  assert.equal(r.verifiedBy, 'tsc -p tsconfig.json --noEmit');
+
+  const audit = auditValidation(tasks, results, { newlyUnchecked: [] });
+  assert.equal(audit.checkedWithWeakEvidence.length, 0);
+});
+
 test('backticked HTTP request spans are not rescanned as standalone route hints', () => {
   const projectRoot = setupFixture('generic');
   const config = loadConfig({ projectRoot });

--- a/skills.json
+++ b/skills.json
@@ -26,13 +26,13 @@
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Initialize ROADMAP.md, AGENTS.md, and host integration files for a project.",
-      "version": "0.11.3"
+      "version": "0.12.0"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Refresh ROADMAP.md with evidence-backed validation, add tasks, or record evidence.",
-      "version": "0.11.3"
+      "version": "0.12.0"
     }
   ]
 }

--- a/skills/roadmap-update/SKILL.md
+++ b/skills/roadmap-update/SKILL.md
@@ -50,11 +50,36 @@ Available update flags:
 - `--evidence <text>` — evidence to attach to `--task`
 - `--audit` — show validation audit after refresh (grouped by cause: `path-mismatch`, `no-evidence`, `deletion-task`, `namespace-gate`, `strict-mode`)
 - `--evidence-only` — write ⚠️/✅ sub-bullets but never flip `[ ]`/`[x]` (safe review pass)
+- `--concise` / `--no-warnings` — suppress ⚠️ warning lines in the emitted markdown (safe for READMEs / PR embeds)
 - `--check-drift` — compare northStar to repo state
 - `--strict` — strict validation mode (preservedCheckedState does not count as pass)
 - `--dry-run` — preview without writing
 - `--json` — output in JSON format
 - `--project-root <path>` — project root (default: cwd)
+
+## Task marker attributes
+
+Tasks use a stable-id comment: `<!-- rs:task=slug -->`. The same comment can carry extra attributes that change how the validator treats the task:
+
+- `rs:planned` — "intentionally not implemented yet". Validator skips evidence hunt. Sync emits **no** ⚠️ warning and does not flip the checkbox. Use for future scope you want on the roadmap without polluting every refresh with warnings. Example: `- [ ] Ship v0.2 feature X <!-- rs:task=ship-x rs:planned -->`.
+- `rs:kind=rollup` — "milestone/aggregator; children carry the evidence". Passes validation without a file-existence hunt. Use for phase exits, milestone rollups, "Finalize module implementation" style parent tasks. Example: `- [x] Milestone v0.2 shipped <!-- rs:task=milestone-v0-2 rs:kind=rollup -->`.
+- `rs:kind=command` + `rs:verified-by=<command>` — "evidence = a command exits 0". Passes validation on the marker alone during `update` (no shell execution). To actually run the command and flip the checkbox, use `roadmapsmith verify --task <id> --run`. Example: `- [ ] TypeScript compila sin errores <!-- rs:task=tsc-clean rs:kind=command rs:verified-by=tsc-noemit -->`. Note: `rs:verified-by` captures a single non-whitespace token — use a script path or an npm-script name if the command needs arguments.
+- `rs:evidence=manual` — human-attested completion. Trust the checked state, no evidence hunt.
+- `rs:no-test` — the task legitimately has no test.
+
+## Command-verified tasks (`verify`)
+
+For tasks marked `rs:kind=command`, `roadmapsmith update --audit` prints a **"Command-verified tasks pending run"** block listing the exact ready-to-run invocation for each unchecked command task:
+
+```
+Command-verified tasks pending run (2):
+- [tsc-clean] roadmapsmith verify --task tsc-clean --run   # (would run: tsc-noemit)
+- [test-suite] roadmapsmith verify --task test-suite --run # (would run: npm-test)
+```
+
+When you (agent) see that block, invoke each `verify --task <id> --run` yourself — the human user should not have to type them. `verify --run` executes the `rs:verified-by` command in the repo root, prints stdout/stderr, and flips `[x]` on exit 0. Non-zero exit leaves the checkbox unchecked and CLI exits with code 2.
+
+`verify --task <id>` without `--run` is a dry-preview that just prints `Would run: <command>`.
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary

- **New**: `rs:kind=rollup`, `rs:kind=command` + `rs:verified-by=<cmd>` marker attributes.
- **New**: `roadmapsmith verify --task <id> [--run]` subcommand that executes the `rs:verified-by` command and flips `[x]` on exit 0.
- **New**: `roadmapsmith update --concise` / `--no-warnings` — suppress `⚠️` lines in the emitted markdown.
- **New**: `printAudit` surfaces a "Command-verified tasks pending run" section so an AI agent picks up `verify --run` on the user's behalf, and now includes `checkedWithWeakEvidence` count in the default text summary.
- **Fixed**: Bug 1 — validator strips `:line[-range][:col]` before file-existence check (evidence like `.github/workflows/x.yml:99-144 (...)` now resolves correctly).
- **Fixed**: Bug 2 — `rs:planned` tasks emit no warning; sync drops any pre-existing warning line for planned tasks.
- **Fixed**: Bug 3 — two consecutive `update --dry-run` runs on an unchanged repo produce byte-identical output. `normalizeWarningReasons` sorts alphabetically; `shouldPreserveExistingWarning` deleted outright.
- **Fixed**: Bug 4 — `kind=rollup` / `kind=command` results skip the `checkedWithWeakEvidence` audit bucket.

## Test plan

- [x] 249 / 249 unit tests pass locally.
- [x] Determinism check: `roadmapsmith update --project-root . --dry-run` twice against this monorepo → byte-identical output (`diff` returns empty).
- [x] `roadmapsmith update --concise --dry-run` produces zero `⚠️` lines.
- [x] `verify --task <id>` without `--run` prints `Would run: <cmd>` (dry preview).
- [x] `verify --task <id> --run` on exit-0 command flips checkbox; on failing command exits 2 and leaves checkbox unchecked.

## Release notes

See CHANGELOG.md → v0.12.0 section for the full list.

The commit subject `chore(release): v0.12.0` will trigger the CI **repair mode** on merge: tag `v0.12.0`, push tag, `npm publish --access public`, and GitHub release creation.