### PR TITLE
chore(release): v0.14.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/plugins/roadmapsmith/.codex-plugin/plugin.json
+++ b/plugins/roadmapsmith/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "author": {
     "name": "PapiScholz"

--- a/roadmap-skill/CHANGELOG.md
+++ b/roadmap-skill/CHANGELOG.md
@@ -2,36 +2,18 @@
 
 ## Unreleased
 
-### Breaking
-- (init) default `init` output shape changed. Fresh runs now scan the repo and
-  emit real tasks (`Add tests for <fn> in <file>:<line>`, `Address TODO: ...`)
-  instead of the v0.14.x `phaseTemplates` boilerplate ("Stabilize project
-  baseline", "Reduce operational risk before v0.3", etc). Empty repos get a
-  minimal "Your first tasks" shape with no fake Phase headers.
-  - Migration for anyone who scripted around the exact phaseTemplate text:
-    pass `--with-phase-templates` to keep the v0.14.x static template
-    byte-for-byte.
+- None yet.
+
+## v0.14.2 - 2026-07-15
 
 ### Added
-- (init) new `--interactive` flag. Prompts for product name, primary user,
-  whether AI coding agents are used daily, and target host(s). Answering "n"
-  to the AI-agents question exits 0 with a redirect message — this tool is
-  not the right fit for non-agent workflows.
-- (init) new `--with-phase-templates` flag preserves the v0.14.x static
-  template output for callers that scripted around the old shape.
-- (update) `--add-task --json` now includes the assigned task in the JSON
-  payload (`{ id, text, phase }`) so callers can pipe
-  `add-task --json | jq -r .task.id | xargs -I{} update --task {} --evidence …`
-  without re-parsing ROADMAP.md.
-- (scripts) new `scripts/demo/false-claim-repro.sh` at the repo root — a
-  deterministic reproducer of the "agent claims [x], validator catches it"
-  value proposition. Wired into `roadmap-skill/scripts/e2e-smoke.sh` so the
-  catch stops silently regressing.
-
-### Internal
-- New `src/inferTasks.js` module: JS/TS/Python function-without-test +
-  TODO/FIXME/HACK scanner used by the dynamic `init` path. Cap: 10 tasks
-  per run; falls back to the minimal empty-repo shape below that threshold.
+- (v0.15) dynamic init + add-task pipeability + false-claim hero demo
+  - init now scans the repo (JS/TS/Python) and emits real tasks
+  - init --interactive: 4-prompt wizard (product name, primary user,
+  - update --add-task --json now returns { task: { id, text, phase } }
+  - Hero demo replaced: assets/demo.gif (106 KB) shows the killer
+  - scripts/demo/false-claim-repro.sh: deterministic 3-frame reproducer
+  - Plan lifecycle: docs/plans/plan.md moved to
 
 ## v0.14.1 - 2026-07-15
 

--- a/roadmap-skill/package-lock.json
+++ b/roadmap-skill/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roadmapsmith",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roadmapsmith",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT",
       "bin": {
         "roadmapsmith": "bin/cli.js"

--- a/roadmap-skill/package.json
+++ b/roadmap-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmapsmith",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Evidence-backed ROADMAP.md workflows for AI coding agents — two commands: init and update.",
   "main": "src/index.js",
   "bin": {

--- a/skills.json
+++ b/skills.json
@@ -26,13 +26,13 @@
       "name": "roadmap-init",
       "path": "skills/roadmap-init",
       "description": "Initialize ROADMAP.md, AGENTS.md, and host integration files for a project.",
-      "version": "0.14.1"
+      "version": "0.14.2"
     },
     {
       "name": "roadmap-update",
       "path": "skills/roadmap-update",
       "description": "Refresh ROADMAP.md with evidence-backed validation, add tasks, or record evidence.",
-      "version": "0.14.1"
+      "version": "0.14.2"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- automated release PR for v0.14.2
- bumps package metadata and resets the changelog through the protected-branch path
- merges back into `main` as the bot release commit, then the follow-up `main` run publishes npm and the GitHub Release in repair mode

## Notes
## v0.14.2 - 2026-07-15

### Added
- (v0.15) dynamic init + add-task pipeability + false-claim hero demo
  - init now scans the repo (JS/TS/Python) and emits real tasks
  - init --interactive: 4-prompt wizard (product name, primary user,
  - update --add-task --json now returns { task: { id, text, phase } }
  - Hero demo replaced: assets/demo.gif (106 KB) shows the killer
  - scripts/demo/false-claim-repro.sh: deterministic 3-frame reproducer
  - Plan lifecycle: docs/plans/plan.md moved to