### PR TITLE
chore(release): v0.12.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,4 +136,4 @@ jobs:
       - name: Merge automated release PR
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-        run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash --delete-branch

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - None yet.
 
+## v0.12.2 - 2026-07-13
+
+### Changed
+- (deps) bump hashgraph-online/ai-plugin-scanner-action (#84)
+
 ## v0.12.1 - 2026-07-13
 
 ### Added

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "main": "src/index.js",
   "bin": {

--- a/skills.json
+++ b/skills.json
@@ -26,13 +26,13 @@
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Initialize ROADMAP.md, AGENTS.md, and host integration files for a project.",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Refresh ROADMAP.md with evidence-backed validation, add tasks, or record evidence.",
-      "version": "0.12.1"
+      "version": "0.12.2"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- automated release PR for v0.12.2
- bumps package metadata and resets the changelog through the protected-branch path
- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode

## Notes
## v0.12.2 - 2026-07-13

### Changed
- (deps) bump hashgraph-online/ai-plugin-scanner-action (#84)