### PR TITLE
fix(update): refuse to run when no ROADMAP.md exists

### DIFF
--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -280,6 +280,14 @@ function runUpdate(projectRoot, config, flags) {
   }
 
   // Default: refresh existing tasks (parse → validate → apply)
+  // v0.13.8: fail loud when there's no ROADMAP.md to refresh instead of silently
+  // creating an empty one in the current directory. `init` is the intended entry point
+  // for bootstrapping; `update` is only for maintaining an existing roadmap.
+  if (!fs.existsSync(roadmapFile)) {
+    console.error(`No ROADMAP.md found at ${roadmapFile}. Run 'roadmapsmith init' first, or pass --project-root <existing-repo>.`);
+    process.exitCode = 1;
+    return;
+  }
   const existingContent = readTextIfExists(roadmapFile) || '';
   const plugins = loadPlugins(projectRoot, config.plugins || []);
   const context = buildValidationContext(projectRoot, config, plugins, { strictValidation: strict });

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -429,6 +429,17 @@ test('migrate-markers is a no-op on already-migrated roadmap', () => {
   assert.equal(fs.readFileSync(path.join(dir, 'ROADMAP.md'), 'utf8'), initial);
 });
 
+test('update fails loud when no ROADMAP.md exists (does not silently create one)', () => {
+  // v0.13.8 regression: pre-fix, running `update` in a directory without a
+  // ROADMAP.md created a bare/empty one instead of pointing the user at `init`.
+  const dir = tmpdir();
+  // deliberately no ROADMAP.md, no package.json — pristine empty dir
+  const res = runResult(['update', '--project-root', dir], dir);
+  assert.equal(res.status, 1, 'must exit 1 on missing roadmap');
+  assert.match(res.stderr, /No ROADMAP\.md found at .+ Run 'roadmapsmith init' first/);
+  assert.equal(fs.existsSync(path.join(dir, 'ROADMAP.md')), false, 'must NOT create a file as side effect');
+});
+
 test('update --json without --audit still emits a valid JSON status on stdout', () => {
   // v0.13.5: pre-fix, `--json` without `--audit` printed nothing to stdout — --json is
   // supposed to always mean "machine-parseable output".


### PR DESCRIPTION
## Summary

Discovered while dogfooding v0.13.7: running `roadmapsmith update` from a subdirectory without a ROADMAP.md silently created a bare 1-byte file in that directory instead of pointing the user at `init`. The user noticed the phantom file a session later ("qué carajo pasó con este archivo?").

## Fix

`update` (default refresh path only) now checks `fs.existsSync(roadmapFile)` and errors out with:

```
No ROADMAP.md found at <path>. Run 'roadmapsmith init' first, or pass --project-root <existing-repo>.
```

Unaffected paths: `--add-task`, `--task/--evidence`, `--check-drift` (each has its own route and doesn't need an existing roadmap for its own semantics).

## Test plan

- [x] `npm test` — 291/291 (1 new regression test asserts exit 1 + no file created)
- [x] Manual: `roadmapsmith update --project-root /tmp/empty` now exits 1 with the actionable message; no phantom file created.