### PR TITLE
fix(update): preserve --json contract on the v0.13.8 missing-roadmap guard

### DIFF
--- a/roadmap-skill/bin/cli.js
+++ b/roadmap-skill/bin/cli.js
@@ -284,7 +284,13 @@ function runUpdate(projectRoot, config, flags) {
   // creating an empty one in the current directory. `init` is the intended entry point
   // for bootstrapping; `update` is only for maintaining an existing roadmap.
   if (!fs.existsSync(roadmapFile)) {
-    console.error(`No ROADMAP.md found at ${roadmapFile}. Run 'roadmapsmith init' first, or pass --project-root <existing-repo>.`);
+    const msg = `No ROADMAP.md found at ${roadmapFile}. Run 'roadmapsmith init' first, or pass --project-root <existing-repo>.`;
+    console.error(msg);
+    // v0.13.9: preserve the "--json always emits parseable JSON on stdout" contract
+    // even on the guard-fail path added in v0.13.8.
+    if (useJson) {
+      console.log(JSON.stringify({ error: 'roadmap-not-found', message: msg, file: roadmapFile }, null, 2));
+    }
     process.exitCode = 1;
     return;
   }

--- a/roadmap-skill/test/cli.test.js
+++ b/roadmap-skill/test/cli.test.js
@@ -429,6 +429,19 @@ test('migrate-markers is a no-op on already-migrated roadmap', () => {
   assert.equal(fs.readFileSync(path.join(dir, 'ROADMAP.md'), 'utf8'), initial);
 });
 
+test('update --json on missing ROADMAP.md still emits parseable JSON error on stdout', () => {
+  // v0.13.9: v0.13.8's guard broke v0.13.5's "--json always emits parseable JSON" invariant
+  // by exiting before the JSON payload was written. This locks the fix.
+  const dir = tmpdir();
+  const res = runResult(['update', '--json', '--project-root', dir], dir);
+  assert.equal(res.status, 1);
+  const parsed = JSON.parse(res.stdout);
+  assert.equal(parsed.error, 'roadmap-not-found');
+  assert.match(parsed.message, /Run 'roadmapsmith init' first/);
+  assert.equal(typeof parsed.file, 'string');
+  assert.match(res.stderr, /No ROADMAP\.md found/);
+});
+
 test('update fails loud when no ROADMAP.md exists (does not silently create one)', () => {
   // v0.13.8 regression: pre-fix, running `update` in a directory without a
   // ROADMAP.md created a bare/empty one instead of pointing the user at `init`.


### PR DESCRIPTION
## Summary

Self-regression detected during v0.13.8 dogfood. v0.13.8's "no ROADMAP.md → fail loud" guard exited before the JSON payload was written to stdout, which broke v0.13.5's invariant that `--json` always emits parseable JSON. `roadmapsmith update --json | jq .` failed with `Unexpected end of JSON input` instead of surfacing the actionable error.

## Fix

On the guard path, when `--json` is set, also emit a JSON error payload to stdout:
```json
{"error":"roadmap-not-found","message":"No ROADMAP.md found at ...","file":"..."}
```
Human `stderr` message stays for interactive users.

## Test plan

- [x] `npm test` — 292/292 (1 new regression test)
- [x] Both channels validated: exit 1, JSON on stdout, human message on stderr