### PR TITLE
fix(parser): accept hand-authored ✅ evidence and standalone rs: markers

### DIFF
--- a/roadmap-skill/src/parser/index.js
+++ b/roadmap-skill/src/parser/index.js
@@ -60,6 +60,11 @@ function parseTaskLine(line) {
       markerId = markerParts[0] || null;
       markerFlags = markerParts.slice(1).join(' ');
       text = text.slice(0, markerStart).trimEnd();
+    } else if (markerBody.startsWith('rs:')) {
+      // Standalone rs: flags (e.g. `<!-- rs:kind=rollup -->`) without rs:task=; let downstream
+      // deprecated-marker checks + kind extraction run on markerFlags instead of silently ignoring.
+      markerFlags = markerBody;
+      text = text.slice(0, markerStart).trimEnd();
     }
   }
 
@@ -84,9 +89,11 @@ function parseChildBulletLine(line) {
 }
 
 function parseEvidenceLine(content) {
-  if (content.length < 9) return null;
-  if (content.slice(0, 9).toLowerCase() !== 'evidence:') return null;
-  return content.slice(9).trim();
+  // ponytail: sync/index.js emits `- ✅ evidence: <path>`; tolerate that shape when hand-authored.
+  const normalized = content.replace(/^✅\s*/, '');
+  if (normalized.length < 9) return null;
+  if (normalized.slice(0, 9).toLowerCase() !== 'evidence:') return null;
+  return normalized.slice(9).trim();
 }
 
 function parsePrefixedChildLine(content, prefix) {

--- a/roadmap-skill/test/parser.test.js
+++ b/roadmap-skill/test/parser.test.js
@@ -174,3 +174,30 @@ test('parseRoadmap does not emit parseWarnings when explicit IDs are unique', ()
   const parsed = parseRoadmap(content);
   assert.deepEqual(parsed.parseWarnings, []);
 });
+
+test('parseRoadmap accepts ✅ evidence: sub-bullets (matches sync emit format)', () => {
+  const content = [
+    '- [x] Ship thermal printer <!-- rs:task=thermal-printer -->',
+    '  - ✅ evidence: src/lib/thermal-printer.ts',
+    ''
+  ].join('\n');
+
+  const task = parseRoadmap(content).tasks[0];
+  assert.equal(task.evidenceLines.length, 1);
+  assert.equal(task.evidenceLines[0].text, 'src/lib/thermal-printer.ts');
+});
+
+test('parseRoadmap accepts standalone rs:kind=rollup marker without rs:task=', () => {
+  const content = '- [x] Milestone shipped <!-- rs:kind=rollup -->';
+  const task = parseRoadmap(content).tasks[0];
+  assert.equal(task.kind, 'rollup');
+  assert.equal(task.text, 'Milestone shipped');
+  assert.equal(task.markerId, null);
+});
+
+test('parseRoadmap throws deprecated marker error even without rs:task= prefix', () => {
+  assert.throws(
+    () => parseRoadmap('- [ ] Legacy <!-- rs:no-test -->'),
+    /rs:no-test.*migrate-markers/s
+  );
+});


### PR DESCRIPTION
## Summary

Two silent-rejection bugs in the roadmap parser, reported against v0.13.0:

1. **`- ✅ evidence: <path>` sub-bullets are silently ignored.** `sync/index.js` emits this exact shape when auto-adding evidence, so users reasonably copy it when hand-authoring. The parser required the content to start literally with `evidence:` (offset 0), so the leading `✅ ` prefix caused a silent no-op — audit kept flagging the task as weak-evidence, zero diagnostics.
2. **`<!-- rs:kind=rollup -->` alone is silently ignored.** Parser only extracted marker flags when the comment body started with `rs:task=`. Standalone `rs:kind=rollup` (or any `rs:` flag) was left in the task text and never reached the validator's kind check. The docs and audit hint reference `rs:kind=rollup` in isolation, so the shape looks legal.

## Changes

- `src/parser/index.js`
  - `parseEvidenceLine`: strip a leading `✅` before checking for `evidence:` — narrow tolerance, matches exactly the shape `sync/index.js` emits.
  - `parseTaskLine`: accept marker bodies that begin with any `rs:` flag (not only `rs:task=`); populate `markerFlags` with `markerId=null`, letting downstream kind extraction + deprecated-marker checks run.
- `test/parser.test.js`: three new tests covering both fixes plus the desirable side effect (standalone `rs:no-test` now correctly throws the migrate error instead of being silently kept in text).

## Test plan

- [x] `node --test test/parser.test.js` — 15/15 (12 existing + 3 new)
- [x] `npm test` — 280/280
- [x] `npm run validate:pre-push` — all gates PASS
- [x] End-to-end repro of both bug shapes returns expected values (`kind=rollup`, `evidenceLines.length=1`)

## Non-goals (kept out to keep the diff small)

- Docs update in `skills/roadmap-update/SKILL.md` — the emitted `- ✅ evidence:` shape is now roundtrip-safe, so the existing doc line is accurate.
- Malformed-marker diagnostic pass (user's meta-suggestion) — deferred until a third class of silent-rejection surfaces.