### PR TITLE
fix(config): walk up directories to find roadmap-skill.config.json

### DIFF
--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { renderRoadmapTemplate, renderAgentsTemplate } = require('../src/templates');
-const { resolveRoadmapFile, loadConfig, loadPlugins } = require('../src/config');
+const { resolveRoadmapFile, loadConfig, loadPlugins, resolveConfigPath } = require('../src/config');
 const { readTextIfExists, writeText } = require('../src/io');
 const { importTasks } = require('../src/importer');
 const { addTask } = require('../src/addTask');
@@ -248,7 +248,13 @@ function runUpdate(projectRoot, config, flags) {
   if (isEnabled(flags['check-drift'])) {
     const northStar = config && config.product && config.product.northStar;
     if (!northStar) {
-      console.error('No northStar configured. Set product.northStar in roadmap-skill.config.json');
+      const resolvedConfigPath = resolveConfigPath({ projectRoot, configPath: flags.config });
+      const configExists = fs.existsSync(resolvedConfigPath);
+      if (!configExists) {
+        console.error(`Config \`roadmap-skill.config.json\` not found (searched from ${projectRoot} upwards). Pass --project-root <repo-root> or --config <path>.`);
+      } else {
+        console.error(`Config at ${resolvedConfigPath} has no \`product.northStar\`. Add it and re-run.`);
+      }
       process.exitCode = 1;
       return;
     }

--- a/roadmap-skill/src/config.js
+++ b/roadmap-skill/src/config.js
@@ -125,11 +125,28 @@ function mergeConfig(userConfig) {
   };
 }
 
+function findConfigUpwards(startDir, filename) {
+  let current = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(current, filename);
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch (_) { /* ignore stat errors, keep walking */ }
+    const parent = path.dirname(current);
+    if (parent === current) return null; // reached filesystem root
+    current = parent;
+  }
+}
+
 function resolveConfigPath(options = {}) {
   const projectRoot = path.resolve(options.projectRoot || process.cwd());
-  return options.configPath
-    ? path.resolve(projectRoot, String(options.configPath))
-    : path.resolve(projectRoot, 'roadmap-skill.config.json');
+  if (options.configPath) {
+    return path.resolve(projectRoot, String(options.configPath));
+  }
+  // v0.13.6: walk up directories looking for roadmap-skill.config.json so users can invoke
+  // the CLI from a nested sub-directory (roadmap-skill/, packages/foo/) without --config.
+  const found = findConfigUpwards(projectRoot, 'roadmap-skill.config.json');
+  return found || path.resolve(projectRoot, 'roadmap-skill.config.json');
 }
 
 function loadConfig(options = {}) {

--- a/roadmap-skill/test/config.test.js
+++ b/roadmap-skill/test/config.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const os = require('os');
-const { DEFAULT_CONFIG, loadConfig, resolveRoadmapFile } = require('../src/config');
+const { DEFAULT_CONFIG, loadConfig, resolveRoadmapFile, resolveConfigPath } = require('../src/config');
 
 function withMockedReaddir(entries, callback) {
   const original = fs.readdirSync;
@@ -63,4 +63,25 @@ test('loadConfig preserves user-defined pathAliases object', () => {
   fs.writeFileSync(path.join(dir, 'roadmap-skill.config.json'), JSON.stringify({ pathAliases: aliases }));
   const loaded = loadConfig({ projectRoot: dir });
   assert.deepEqual(loaded.pathAliases, aliases);
+});
+
+test('resolveConfigPath walks up directories to find roadmap-skill.config.json', () => {
+  // v0.13.6: running `roadmapsmith update --check-drift` from a nested subdir
+  // should still find the repo-root config instead of silently defaulting.
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rs-config-walkup-'));
+  const configPath = path.join(repoRoot, 'roadmap-skill.config.json');
+  fs.writeFileSync(configPath, JSON.stringify({ product: { northStar: 'test' } }));
+  const nested = path.join(repoRoot, 'packages', 'foo', 'src');
+  fs.mkdirSync(nested, { recursive: true });
+
+  assert.equal(resolveConfigPath({ projectRoot: nested }), configPath);
+  const loaded = loadConfig({ projectRoot: nested });
+  assert.equal(loaded.product.northStar, 'test');
+});
+
+test('resolveConfigPath falls back to projectRoot/roadmap-skill.config.json when no config exists anywhere', () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), 'rs-config-none-'));
+  const resolved = resolveConfigPath({ projectRoot: isolated });
+  assert.equal(resolved, path.join(isolated, 'roadmap-skill.config.json'));
+  assert.equal(fs.existsSync(resolved), false);
 });


### PR DESCRIPTION
## Summary

Config auto-discovery only checked cwd. Running any command from a nested subdirectory (e.g. `roadmap-skill/`, `packages/foo/`) silently fell back to defaults with no diagnostic. `--check-drift` was the worst case — reported `No northStar configured` without hinting the user was in the wrong directory.

## Fix

- `resolveConfigPath` walks up from `projectRoot` looking for `roadmap-skill.config.json` (git-style discovery). Falls back to the original default if no config exists anywhere on the walk.
- `--check-drift` error now distinguishes "no config found (searched from `<path>` upwards)" vs "config found at `<path>` but has no `product.northStar`". Actionable in both cases.

## Test plan

- [x] `npm test` — 289/289 (2 new tests for walk-up + fallback)
- [x] Manual: `cd roadmap-skill/ && roadmapsmith update --check-drift` now returns `Drift score: 100/100 — aligned` instead of `No northStar configured`.