### PR TITLE
chore(release): v0.13.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- None yet.
+
+## v0.13.2 - 2026-07-14
+
+Parser tolerance patch. Two silent-rejection bugs surfaced while hand-editing `ROADMAP.md` to strengthen weak-evidence tasks.
+
+### Fixed
+
+- **`- ✅ evidence: <path>` sub-bullets are now parsed as evidence.** `sync/index.js` emits this exact shape when auto-adding evidence, so users reasonably copy it when hand-authoring. Previously `parseEvidenceLine` required the content to start literally with `evidence:` (offset 0), so the leading `✅ ` prefix caused a silent no-op — audit kept flagging the task as weak-evidence, zero diagnostics fired. `parseEvidenceLine` now strips the leading `✅` before the prefix test, making the emitted format roundtrip-safe when hand-authored.
+- **Standalone `<!-- rs:kind=rollup -->` markers (and any `rs:` flag without `rs:task=`) are now honored.** `parseTaskLine` only extracted marker flags when the comment body began with `rs:task=`, so `<!-- rs:kind=rollup -->` alone was left inside the task text and never reached the validator's kind check. The docs and audit hint reference `rs:kind=rollup` in isolation, so the shape looked legal. Standalone `rs:` markers now populate `markerFlags` with `markerId=null`, letting downstream kind extraction and deprecated-marker checks run as intended. As a side effect, standalone `<!-- rs:no-test -->` now correctly throws the `migrate-markers` error instead of being silently dropped into the task text.
+
+### Migration
+
+None required. Both changes are additive parser tolerance; no existing marker shape changes behavior.
+
 ## v0.13.1 - 2026-07-14
 
 Security + honesty patch. Two critical audit findings from the v0.13.0 review are addressed.

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.12.2",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.12.2",
+      "version": "0.13.2",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "main": "src/index.js",
   "bin": {

--- a/skills.json
+++ b/skills.json
@@ -26,13 +26,13 @@
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Initialize ROADMAP.md, AGENTS.md, and host integration files for a project.",
-      "version": "0.13.1"
+      "version": "0.13.2"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Refresh ROADMAP.md with evidence-backed validation, add tasks, or record evidence.",
-      "version": "0.13.1"
+      "version": "0.13.2"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Automated release PR for v0.13.2 (patch). Ships the parser-tolerance fixes from #89.

- Bumps `roadmap-skill/package.json` + `package-lock.json` + all plugin manifests + `skills.json` to 0.13.2.
- Restores the `## Unreleased` invariant in `CHANGELOG.md` (was dropped during v0.13.1's hand-crafted release).
- Adds the v0.13.2 CHANGELOG entry: two silent-rejection fixes in `parseEvidenceLine` (leading `✅`) and `parseTaskLine` (standalone `rs:` markers).

## Notes

Merge triggers auto-release repair mode: `npm publish --access public` + `gh release create v0.13.2`.