### PR TITLE
fix(release): strip (#N) PR ref from CHANGELOG + widen Node test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18', '20']
+        node-version: ['18', '20', '22', '24']
 
     defaults:
       run:

--- a/roadmap-skill/scripts/generate-changelog.js
+++ b/roadmap-skill/scripts/generate-changelog.js
@@ -22,7 +22,8 @@ function isReleaseCommitSubject(subject) {
 }
 
 function normalizeCommitEntry(subject) {
-  const trimmed = String(subject || '').trim();
+  // v0.13.7: strip trailing `(#123)` PR-merge ref so CHANGELOG bullets stay signal-only.
+  const trimmed = String(subject || '').trim().replace(/\s*\(#\d+\)\s*$/, '');
   const match = /^([a-z]+)(?:\(([^)]+)\))?!?:\s*(.+)$/i.exec(trimmed);
   if (!match) {
     return trimmed;

--- a/roadmap-skill/test/release-automation.test.js
+++ b/roadmap-skill/test/release-automation.test.js
@@ -191,6 +191,23 @@ test('buildReleaseSection groups commits and falls back to Changed while excludi
   assert.doesNotMatch(section, /chore\(release\)/);
 });
 
+test('normalizeCommitEntry strips trailing (#N) PR-merge ref from squashed subjects', () => {
+  const section = buildReleaseSection({
+    version: '1.2.4',
+    date: '2026-06-18',
+    subjects: [
+      'fix(config): walk up directories to find roadmap-skill.config.json (#97)',
+      'feat: add magic (#100)',
+      'chore: no PR ref here'
+    ]
+  });
+  assert.match(section, /- \(config\) walk up directories to find roadmap-skill\.config\.json$/m);
+  assert.doesNotMatch(section, /\(#97\)/);
+  assert.doesNotMatch(section, /\(#100\)/);
+  assert.match(section, /- add magic$/m);
+  assert.match(section, /- no PR ref here$/m);
+});
+
 test('buildReleaseSection renders commit body `- ` lines as CHANGELOG sub-bullets', () => {
   const section = buildReleaseSection({
     version: '1.2.4',


### PR DESCRIPTION
## Summary

- **CHANGELOG hygiene:** `normalizeCommitEntry` now strips trailing `(#123)` PR-merge refs from squashed commit subjects. Every prior release entry had that noise (`- (config) walk up ... (#97)`); now it's just `- (config) walk up ...`.
- **Test matrix widened:** CI runs the test suite on Node 18/20/22/24 (was 18/20). Catches Node-version-specific regressions before the release job — which runs on Node 24 — ships something broken.

## Test plan

- [x] `npm test` — 290/290 (1 new test for the PR-ref strip)
- [x] Manual: verified `normalizeCommitEntry('fix: X (#97)')` returns `X`, unchanged when no `(#N)` suffix.

## First release under this fix

The v0.13.7 CHANGELOG entry auto-generated by this PR's merge will be the first to appear without a `(#N)` suffix — the regression test would catch any relapse.