### PR TITLE
fix(release): auto-restore missing Unreleased section in CHANGELOG

### DIFF
--- a/roadmap-skill/scripts/generate-changelog.js
+++ b/roadmap-skill/scripts/generate-changelog.js
@@ -125,9 +125,13 @@ function updateChangelogContent(existingContent, options = {}) {
   } = options;
 
   const normalized = normalizeNewlines(existingContent);
-  const unreleasedRange = findSectionRange(normalized, 'Unreleased');
+  let unreleasedRange = findSectionRange(normalized, 'Unreleased');
   if (!unreleasedRange) {
-    throw new Error('CHANGELOG.md must contain a "## Unreleased" section.');
+    // ponytail: auto-restore the missing Unreleased stub instead of throwing.
+    // Hand-crafted release commits sometimes drop it; synthesize a zero-width range at the topmost `## ` heading.
+    const firstRelease = /^## /m.exec(normalized);
+    const insertAt = firstRelease ? firstRelease.index : normalized.length;
+    unreleasedRange = { start: insertAt, end: insertAt };
   }
 
   const releaseSection = buildReleaseSection({ version, date, subjects });

--- a/roadmap-skill/test/release-automation.test.js
+++ b/roadmap-skill/test/release-automation.test.js
@@ -191,6 +191,33 @@ test('buildReleaseSection groups commits and falls back to Changed while excludi
   assert.doesNotMatch(section, /chore\(release\)/);
 });
 
+test('updateChangelog auto-restores a missing Unreleased stub instead of throwing', () => {
+  // Simulates the state left behind by a hand-crafted release commit that dropped the
+  // Unreleased section (as happened during v0.13.1 -> v0.13.2).
+  const content = [
+    '# Changelog',
+    '',
+    '## v1.2.3 - 2026-06-17',
+    '',
+    '### Changed',
+    '- Previous release.',
+    ''
+  ].join('\n');
+
+  const updated = updateChangelog({
+    version: '1.2.4',
+    date: '2026-06-18',
+    subjects: ['fix: recover from missing Unreleased'],
+    existingContent: content
+  });
+
+  assert.match(updated.content, new RegExp(`## Unreleased\\n\\n${UNRELEASED_PLACEHOLDER.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}`));
+  assert.match(updated.content, /## v1\.2\.4 - 2026-06-18/);
+  assert.match(updated.content, /- \(recover from missing Unreleased\)|- recover from missing Unreleased/);
+  assert.match(updated.content, /## v1\.2\.3 - 2026-06-17/);
+  assert.match(updated.content, /- Previous release\./);
+});
+
 test('updateChangelog resets Unreleased and inserts the generated version section', () => {
   const content = [
     '# Changelog',


### PR DESCRIPTION
## Summary

Prevents the `auto-release.js` job from aborting when a hand-crafted release commit drops the `## Unreleased` stub from `CHANGELOG.md` — the exact failure that blocked the v0.13.2 auto-release cycle earlier today.

## Root cause

`generate-changelog.js:updateChangelogContent` threw `CHANGELOG.md must contain a "## Unreleased" section.` when `findSectionRange` returned null. v0.13.1 was hand-crafted and dropped the section, so the next auto-release on main died before touching npm.

## Fix

When Unreleased is missing, synthesize a zero-width range at the topmost `## ` heading (or EOF for an empty changelog). The existing rebuild logic then inserts a fresh `## Unreleased\n\n- None yet.\n\n<release section>\n\n` at the right spot. Behavior when the section IS present is unchanged.

## Test plan

- [x] `node --test test/release-automation.test.js` — 10/10 (9 existing + 1 new missing-section test)
- [x] `npm test` — 281/281