### PR TITLE
chore(release): v0.13.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - None yet.
 
+## v0.13.4 - 2026-07-15
+
+### Fixed
+- (update) clean --json stdout, honest no-op status, useful drift detection (#93)
+
 ## v0.13.3 - 2026-07-14
 
 ### Fixed

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "main": "src/index.js",
   "bin": {

--- a/skills.json
+++ b/skills.json
@@ -26,13 +26,13 @@
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Initialize ROADMAP.md, AGENTS.md, and host integration files for a project.",
-      "version": "0.13.3"
+      "version": "0.13.4"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Refresh ROADMAP.md with evidence-backed validation, add tasks, or record evidence.",
-      "version": "0.13.3"
+      "version": "0.13.4"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- automated release PR for v0.13.4
- bumps package metadata and resets the changelog through the protected-branch path
- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode

## Notes
## v0.13.4 - 2026-07-15

### Fixed
- (update) clean --json stdout, honest no-op status, useful drift detection (#93)